### PR TITLE
Js further quickmaps params updates

### DIFF
--- a/src/app/apiAndObjects/api/currentData/getDietarySources.ts
+++ b/src/app/apiAndObjects/api/currentData/getDietarySources.ts
@@ -41,5 +41,5 @@ DietarySource
 export interface GetDietarySourcesParams {
   countryOrGroupId: string;
   micronutrients: Array<MicronutrientDictionaryItem>;
-  mndsDataOption: MicronutrientDataOption,
+  mndsDataOption: MicronutrientDataOption;
 }

--- a/src/app/apiAndObjects/api/currentData/getDietarySources.ts
+++ b/src/app/apiAndObjects/api/currentData/getDietarySources.ts
@@ -1,6 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { MicronutrientDictionaryItem } from '../../objects/dictionaries/micronutrientDictionaryItem';
 import { DietarySource } from '../../objects/dietarySource';
+import { MicronutrientDataOption } from '../../objects/micronutrientDataOption';
 import { CacheableEndpoint } from '../../_lib_code/api/cacheableEndpoint.abstract';
 
 export class GetDietarySources extends CacheableEndpoint<
@@ -40,5 +41,5 @@ DietarySource
 export interface GetDietarySourcesParams {
   countryOrGroupId: string;
   micronutrients: Array<MicronutrientDictionaryItem>;
-  mndsDataId: string;
+  mndsDataOption: MicronutrientDataOption,
 }

--- a/src/app/apiAndObjects/api/currentData/getHouseholdHistogramData.ts
+++ b/src/app/apiAndObjects/api/currentData/getHouseholdHistogramData.ts
@@ -1,6 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { MicronutrientDictionaryItem } from '../../objects/dictionaries/micronutrientDictionaryItem';
 import { HouseholdHistogramData } from '../../objects/householdHistogramData';
+import { MicronutrientDataOption } from '../../objects/micronutrientDataOption';
 import { CacheableEndpoint } from '../../_lib_code/api/cacheableEndpoint.abstract';
 
 export class GetHouseholdHistogramData extends CacheableEndpoint<
@@ -49,5 +50,5 @@ GetHouseholdHistogramDataParams
 export interface GetHouseholdHistogramDataParams {
   countryOrGroupId: string;
   micronutrients: Array<MicronutrientDictionaryItem>;
-  mndsDataId: string;
+  mndsDataOption: MicronutrientDataOption,
 }

--- a/src/app/apiAndObjects/api/currentData/getHouseholdHistogramData.ts
+++ b/src/app/apiAndObjects/api/currentData/getHouseholdHistogramData.ts
@@ -50,5 +50,5 @@ GetHouseholdHistogramDataParams
 export interface GetHouseholdHistogramDataParams {
   countryOrGroupId: string;
   micronutrients: Array<MicronutrientDictionaryItem>;
-  mndsDataOption: MicronutrientDataOption,
+  mndsDataOption: MicronutrientDataOption;
 }

--- a/src/app/apiAndObjects/api/currentData/getMonthlyFoodGroups.ts
+++ b/src/app/apiAndObjects/api/currentData/getMonthlyFoodGroups.ts
@@ -54,5 +54,5 @@ GetMonthlyFoodGroupsParams
 export interface GetMonthlyFoodGroupsParams {
   countryOrGroupId: string;
   micronutrients: Array<MicronutrientDictionaryItem>;
-  mndsDataOption: MicronutrientDataOption,
+  mndsDataOption: MicronutrientDataOption;
 }

--- a/src/app/apiAndObjects/api/currentData/getMonthlyFoodGroups.ts
+++ b/src/app/apiAndObjects/api/currentData/getMonthlyFoodGroups.ts
@@ -1,6 +1,7 @@
 /* tslint:disable: no-string-literal */
 import { HttpClient } from '@angular/common/http';
 import { MicronutrientDictionaryItem } from '../../objects/dictionaries/micronutrientDictionaryItem';
+import { MicronutrientDataOption } from '../../objects/micronutrientDataOption';
 import { MonthlyFoodGroups } from '../../objects/monthlyFoodGroups';
 import { CacheableEndpoint } from '../../_lib_code/api/cacheableEndpoint.abstract';
 
@@ -53,5 +54,5 @@ GetMonthlyFoodGroupsParams
 export interface GetMonthlyFoodGroupsParams {
   countryOrGroupId: string;
   micronutrients: Array<MicronutrientDictionaryItem>;
-  mndsDataId: string;
+  mndsDataOption: MicronutrientDataOption,
 }

--- a/src/app/apiAndObjects/api/currentData/getProjectedAvailabilities.ts
+++ b/src/app/apiAndObjects/api/currentData/getProjectedAvailabilities.ts
@@ -3,6 +3,7 @@ import { CacheableEndpoint } from '../../_lib_code/api/cacheableEndpoint.abstrac
 import { ProjectedAvailability } from '../../objects/projectedAvailability';
 import { RequestMethod } from '../../_lib_code/api/requestMethod.enum';
 import { MicronutrientDictionaryItem } from '../../objects/dictionaries/micronutrientDictionaryItem';
+import { MicronutrientDataOption } from '../../objects/micronutrientDataOption';
 
 export class GetProjectedAvailabilities extends CacheableEndpoint<
 Array<ProjectedAvailability>,
@@ -46,5 +47,5 @@ ProjectedAvailability
 export interface GetProjectedAvailabilityParams {
   countryOrGroupId: string;
   micronutrients: Array<MicronutrientDictionaryItem>;
-  mndsDataId: string;
+  mndsDataOption: MicronutrientDataOption;
 }

--- a/src/app/apiAndObjects/api/currentData/getSubRegionData.ts
+++ b/src/app/apiAndObjects/api/currentData/getSubRegionData.ts
@@ -1,6 +1,7 @@
 /* tslint:disable: no-string-literal */
 import { HttpClient } from '@angular/common/http';
 import { MicronutrientDictionaryItem } from '../../objects/dictionaries/micronutrientDictionaryItem';
+import { MicronutrientDataOption } from '../../objects/micronutrientDataOption';
 import { SubRegionDataItem } from '../../objects/subRegionDataItem';
 import { CacheableEndpoint } from '../../_lib_code/api/cacheableEndpoint.abstract';
 
@@ -47,5 +48,5 @@ export class GetSubRegionData extends CacheableEndpoint<Array<SubRegionDataItem>
 export interface GetSubRegionDataParams {
   countryOrGroupId: string;
   micronutrients: Array<MicronutrientDictionaryItem>;
-  mndsDataId: string;
+  mndsDataOption: MicronutrientDataOption;
 }

--- a/src/app/pages/quickMaps/components/sideNavContent/sideNavContent.component.html
+++ b/src/app/pages/quickMaps/components/sideNavContent/sideNavContent.component.html
@@ -99,7 +99,7 @@
       <mat-form-field appearance="fill">
         <mat-select name="mndsData" formControlName="mndsData" placeholder="Click to select options"
           panelClass="allow-long-text">
-          <mat-option *ngFor="let item of micronutrientDataOptions" [value]="item.id">{{item.name}}
+          <mat-option *ngFor="let item of micronutrientDataOptions" [value]="item">{{item.name}}
           </mat-option>
         </mat-select>
         <mat-error>{{errorReponse[0]}}</mat-error>

--- a/src/app/pages/quickMaps/components/sideNavContent/sideNavContent.component.ts
+++ b/src/app/pages/quickMaps/components/sideNavContent/sideNavContent.component.ts
@@ -64,7 +64,7 @@ export class SideNavContentComponent implements OnInit {
           nation: [this.quickMapsService.countryId, Validators.required],
           micronutrient: [this.quickMapsService.micronutrient, Validators.required],
           measure: [this.quickMapsService.measure, Validators.required], // to be initialized from service
-          mndsData: [this.quickMapsService.mndDataId, Validators.required],
+          mndsData: [this.quickMapsService.mndDataOption, Validators.required],
         });
 
         // watches changes so that reacts to location component selections
@@ -91,11 +91,10 @@ export class SideNavContentComponent implements OnInit {
           this.quickMapsService.setMeasure(value);
           this.updateMicronutrientDataOptions();
         });
-        this.quickMapsForm.get('mndsData').valueChanges.subscribe((value: string) => {
-          this.quickMapsService.setMndDataId(value);
-          const selectedItem = this.micronutrientDataOptions.find(option => option.id === value);
-          if (null != selectedItem) {
-            this.quickMapsService.setDataLevelOptions(selectedItem.dataLevelOptions);
+        this.quickMapsForm.get('mndsData').valueChanges.subscribe((value: MicronutrientDataOption) => {
+          this.quickMapsService.setMndDataOption(value);
+          if (null != value) {
+            this.quickMapsService.setDataLevelOptions(value.dataLevelOptions);
           }
         });
       });
@@ -173,7 +172,7 @@ export class SideNavContentComponent implements OnInit {
           this.micronutrientDataOptions = options;
           // if only one option, preselect
           if (1 === options.length) {
-            this.quickMapsForm.get('mndsData').setValue(options[0].id);
+            this.quickMapsForm.get('mndsData').setValue(options[0]);
           }
         });
     } else {

--- a/src/app/pages/quickMaps/components/sideNavContent/sideNavContent.component.ts
+++ b/src/app/pages/quickMaps/components/sideNavContent/sideNavContent.component.ts
@@ -93,6 +93,11 @@ export class SideNavContentComponent implements OnInit {
         });
         this.quickMapsForm.get('mndsData').valueChanges.subscribe((value: MicronutrientDataOption) => {
           this.quickMapsService.setMndDataOption(value);
+          if (null != value) {
+            if (!value.dataLevelOptions.includes(this.quickMapsService.dataLevel)) {
+              this.quickMapsService.setDataLevel(value.dataLevelOptions[0]);
+            }
+          }
         });
       });
 

--- a/src/app/pages/quickMaps/components/sideNavContent/sideNavContent.component.ts
+++ b/src/app/pages/quickMaps/components/sideNavContent/sideNavContent.component.ts
@@ -93,9 +93,6 @@ export class SideNavContentComponent implements OnInit {
         });
         this.quickMapsForm.get('mndsData').valueChanges.subscribe((value: MicronutrientDataOption) => {
           this.quickMapsService.setMndDataOption(value);
-          if (null != value) {
-            this.quickMapsService.setDataLevelOptions(value.dataLevelOptions);
-          }
         });
       });
 

--- a/src/app/pages/quickMaps/pages/baselineDetails/baselineDescription/baselineDescription.component.html
+++ b/src/app/pages/quickMaps/pages/baselineDetails/baselineDescription/baselineDescription.component.html
@@ -14,15 +14,16 @@
           </div>
           <div class="item">
             Data level:
-            <strong *ngIf="(1 === (quickMapsService.dataLevelOptionsObs | async)?.length)" class="capitalize-text">
-              {{(quickMapsService.dataLevelOptionsObs | async)[0]}}
+            <strong *ngIf="(1 === (quickMapsService.mndDataOptionObs | async).dataLevelOptions.length)" class="capitalize-text">
+              {{(quickMapsService.mndDataOptionObs | async).dataLevelOptions[0]}}
             </strong>
-            <mat-form-field *ngIf="(1 < (quickMapsService.dataLevelOptionsObs | async)?.length)"
+            <mat-form-field *ngIf="(1 < (quickMapsService.mndDataOptionObs | async).dataLevelOptions.length)"
               appearance="fill" class="data-level-select-wrapper">
               <mat-select panelClass="data-level-select"
                 name="data-level" placeholder="Data Level" [value]="quickMapsService.dataLevelObs | async"
                 (selectionChange)="setDataLevel($event)" (click)="$event.stopPropagation()">
-                <mat-option *ngFor="let option of quickMapsService.dataLevelOptionsObs | async" [value]="option" class="capitalize-text">
+                <mat-option *ngFor="let option of (quickMapsService.mndDataOptionObs | async).dataLevelOptions"
+                  [value]="option" class="capitalize-text">
                   {{option}}
                 </mat-option>
               </mat-select>

--- a/src/app/pages/quickMaps/pages/baselineDetails/baselineDetails.component.ts
+++ b/src/app/pages/quickMaps/pages/baselineDetails/baselineDetails.component.ts
@@ -110,7 +110,6 @@ export class BaselineDetailsComponent implements OnInit {
   }
 
   private setDataLevel(level: DataLevel): void {
-    console.debug('setDataLevel', level);
     if (null != level) {
       const newWidgetsTypes = this.dataLevelWidgetTypesMap.get(level);
 

--- a/src/app/pages/quickMaps/pages/baselineDetails/baselineDetails.component.ts
+++ b/src/app/pages/quickMaps/pages/baselineDetails/baselineDetails.component.ts
@@ -110,6 +110,7 @@ export class BaselineDetailsComponent implements OnInit {
   }
 
   private setDataLevel(level: DataLevel): void {
+    console.debug('setDataLevel', level);
     if (null != level) {
       const newWidgetsTypes = this.dataLevelWidgetTypesMap.get(level);
 

--- a/src/app/pages/quickMaps/pages/baselineDetails/householdSupply/householdSupply.component.ts
+++ b/src/app/pages/quickMaps/pages/baselineDetails/householdSupply/householdSupply.component.ts
@@ -76,7 +76,7 @@ export class HouseholdSupplyComponent implements AfterViewInit {
           this.init(this.currentDataService.getHouseholdHistogramData(
             this.quickMapsService.countryId,
             [this.quickMapsService.micronutrient],
-            this.quickMapsService.mndDataId,
+            this.quickMapsService.mndDataOption,
           ));
         })
       );

--- a/src/app/pages/quickMaps/pages/baselineDetails/mapView/mapView.component.ts
+++ b/src/app/pages/quickMaps/pages/baselineDetails/mapView/mapView.component.ts
@@ -138,7 +138,7 @@ export class MapViewComponent implements AfterViewInit {
           this.init(this.currentDataService.getSubRegionData(
             this.quickMapsService.countryId,
             [this.quickMapsService.micronutrient],
-            this.quickMapsService.mndDataId,
+            this.quickMapsService.mndDataOption,
           ));
         })
       );

--- a/src/app/pages/quickMaps/pages/baselineDetails/monthlyFood/monthlyFood.component.ts
+++ b/src/app/pages/quickMaps/pages/baselineDetails/monthlyFood/monthlyFood.component.ts
@@ -91,7 +91,7 @@ export class MonthlyFoodComponent implements AfterViewInit {
           this.init(this.currentDataService.getMonthlyFoodGroups(
             this.quickMapsService.countryId,
             [this.quickMapsService.micronutrient],
-            this.quickMapsService.mndDataId,
+            this.quickMapsService.mndDataOption,
           ));
         })
       );

--- a/src/app/pages/quickMaps/pages/projection/projectionAvailability/projectionAvailability.component.ts
+++ b/src/app/pages/quickMaps/pages/projection/projectionAvailability/projectionAvailability.component.ts
@@ -107,7 +107,7 @@ export class ProjectionAvailabilityComponent implements AfterViewInit {
             this.currentDataService.getProjectedAvailabilities(
               this.quickMapsService.countryId,
               [this.quickMapsService.micronutrient],
-              this.quickMapsService.mndDataId,
+              this.quickMapsService.mndDataOption,
             ),
           );
         }),

--- a/src/app/pages/quickMaps/quickMaps.service.ts
+++ b/src/app/pages/quickMaps/quickMaps.service.ts
@@ -145,17 +145,17 @@ export class QuickMapsService {
     this.parameterChangedSrc.next();
   }
 
-  public getMndOption(): Promise<MicronutrientDataOption> {
+  private getMndOption(): Promise<MicronutrientDataOption> {
     return Promise.all([
       this.quickMapsParameters.getCountry(),
-    ]).then((data: [CountryDictionaryItem]) => {
-      return (null == data[0])
+    ]).then((data: [CountryDictionaryItem]) =>
+      (null == data[0])
         ? null
         : this.currentDataService.getMicronutrientDataOptions(
           data[0],
           this.quickMapsParameters.getMeasure(),
           true,
-        ).then(options => options[0]); // first item
-    });
+        ).then(options => options[0]) // first item
+    );
   }
 }

--- a/src/app/pages/quickMaps/quickMaps.service.ts
+++ b/src/app/pages/quickMaps/quickMaps.service.ts
@@ -4,6 +4,7 @@ import { QuickMapsQueryParams } from './quickMapsQueryParams';
 import { DataLevel } from 'src/app/apiAndObjects/objects/enums/dataLevel.enum';
 import { MicronutrientDictionaryItem } from 'src/app/apiAndObjects/objects/dictionaries/micronutrientDictionaryItem';
 import { MicronutrientMeasureType } from 'src/app/apiAndObjects/objects/enums/micronutrientMeasureType.enum';
+import { MicronutrientDataOption } from 'src/app/apiAndObjects/objects/micronutrientDataOption';
 
 @Injectable()
 export class QuickMapsService {
@@ -27,9 +28,9 @@ export class QuickMapsService {
   // eslint-disable-next-line @typescript-eslint/member-ordering
   public measureObs = this.measureSrc.asObservable();
 
-  private readonly mndDataIdSrc = new BehaviorSubject<string>(null);
+  private readonly mndDataOptionSrc = new BehaviorSubject<MicronutrientDataOption>(null);
   // eslint-disable-next-line @typescript-eslint/member-ordering
-  public mndDataIdObs = this.mndDataIdSrc.asObservable();
+  public mndDataOptionObs = this.mndDataOptionSrc.asObservable();
 
   private readonly dataLevelSrc = new BehaviorSubject<DataLevel>(null);
   // eslint-disable-next-line @typescript-eslint/member-ordering
@@ -57,17 +58,17 @@ export class QuickMapsService {
 
     this.setCountryId(this.quickMapsParameters.getCountryId());
     promises.push(
-      this.quickMapsParameters.getMicronutrient().then(micronutrient => this.setMicronutrient(micronutrient))
+      this.quickMapsParameters.getMicronutrient().then(micronutrient => this.setMicronutrient(micronutrient)),
+      this.quickMapsParameters.getMndOption().then(option => this.setMndDataOption(option)),
     );
     this.setMeasure(this.quickMapsParameters.getMeasure());
-    this.setMndDataId(this.quickMapsParameters.getMndsDataId());
     this.setDataLevel(this.quickMapsParameters.getDataLevel());
 
     void Promise.all(promises).then(() => {
       this.countryIdObs.subscribe(() => this.parameterChanged());
       this.micronutrientObs.subscribe(() => this.parameterChanged());
       this.measureObs.subscribe(() => this.parameterChanged());
-      this.mndDataIdObs.subscribe(() => this.parameterChanged());
+      this.mndDataOptionObs.subscribe(() => this.parameterChanged());
       this.dataLevelObs.subscribe(() => this.parameterChanged());
 
       this.initSrc.next(true);
@@ -108,11 +109,11 @@ export class QuickMapsService {
     this.setValue(this.measureSrc, measure, force);
   }
 
-  public get mndDataId(): string {
-    return this.mndDataIdSrc.value;
+  public get mndDataOption(): MicronutrientDataOption {
+    return this.mndDataOptionSrc.value;
   }
-  public setMndDataId(mndDataId: string, force = false): void {
-    this.setValue(this.mndDataIdSrc, mndDataId, force);
+  public setMndDataOption(mndDataOption: MicronutrientDataOption, force = false): void {
+    this.setValue(this.mndDataOptionSrc, mndDataOption, force);
   }
 
   public get dataLevel(): DataLevel {
@@ -137,7 +138,6 @@ export class QuickMapsService {
     paramsObj[QuickMapsQueryParams.QUERY_PARAM_KEYS.MICRONUTRIENT_ID] =
       (null != this.micronutrient) ? this.micronutrient.id : null;
     paramsObj[QuickMapsQueryParams.QUERY_PARAM_KEYS.MEASURE] = this.measure;
-    paramsObj[QuickMapsQueryParams.QUERY_PARAM_KEYS.MICRONUTRIENT_DATASET] = this.mndDataId;
     paramsObj[QuickMapsQueryParams.QUERY_PARAM_KEYS.DATA_LEVEL] = this.dataLevel;
     this.quickMapsParameters.setQueryParams(paramsObj);
   }

--- a/src/app/pages/quickMaps/quickMapsQueryParams.ts
+++ b/src/app/pages/quickMaps/quickMapsQueryParams.ts
@@ -5,6 +5,8 @@ import { CountryDictionaryItem } from 'src/app/apiAndObjects/objects/dictionarie
 import { MicronutrientDictionaryItem } from 'src/app/apiAndObjects/objects/dictionaries/micronutrientDictionaryItem';
 import { DataLevel } from 'src/app/apiAndObjects/objects/enums/dataLevel.enum';
 import { MicronutrientMeasureType } from 'src/app/apiAndObjects/objects/enums/micronutrientMeasureType.enum';
+import { MicronutrientDataOption } from 'src/app/apiAndObjects/objects/micronutrientDataOption';
+import { CurrentDataService } from 'src/app/services/currentData.service';
 import { DictionaryService } from 'src/app/services/dictionary.service';
 import { EnumTools } from 'src/utility/enumTools';
 
@@ -13,15 +15,16 @@ export class QuickMapsQueryParams {
     COUNTRY_ID: 'country-id',
     MICRONUTRIENT_ID: 'mnd-id',
     MEASURE: 'measure',
-    MICRONUTRIENT_DATASET: 'dataset-id',
     DATA_LEVEL: 'data-level',
   };
 
+  private readonly currentDataService: CurrentDataService;
   private readonly dictionariesService: DictionaryService;
   private readonly router: Router;
   private readonly route: ActivatedRoute;
 
   constructor(injector: Injector) {
+    this.currentDataService = injector.get<CurrentDataService>(CurrentDataService);
     this.dictionariesService = injector.get<DictionaryService>(DictionaryService);
     this.router = injector.get<Router>(Router);
     this.route = injector.get<ActivatedRoute>(ActivatedRoute);
@@ -50,9 +53,18 @@ export class QuickMapsQueryParams {
     );
   }
 
-  public getMndsDataId(queryParamMap?: ParamMap): string {
-    return this.params(queryParamMap).get(QuickMapsQueryParams.QUERY_PARAM_KEYS.MICRONUTRIENT_DATASET);
+  public getMndOption(queryParamMap?: ParamMap): Promise<MicronutrientDataOption> {
+    return Promise.all([
+      this.getCountry(queryParamMap),
+    ]).then((data: [CountryDictionaryItem]) => {
+      return this.currentDataService.getMicronutrientDataOptions(
+        data[0],
+        this.getMeasure(queryParamMap),
+        true,
+      ).then(options => options[0]);
+    });
   }
+
 
   public getDataLevel(queryParamMap?: ParamMap): DataLevel {
     return EnumTools.getEnumFromValue(

--- a/src/app/pages/quickMaps/quickMapsQueryParams.ts
+++ b/src/app/pages/quickMaps/quickMapsQueryParams.ts
@@ -5,8 +5,6 @@ import { CountryDictionaryItem } from 'src/app/apiAndObjects/objects/dictionarie
 import { MicronutrientDictionaryItem } from 'src/app/apiAndObjects/objects/dictionaries/micronutrientDictionaryItem';
 import { DataLevel } from 'src/app/apiAndObjects/objects/enums/dataLevel.enum';
 import { MicronutrientMeasureType } from 'src/app/apiAndObjects/objects/enums/micronutrientMeasureType.enum';
-import { MicronutrientDataOption } from 'src/app/apiAndObjects/objects/micronutrientDataOption';
-import { CurrentDataService } from 'src/app/services/currentData.service';
 import { DictionaryService } from 'src/app/services/dictionary.service';
 import { EnumTools } from 'src/utility/enumTools';
 
@@ -18,13 +16,11 @@ export class QuickMapsQueryParams {
     DATA_LEVEL: 'data-level',
   };
 
-  private readonly currentDataService: CurrentDataService;
   private readonly dictionariesService: DictionaryService;
   private readonly router: Router;
   private readonly route: ActivatedRoute;
 
   constructor(injector: Injector) {
-    this.currentDataService = injector.get<CurrentDataService>(CurrentDataService);
     this.dictionariesService = injector.get<DictionaryService>(DictionaryService);
     this.router = injector.get<Router>(Router);
     this.route = injector.get<ActivatedRoute>(ActivatedRoute);
@@ -52,19 +48,6 @@ export class QuickMapsQueryParams {
       MicronutrientMeasureType,
     );
   }
-
-  public getMndOption(queryParamMap?: ParamMap): Promise<MicronutrientDataOption> {
-    return Promise.all([
-      this.getCountry(queryParamMap),
-    ]).then((data: [CountryDictionaryItem]) => {
-      return this.currentDataService.getMicronutrientDataOptions(
-        data[0],
-        this.getMeasure(queryParamMap),
-        true,
-      ).then(options => options[0]);
-    });
-  }
-
 
   public getDataLevel(queryParamMap?: ParamMap): DataLevel {
     return EnumTools.getEnumFromValue(
@@ -119,6 +102,7 @@ export class QuickMapsQueryParams {
   // }
 
   private params(queryParamMap?: ParamMap): ParamMap {
+    // console.debug('this.route.snapshot.queryParamMap', this.route.snapshot);
     return (null != queryParamMap) ? queryParamMap : this.route.snapshot.queryParamMap;
   }
 }

--- a/src/app/pages/quickMaps/quickMapsRouteGuard.service.ts
+++ b/src/app/pages/quickMaps/quickMapsRouteGuard.service.ts
@@ -59,7 +59,7 @@ export class QuickMapsRouteGuardService implements CanActivate {
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   private validateParamsForRoute(route: ActivatedRouteSnapshot): Promise<boolean> {
-    // TODO: ensure data level matches route
+    // TODO: ensure meaasure matches route?
     return Promise.resolve(true);
   }
 
@@ -84,11 +84,10 @@ export class QuickMapsRouteGuardService implements CanActivate {
         ? false
         : this.currentDataService.getMicronutrientDataOptions(country, measure, true)
           .then((options: Array<MicronutrientDataOption>) => {
-            const mndsDataId = this.quickMapsParameters.getMndsDataId(queryParamMap);
             const dataLevel = this.quickMapsParameters.getDataLevel(queryParamMap);
 
             let valid = false;
-            const selectedOption = options.find(item => (item.id === mndsDataId));
+            const selectedOption = options[0];
             // while we're here, validate the data level if set
             if (null != selectedOption) {
               if (null == dataLevel) {

--- a/src/app/pages/quickMaps/quickMapsRouteGuard.service.ts
+++ b/src/app/pages/quickMaps/quickMapsRouteGuard.service.ts
@@ -87,7 +87,7 @@ export class QuickMapsRouteGuardService implements CanActivate {
             const dataLevel = this.quickMapsParameters.getDataLevel(queryParamMap);
 
             let valid = false;
-            const selectedOption = options[0];
+            const selectedOption = options[0]; // first item
             // while we're here, validate the data level if set
             if (null != selectedOption) {
               if (null == dataLevel) {

--- a/src/app/services/currentData.service.ts
+++ b/src/app/services/currentData.service.ts
@@ -41,24 +41,24 @@ export class CurrentDataService {
   public getSubRegionData(
     countryOrGroupId: string,
     micronutrients: Array<MicronutrientDictionaryItem>,
-    mndsDataId: string,
+    mndsDataOption: MicronutrientDataOption,
   ): Promise<Array<SubRegionDataItem>> {
     return this.apiService.endpoints.currentData.getSubRegionData.call({
       countryOrGroupId,
       micronutrients,
-      mndsDataId,
+      mndsDataOption,
     });
   }
 
   public getDietarySources(
     countryOrGroupId: string,
     micronutrients: Array<MicronutrientDictionaryItem>,
-    mndsDataId: string,
+    mndsDataOption: MicronutrientDataOption,
   ): Promise<Array<DietarySource>> {
     return this.apiService.endpoints.currentData.getDietarySources.call({
       countryOrGroupId,
       micronutrients,
-      mndsDataId,
+      mndsDataOption,
     });
   }
 
@@ -77,36 +77,36 @@ export class CurrentDataService {
   public getHouseholdHistogramData(
     countryOrGroupId: string,
     micronutrients: Array<MicronutrientDictionaryItem>,
-    mndsDataId: string,
+    mndsDataOption: MicronutrientDataOption,
   ): Promise<HouseholdHistogramData> {
     return this.apiService.endpoints.currentData.getHouseholdHistogramData.call({
       countryOrGroupId,
       micronutrients,
-      mndsDataId,
+      mndsDataOption,
     });
   }
 
   public getMonthlyFoodGroups(
     countryOrGroupId: string,
     micronutrients: Array<MicronutrientDictionaryItem>,
-    mndsDataId: string,
+    mndsDataOption: MicronutrientDataOption,
   ): Promise<MonthlyFoodGroups> {
     return this.apiService.endpoints.currentData.getMonthlyFoodGroups.call({
       countryOrGroupId,
       micronutrients,
-      mndsDataId,
+      mndsDataOption,
     });
   }
   public getProjectedAvailabilities(
     countryOrGroupId: string,
     micronutrients: Array<MicronutrientDictionaryItem>,
-    mndsDataId: string,
+    mndsDataOption: MicronutrientDataOption,
   ): Promise<Array<ProjectedAvailability>> {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     return this.apiService.endpoints.currentData.getProjectedAvailabilities.call({
       countryOrGroupId,
       micronutrients,
-      mndsDataId,
+      mndsDataOption,
     });
   }
 }


### PR DESCRIPTION
cache MicronutrientDataOption object in quickmaps service, rather than just the id, so that it is conveniently available for other api calls.