### PR TITLE
fix: ensure values set in query params if we have navigated back to quickmaps

### DIFF
--- a/src/app/pages/quickMaps/components/sideNavContent/sideNavContent.component.ts
+++ b/src/app/pages/quickMaps/components/sideNavContent/sideNavContent.component.ts
@@ -42,8 +42,6 @@ export class SideNavContentComponent implements OnInit {
 
   public quickMapsForm: FormGroup;
 
-  public selectedCountry;
-
   constructor(
     private fb: FormBuilder,
     public dictionariesService: DictionaryService,

--- a/src/app/pages/quickMaps/quickMaps.component.ts
+++ b/src/app/pages/quickMaps/quickMaps.component.ts
@@ -35,5 +35,9 @@ export class QuickMapsComponent implements OnInit {
     });
   }
 
-  ngOnInit(): void { }
+  ngOnInit(): void {
+    // ensure values set in query params if we have navigated back to
+    // quickmaps having been here before, since the service exists from last time.
+    this.quickMapsService.updateQueryParams();
+  }
 }

--- a/src/app/pages/quickMaps/quickMaps.service.ts
+++ b/src/app/pages/quickMaps/quickMaps.service.ts
@@ -100,17 +100,17 @@ export class QuickMapsService {
     }
   }
 
-  private parameterChanged(): void {
-    this.updateQueryParams();
-    this.parameterChangedSrc.next();
-  }
-
-  private updateQueryParams(): void {
+  public updateQueryParams(): void {
     const paramsObj = {} as Record<string, string | Array<string>>;
     paramsObj[QuickMapsQueryParams.QUERY_PARAM_KEYS.COUNTRY_ID] = this.countryId;
     paramsObj[QuickMapsQueryParams.QUERY_PARAM_KEYS.MICRONUTRIENT_ID] = this.micronutrientId;
     paramsObj[QuickMapsQueryParams.QUERY_PARAM_KEYS.POP_GROUP_ID] = this.popGroupId;
     paramsObj[QuickMapsQueryParams.QUERY_PARAM_KEYS.MICRONUTRIENT_DATASET] = this.mndDataId;
     QuickMapsQueryParams.setQueryParams(this.router, this.activatedRoute, paramsObj);
+  }
+
+  private parameterChanged(): void {
+    this.updateQueryParams();
+    this.parameterChangedSrc.next();
   }
 }


### PR DESCRIPTION
- navigate to quickmaps, select params, click "view results".
- The baseline page is displayed.
- Navigate to the maps tool page.
- Navigate back to the quickmaps page

- [ ] The query params (in the url) will be pre-populated with the values from your last visit, which were already showing in the sidebar due to the persistence of the service between navigations.