### PR TITLE
Add workflow to (hopefully) deploy to netlify on merge to develop

### DIFF
--- a/.github/workflows/develop-release.yml
+++ b/.github/workflows/develop-release.yml
@@ -1,0 +1,39 @@
+name: Develop Release
+on:
+  push:
+    branches:
+      - develop
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+
+    steps:
+      - uses: actions/checkout@v2.3.4
+
+      - name: Cache node modules
+        uses: actions/cache@v2.1.3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v2.1.4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: npm install and npm run build
+        run: |
+          npm i
+          npm run build:prod
+
+      - name: Deploy to netlify
+        id: deploy-netlify
+        uses: netlify/actions/cli@master
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        with:
+          args: deploy --dir=dist/micronutrient-support-tool --alias develop


### PR DESCRIPTION
Should deploy the head of `develop` to https://develop--micronutrientsupport-tool.netlify.app/ as a fixed URL for latest merged progress