### PR TITLE
139 map tools layout

### DIFF
--- a/src/app/pages/educationalResources/educationalResources.component.html
+++ b/src/app/pages/educationalResources/educationalResources.component.html
@@ -10,7 +10,7 @@
         elementum enim at nibh egestas. </h2>
     </div>
     <div class="mdc-layout-grid__cell--span-6">
-      <img class="eduCellImage" src="/assets/images/webp/study-map-min.webp">
+      <img class="header-image" src="/assets/images/webp/study-map-min.webp">
     </div>
   </div>
 </div>

--- a/src/app/pages/educationalResources/educationalResources.component.scss
+++ b/src/app/pages/educationalResources/educationalResources.component.scss
@@ -1,5 +1,0 @@
-.eduCellImage {
-  width: 100%;
-  max-height: 500px;
-  object-fit: contain;
-}

--- a/src/app/pages/help/help.component.html
+++ b/src/app/pages/help/help.component.html
@@ -10,7 +10,7 @@
         elementum enim at nibh egestas. </h2>
     </div>
     <div class="mdc-layout-grid__cell--span-6">
-      <img class="helpCellImage" src="/assets/images/webp/study-map-min.webp">
+      <img class="header-image" src="/assets/images/webp/study-map-min.webp">
     </div>
   </div>
 </div>

--- a/src/app/pages/help/help.component.scss
+++ b/src/app/pages/help/help.component.scss
@@ -1,5 +1,0 @@
-.helpCellImage {
-  width: 100%;
-  max-height: 500px;
-  object-fit: contain;
-}

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -16,7 +16,7 @@
       <button mat-raised-button color="primary" [routerLink]="ROUTES.MAPS_TOOL | route">Maps Tool Portal</button>
     </div>
     <div class="mdc-layout-grid__cell--span-6">
-      <img class="homeCellImage" src="/assets/images/webp/study-map-min.webp">
+      <img class="header-image" src="/assets/images/webp/study-map-min.webp">
     </div>
   </div>
 </div>

--- a/src/app/pages/mapsTool/mapsTool.component.html
+++ b/src/app/pages/mapsTool/mapsTool.component.html
@@ -11,7 +11,7 @@
 <div class="mdc-layout-grid header">
   <div class="mdc-layout-grid__inner">
     <div class="mdc-layout-grid__cell--span-6 mdc-layout-grid__cell--align-middle">
-      <img class="toolCellImage" src="/assets/images/webp/tools-min.webp">
+      <img class="header-image" src="/assets/images/webp/tools-min.webp">
     </div>
     <div class="mdc-layout-grid__cell--span-6 text-right">
       <h1>MAPS Tool Interface</h1>
@@ -25,7 +25,7 @@
 
 <div class="mdc-layout-grid section">
   <div class=" mdc-layout-grid__inner">
-    <div class="toolCell mdc-layout-grid__cell mdc-layout-grid__cell--span-6-desktop">
+    <div class="tool-cell mdc-layout-grid__cell mdc-layout-grid__cell--span-3-desktop">
       <div class="basic-card">
         <i class="fas fa-map-marked-alt fa-5x" style="color: #703AA3;"></i>
         <div class="text text-center">
@@ -37,7 +37,7 @@
 
       </div>
     </div>
-    <div class="toolCell mdc-layout-grid__cell mdc-layout-grid__cell--span-6-desktop">
+    <div class="tool-cell mdc-layout-grid__cell mdc-layout-grid__cell--span-3-desktop">
       <div class="basic-card">
         <i class="fas fa-user-cog fa-5x" style="color: #703AA3;"></i>
         <div class="text text-center">
@@ -48,7 +48,7 @@
       </div>
     </div>
 
-    <div class="toolCell mdc-layout-grid__cell mdc-layout-grid__cell--span-6-desktop">
+    <div class="tool-cell mdc-layout-grid__cell mdc-layout-grid__cell--span-3-desktop">
       <div class="basic-card">
         <i class="fas fa-sliders-h fa-5x" style="color: #703AA3;"></i>
         <div class="text text-center">
@@ -59,7 +59,7 @@
       </div>
     </div>
 
-    <div class="toolCell mdc-layout-grid__cell mdc-layout-grid__cell--span-6-desktop">
+    <div class="tool-cell mdc-layout-grid__cell mdc-layout-grid__cell--span-3-desktop">
       <div class="basic-card">
         <i class="fas fa-share-alt fa-5x" style="color: #703AA3;"></i>
         <div class="text text-center">

--- a/src/app/pages/mapsTool/mapsTool.component.scss
+++ b/src/app/pages/mapsTool/mapsTool.component.scss
@@ -1,10 +1,4 @@
-.toolCell {
-  height: 100%;
-  display: flex;
-}
 
-.toolCellImage {
-  width: 100%;
-  max-height: 500px;
-  object-fit: contain;
+.tool-cell {
+  display: flex;
 }

--- a/src/app/pages/projectObjectives/projectObjectives.component.html
+++ b/src/app/pages/projectObjectives/projectObjectives.component.html
@@ -10,7 +10,7 @@
         elementum enim at nibh egestas. </h2>
     </div>
     <div class="mdc-layout-grid__cell--span-6">
-      <img class="objCellImage" src="/assets/images/webp/study-map-min.webp">
+      <img class="header-image" src="/assets/images/webp/study-map-min.webp">
     </div>
   </div>
 </div>

--- a/src/app/pages/projectObjectives/projectObjectives.component.scss
+++ b/src/app/pages/projectObjectives/projectObjectives.component.scss
@@ -1,5 +1,0 @@
-.objCellImage {
-  width: 100%;
-  max-height: 500px;
-  object-fit: contain;
-}

--- a/src/assets/scss/_card.scss
+++ b/src/assets/scss/_card.scss
@@ -5,7 +5,6 @@
   flex-flow: column wrap;
   flex-grow: 1;
   align-items: center;
-  margin: 10px;
   background-color: white;
   border: 2px $color_primary solid;
   border-radius: 5px;

--- a/src/assets/scss/_page.scss
+++ b/src/assets/scss/_page.scss
@@ -1,5 +1,10 @@
 .header {
   margin-bottom: 10px;
+  & .header-image {
+    width: 100%;
+    max-height: 400px;
+    object-fit: contain;
+  }
 }
 .section {
   margin-top: 30px;
@@ -10,11 +15,10 @@
   }
 }
 .wave-header {
-  // top: 63px;
-  // position: absolute;
-  // width: 100%;
-  // overflow: hidden;
-  // line-height: 0;
+  & img {
+    height: 60px;
+    width: 100%;
+  }
 }
 .wedge-section {
   background-image: url(/assets/images/purple-wedge.svg);

--- a/src/assets/scss/_scroll.scss
+++ b/src/assets/scss/_scroll.scss
@@ -27,7 +27,7 @@
   @include custom-scroll;
 }
 
-body {
+html {
   @include custom-scroll;
 }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -21,7 +21,7 @@ body {
 // ) !default;
 
 :root {
-  --mdc-layout-grid-margin-desktop: 60px 100px;
+  --mdc-layout-grid-margin-desktop: 30px 100px;
   --mdc-layout-grid-gutter-desktop: 60px;
   --mdc-layout-grid-margin-tablet: 24px;
   --mdc-layout-grid-gutter-tablet: 24px;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -21,8 +21,8 @@ body {
 // ) !default;
 
 :root {
-  --mdc-layout-grid-margin-desktop: 30px 100px;
-  --mdc-layout-grid-gutter-desktop: 60px;
+  --mdc-layout-grid-margin-desktop: 30px 50px;
+  --mdc-layout-grid-gutter-desktop: 30px;
   --mdc-layout-grid-margin-tablet: 24px;
   --mdc-layout-grid-gutter-tablet: 24px;
   --mdc-layout-grid-margin-phone: 24px;


### PR DESCRIPTION
closes #139 
- attempt to reduce top areas of pages enough to show at least a taste of the content below
- switch the main scroll from body to html to interact better when dialogs are shown