### PR TITLE
Js quick maps menu

### DIFF
--- a/src/app/pages/quickMaps/components/quickMapsHeader.component/quickMapsHeader.component.scss
+++ b/src/app/pages/quickMaps/components/quickMapsHeader.component/quickMapsHeader.component.scss
@@ -3,9 +3,13 @@
 .container {
   width: 100%;
   display: flex;
-  justify-content: space-evenly;
+  justify-content: center;
   & .active-route {
     background-color: $color_primary;
     color: white;
   }
+}
+
+a {
+  flex-shrink: 0;
 }

--- a/src/app/pages/quickMaps/quickMaps.component.html
+++ b/src/app/pages/quickMaps/quickMaps.component.html
@@ -4,9 +4,7 @@
     <app-side-nav-content></app-side-nav-content>
   </mat-drawer>
   <div class="sidenav-content">
-    <div class="menu-header">
-      <app-quick-maps-header *ngIf="showHeader"></app-quick-maps-header>
-    </div>
+    <app-quick-maps-header *ngIf="showHeader"></app-quick-maps-header>
     <router-outlet></router-outlet>
   </div>
 </mat-drawer-container>

--- a/src/app/pages/quickMaps/quickMaps.component.scss
+++ b/src/app/pages/quickMaps/quickMaps.component.scss
@@ -33,9 +33,6 @@ mat-drawer {
   transition: all 0.4s;
 }
 
-.menu-header {
-  margin-top: 10px;
-}
 app-quick-maps-header {
-  width: 100%;
+  margin-top: 10px;
 }

--- a/src/app/pages/quickMaps/quickMaps.component.ts
+++ b/src/app/pages/quickMaps/quickMaps.component.ts
@@ -13,7 +13,7 @@ import { Subscription } from 'rxjs';
 })
 export class QuickMapsComponent implements OnInit {
 
-  public showHeader = true;
+  public showHeader = false;
 
   constructor(
     router: Router,


### PR DESCRIPTION
quick maps menu updates
- #146 remove white space above map in initial 'Quick MAPS' view
- ensure quick maps menu doesn't show on initial quick maps page (currently does only when first navigating there via app link.)