### PR TITLE
use term  "Micronutrient"" and "Underlying Metric"

### DIFF
--- a/src/app/pages/quickMaps/pages/baselineDetails/baselineDescription/baselineDescription.component.html
+++ b/src/app/pages/quickMaps/pages/baselineDetails/baselineDescription/baselineDescription.component.html
@@ -7,10 +7,10 @@
             Nation: <strong>{{ (quickMapsService.countryObs | async)?.name }}</strong>
           </div>
           <div class="item">
-            Vitamin: <strong>{{ (quickMapsService.micronutrientObs | async)?.name }}</strong>
+            Micronutrient: <strong>{{ (quickMapsService.micronutrientObs | async)?.name }}</strong>
           </div>
           <div class="item">
-            Measure of MDN: <strong class="capitalize-text">{{ quickMapsService.measureObs | async }} Data</strong>
+            Underlying Metric: <strong class="capitalize-text">{{ quickMapsService.measureObs | async }} Data</strong>
           </div>
           <div class="item">
             Data level:

--- a/src/app/pages/quickMaps/pages/biomarkers/biomarkerDescription/biomarkerDescription.component.html
+++ b/src/app/pages/quickMaps/pages/biomarkers/biomarkerDescription/biomarkerDescription.component.html
@@ -7,9 +7,11 @@
             Nation: <strong>{{ (quickMapsService.countryObs | async)?.name }}</strong>
           </div>
           <div class="item">
-            Vitamin: <strong>{{ (quickMapsService.micronutrientObs | async)?.name }}</strong>
+            Micronutrient: <strong>{{ (quickMapsService.micronutrientObs | async)?.name }}</strong>
           </div>
-          <div class="item">Measure of MN: <strong>Biomarker</strong></div>
+          <div class="item">
+            Underlying Metric: <strong class="capitalize-text">{{ quickMapsService.measureObs | async }} Data</strong>
+          </div>
           <div class="item">
             Age-gender group: <strong>{{ (quickMapsService.ageGenderObs | async).name }}</strong>
           </div>

--- a/src/app/pages/quickMaps/pages/projection/projectionDescription/projectionDescription.component.html
+++ b/src/app/pages/quickMaps/pages/projection/projectionDescription/projectionDescription.component.html
@@ -7,10 +7,10 @@
             Nation: <strong>{{(quickMapsService.countryObs | async)?.name}}</strong>
           </div>
           <div class="item">
-            Vitamin: <strong>{{(quickMapsService.micronutrientObs | async)?.name}}</strong>
+            Micronutrient: <strong>{{ (quickMapsService.micronutrientObs | async)?.name }}</strong>
           </div>
           <div class="item">
-            Measure of MDN: <strong class="capitalize-text">{{(quickMapsService.measureObs | async)}} Data</strong>
+            Underlying Metric: <strong class="capitalize-text">{{ quickMapsService.measureObs | async }} Data</strong>
           </div>
           <div class="item">
             Baseline assumptions: <strong>{{currentImpactScenario?.name}}</strong>


### PR DESCRIPTION
#482 
use term  "Micronutrient" rather than "Vitamin" and "Underlying Metric" rather than "Measure of MDN" on description cards