### PR TITLE
fix: routeguard when accessing query params

### DIFF
--- a/src/app/pages/quickMaps/quickMapsQueryParams.ts
+++ b/src/app/pages/quickMaps/quickMapsQueryParams.ts
@@ -1,5 +1,5 @@
 import { Injector } from '@angular/core';
-import { ActivatedRoute, ActivatedRouteSnapshot, Router } from '@angular/router';
+import { ActivatedRoute, ParamMap, Router } from '@angular/router';
 import { DictionaryType } from 'src/app/apiAndObjects/api/dictionaryType.enum';
 import { CountryDictionaryItem } from 'src/app/apiAndObjects/objects/dictionaries/countryRegionDictionaryItem';
 import { MicronutrientDictionaryItem } from 'src/app/apiAndObjects/objects/dictionaries/micronutrientDictionaryItem';
@@ -27,36 +27,36 @@ export class QuickMapsQueryParams {
     this.route = injector.get<ActivatedRoute>(ActivatedRoute);
   }
 
-  public getCountryId(): string {
-    return this.snapshot().queryParamMap.get(QuickMapsQueryParams.QUERY_PARAM_KEYS.COUNTRY_ID);
+  public getCountryId(queryParamMap?: ParamMap): string {
+    return this.params(queryParamMap).get(QuickMapsQueryParams.QUERY_PARAM_KEYS.COUNTRY_ID);
   }
-  public getCountry(): Promise<CountryDictionaryItem> {
+  public getCountry(queryParamMap?: ParamMap): Promise<CountryDictionaryItem> {
     return this.dictionariesService.getDictionary(DictionaryType.COUNTRIES)
-      .then(dict => dict.getItem(this.getCountryId()));
+      .then(dict => dict.getItem(this.getCountryId(queryParamMap)));
   }
 
-  public getMicronutrientId(): string {
-    return this.snapshot().queryParamMap.get(QuickMapsQueryParams.QUERY_PARAM_KEYS.MICRONUTRIENT_ID);
+  public getMicronutrientId(queryParamMap?: ParamMap): string {
+    return this.params(queryParamMap).get(QuickMapsQueryParams.QUERY_PARAM_KEYS.MICRONUTRIENT_ID);
   }
-  public getMicronutrient(): Promise<MicronutrientDictionaryItem> {
+  public getMicronutrient(queryParamMap?: ParamMap): Promise<MicronutrientDictionaryItem> {
     return this.dictionariesService.getDictionary(DictionaryType.MICRONUTRIENTS)
-      .then(dict => dict.getItem(this.getMicronutrientId()));
+      .then(dict => dict.getItem(this.getMicronutrientId(queryParamMap)));
   }
 
-  public getMeasure(): MicronutrientMeasureType {
+  public getMeasure(queryParamMap?: ParamMap): MicronutrientMeasureType {
     return EnumTools.getEnumFromValue(
-      this.snapshot().queryParamMap.get(QuickMapsQueryParams.QUERY_PARAM_KEYS.MEASURE),
+      this.params(queryParamMap).get(QuickMapsQueryParams.QUERY_PARAM_KEYS.MEASURE),
       MicronutrientMeasureType,
     );
   }
 
-  public getMndsDataId(): string {
-    return this.snapshot().queryParamMap.get(QuickMapsQueryParams.QUERY_PARAM_KEYS.MICRONUTRIENT_DATASET);
+  public getMndsDataId(queryParamMap?: ParamMap): string {
+    return this.params(queryParamMap).get(QuickMapsQueryParams.QUERY_PARAM_KEYS.MICRONUTRIENT_DATASET);
   }
 
-  public getDataLevel(): DataLevel {
+  public getDataLevel(queryParamMap?: ParamMap): DataLevel {
     return EnumTools.getEnumFromValue(
-      this.snapshot().queryParamMap.get(QuickMapsQueryParams.QUERY_PARAM_KEYS.DATA_LEVEL),
+      this.params(queryParamMap).get(QuickMapsQueryParams.QUERY_PARAM_KEYS.DATA_LEVEL),
       DataLevel,
     );
   }
@@ -106,7 +106,7 @@ export class QuickMapsQueryParams {
   //     .sort();
   // }
 
-  private snapshot(): ActivatedRouteSnapshot {
-    return this.route.snapshot;
+  private params(queryParamMap?: ParamMap): ParamMap {
+    return (null != queryParamMap) ? queryParamMap : this.route.snapshot.queryParamMap;
   }
 }


### PR DESCRIPTION
Routeguard will now allow access to this url, say:

https://preview347--micronutrientsupport-tool.netlify.app/quick-maps/diet/baseline?country-id=AGO&mnd-id=A&measure=diet&dataset-id=0&data-level=country