### PR TITLE
Further dietary change scaffold

### DIFF
--- a/src/app/pages/quickMaps/pages/dietaryChange/components/comparisonCard/comparisonCard.component.html
+++ b/src/app/pages/quickMaps/pages/dietaryChange/components/comparisonCard/comparisonCard.component.html
@@ -1,7 +1,10 @@
 <ng-template #componentTemplate>
   <mat-tab-group mat-align-tabs="center" [(selectedIndex)]="selectedTab">
     <mat-tab label="Map">
-
+      <div>
+        {{modeDisplay | json}}
+        <div *ngFor="let item of tempDisplay">{{item.foodItem}} {{item.changeValuesObs | async}}</div>
+      </div>
     </mat-tab>
 
     <mat-tab label="Table">

--- a/src/app/pages/quickMaps/pages/dietaryChange/components/options/options.component.ts
+++ b/src/app/pages/quickMaps/pages/dietaryChange/components/options/options.component.ts
@@ -3,6 +3,9 @@ import { ChangeDetectionStrategy, Component, ChangeDetectorRef } from '@angular/
 import { AppRoutes } from 'src/app/routes/routes';
 import { Subscription } from 'rxjs';
 import { Unsubscriber } from 'src/app/decorators/unsubscriber.decorator';
+import { DietaryChangeService } from '../../dietaryChange.service';
+import { DietaryChangeMode } from '../../dietaryChangeMode.enum';
+import { CompositionChangeItem, ConsumptionChangeItem, FoodItemChangeItem } from '../../dietaryChange.item';
 
 @Unsubscriber('subscriptions')
 @Component({
@@ -18,5 +21,35 @@ export class OptionsComponent {
 
   private subscriptions = new Array<Subscription>();
 
-  constructor(private cdr: ChangeDetectorRef) {}
+  constructor(private cdr: ChangeDetectorRef, private dietaryChangeService: DietaryChangeService) {
+    this.exampleValueChange();
+  }
+
+  private exampleValueChange(): void {
+    // test
+    setTimeout(() => {
+      // change mode
+      this.dietaryChangeService.setMode(DietaryChangeMode.CONSUMPTION);
+
+      // change food items
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const compositionChangeItem1 = new CompositionChangeItem('Some food item object here - potato', 10);
+
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const FoodItemChangeItem1 = new FoodItemChangeItem(
+        'Some food item object here - potato',
+        'Some food item object here - chips',
+      );
+
+      const consumptionChangeItem1 = new ConsumptionChangeItem('Some food item object here - potato', 55);
+      const consumptionChangeItem2 = new ConsumptionChangeItem('Some food item object here - pizza', 22);
+      this.dietaryChangeService.setChangeItems([consumptionChangeItem1, consumptionChangeItem2]);
+
+      setInterval(() => {
+        // change value on a change item
+        consumptionChangeItem1.setChangeValue(consumptionChangeItem1.changeValue + 1);
+        consumptionChangeItem2.setChangeValue(consumptionChangeItem1.changeValue + 1);
+      }, 500);
+    }, 3000);
+  }
 }

--- a/src/app/pages/quickMaps/pages/dietaryChange/dietaryChange.item.ts
+++ b/src/app/pages/quickMaps/pages/dietaryChange/dietaryChange.item.ts
@@ -1,0 +1,29 @@
+import { BehaviorSubject, Observable } from 'rxjs';
+
+export abstract class DietaryChangeItem<T> {
+  private readonly changeValuesSrc: BehaviorSubject<T>;
+  // eslint-disable-next-line @typescript-eslint/member-ordering
+  public readonly changeValuesObs: Observable<T>;
+
+  constructor(
+    public readonly foodItem: unknown, // TODO: update with FoodItem type
+    initialValue: T,
+  ) {
+    this.changeValuesSrc = new BehaviorSubject<T>(initialValue);
+    this.changeValuesObs = this.changeValuesSrc.asObservable();
+  }
+
+  public get changeValue(): T {
+    return this.changeValuesSrc.value;
+  }
+
+  public setChangeValue(val: T): void {
+    this.changeValuesSrc.next(val);
+  }
+}
+
+export class CompositionChangeItem extends DietaryChangeItem<number> {}
+export class ConsumptionChangeItem extends DietaryChangeItem<number> {}
+export class FoodItemChangeItem extends DietaryChangeItem<unknown> {} // TODO: update with FoodItem type
+
+export type ChangeItemsType = Array<CompositionChangeItem> | Array<ConsumptionChangeItem> | Array<FoodItemChangeItem>;

--- a/src/app/pages/quickMaps/pages/dietaryChange/dietaryChange.module.ts
+++ b/src/app/pages/quickMaps/pages/dietaryChange/dietaryChange.module.ts
@@ -10,6 +10,7 @@ import { DialogModule } from 'src/app/components/dialogs/dialog.module';
 import { DescriptionComponent } from './components/description/description.component';
 import { OptionsComponent } from './components/options/options.component';
 import { ComparisonCardComponent } from './components/comparisonCard/comparisonCard.component';
+import { DietaryChangeService } from './dietaryChange.service';
 
 @NgModule({
   declarations: [DietaryChangeComponent, DescriptionComponent, OptionsComponent, ComparisonCardComponent],
@@ -22,7 +23,7 @@ import { ComparisonCardComponent } from './components/comparisonCard/comparisonC
     ComponentsModule,
     DialogModule,
   ],
-  providers: [],
+  providers: [DietaryChangeService],
   exports: [DietaryChangeComponent],
 })
 export class DietaryChangeModule {}

--- a/src/app/pages/quickMaps/pages/dietaryChange/dietaryChange.service.ts
+++ b/src/app/pages/quickMaps/pages/dietaryChange/dietaryChange.service.ts
@@ -1,0 +1,89 @@
+import { Injectable, Injector } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { CurrentDataService } from 'src/app/services/currentData.service';
+import { ChangeItemsType } from './dietaryChange.item';
+import { DietaryChangeMode } from './dietaryChangeMode.enum';
+
+@Injectable()
+export class DietaryChangeService {
+  private initSrc = new BehaviorSubject<boolean>(false);
+  // eslint-disable-next-line @typescript-eslint/member-ordering
+  public initObservable = this.initSrc.asObservable();
+
+  private readonly modeSrc = new BehaviorSubject<DietaryChangeMode>(DietaryChangeMode.COMPOSITION);
+  // eslint-disable-next-line @typescript-eslint/member-ordering
+  public modeObs = this.modeSrc.asObservable();
+
+  private readonly changeItemsSrc = new BehaviorSubject<ChangeItemsType>([]);
+  // eslint-disable-next-line @typescript-eslint/member-ordering
+  public changeItemsObs = this.changeItemsSrc.asObservable();
+
+  /**
+   * subject to provide a single observable that can be subscribed to, to be notified if anything
+   * changes, so that an observer doesn't need to subscribe to many.
+   */
+  private readonly parameterChangedSrc = new BehaviorSubject<void>(null);
+  // eslint-disable-next-line @typescript-eslint/member-ordering
+  public parameterChangedObs = this.parameterChangedSrc.asObservable();
+
+  private parameterChangeTimeout: NodeJS.Timeout;
+
+  // private readonly quickMapsParameters: QuickMapsQueryParams;
+
+  constructor(injector: Injector, private currentDataService: CurrentDataService) {
+    // this.quickMapsParameters = new QuickMapsQueryParams(injector);
+
+    // set from query params etc. on init
+    // this.setMeasure(this.quickMapsParameters.getMeasure());
+    // this.setDataLevel(this.quickMapsParameters.getDataLevel());
+
+    this.initSubscriptions();
+    this.initSrc.next(true);
+  }
+
+  public get mode(): DietaryChangeMode {
+    return this.modeSrc.value;
+  }
+  public setMode(mode: DietaryChangeMode, force = false): void {
+    this.setValue(this.modeSrc, mode, force);
+  }
+  public get changeItems(): ChangeItemsType {
+    return this.changeItemsSrc.value;
+  }
+  public setChangeItems(changeItems: ChangeItemsType, force = false): void {
+    this.setValue(this.changeItemsSrc, changeItems, force);
+  }
+
+  // public updateQueryParams(): void {
+  //   const paramsObj = {} as Record<string, string | Array<string>>;
+  //   paramsObj[QuickMapsQueryParams.QUERY_PARAM_KEYS.COUNTRY_ID] = null != this.country ? this.country.id : null;
+  //   paramsObj[QuickMapsQueryParams.QUERY_PARAM_KEYS.MICRONUTRIENT_ID] =
+  //     null != this.micronutrient ? this.micronutrient.id : null;
+  //   paramsObj[QuickMapsQueryParams.QUERY_PARAM_KEYS.MEASURE] = this.measure;
+  //   paramsObj[QuickMapsQueryParams.QUERY_PARAM_KEYS.DATA_LEVEL] = this.dataLevel;
+  //   paramsObj[QuickMapsQueryParams.QUERY_PARAM_KEYS.AGE_GENDER_GROUP] =
+  //     null != this.ageGenderGroup ? this.ageGenderGroup.id : null;
+  //   this.quickMapsParameters.setQueryParams(paramsObj);
+  // }
+
+  protected setValue<T>(srcRef: BehaviorSubject<T>, value: T, force: boolean): void {
+    if (force || srcRef.value !== value) {
+      srcRef.next(value);
+    }
+  }
+
+  private initSubscriptions(): void {
+    // set up the parameter changed triggers on param changes
+    this.modeObs.subscribe(() => this.parameterChanged());
+    this.changeItemsObs.subscribe(() => this.parameterChanged());
+  }
+
+  private parameterChanged(): void {
+    // this.updateQueryParams();
+    // ensure not triggered too many times in quick succession
+    clearTimeout(this.parameterChangeTimeout);
+    this.parameterChangeTimeout = setTimeout(() => {
+      this.parameterChangedSrc.next();
+    }, 100);
+  }
+}

--- a/src/app/pages/quickMaps/pages/dietaryChange/dietaryChangeMode.enum.ts
+++ b/src/app/pages/quickMaps/pages/dietaryChange/dietaryChangeMode.enum.ts
@@ -1,0 +1,6 @@
+// eslint-disable-next-line no-shadow
+export enum DietaryChangeMode {
+  COMPOSITION,
+  CONSUMPTION,
+  FOOD_ITEM,
+}

--- a/src/app/pages/quickMaps/quickMaps.service.ts
+++ b/src/app/pages/quickMaps/quickMaps.service.ts
@@ -69,13 +69,7 @@ export class QuickMapsService {
       .then(() => this.setInitialAgeGender(this.micronutrient))
       .then(() => this.setInitialDataSource(this.country, this.measure, this.ageGenderGroup))
       .then(() => {
-        // now set up the parameter changed triggers on param changes
-        this.countryObs.subscribe(() => this.parameterChanged());
-        this.micronutrientObs.subscribe(() => this.parameterChanged());
-        this.measureObs.subscribe(() => this.parameterChanged());
-        this.dataSourceObs.subscribe(() => this.parameterChanged());
-        this.dataLevelObs.subscribe(() => this.parameterChanged());
-        this.ageGenderObs.subscribe(() => this.parameterChanged());
+        this.initSubscriptions();
         this.initSrc.next(true);
       });
   }
@@ -164,16 +158,27 @@ export class QuickMapsService {
   private setInitialAgeGender(micronutrient: MicronutrientDictionaryItem): Promise<void> {
     // if age-gender query param is set, then find the corresponding AgeGenderGroup
     const ageGenderGroupId = this.quickMapsParameters.getAgeGenderGroupId();
-    if ((null == micronutrient) || (null == ageGenderGroupId)) {
+    if (null == micronutrient || null == ageGenderGroupId) {
       return Promise.resolve();
     } else {
       return this.currentDataService
         .getAgeGenderGroups([micronutrient])
         .then((ageGenderGroups: Array<AgeGenderGroup>) =>
-          this.setAgeGenderGroup(ageGenderGroups.find((option) => option.id === ageGenderGroupId))
+          this.setAgeGenderGroup(ageGenderGroups.find((option) => option.id === ageGenderGroupId)),
         );
     }
   }
+
+  private initSubscriptions(): void {
+    // set up the parameter changed triggers on param changes
+    this.countryObs.subscribe(() => this.parameterChanged());
+    this.micronutrientObs.subscribe(() => this.parameterChanged());
+    this.measureObs.subscribe(() => this.parameterChanged());
+    this.dataSourceObs.subscribe(() => this.parameterChanged());
+    this.dataLevelObs.subscribe(() => this.parameterChanged());
+    this.ageGenderObs.subscribe(() => this.parameterChanged());
+  }
+
   private setInitialDataSource(
     country: CountryDictionaryItem,
     measure: MicronutrientMeasureType,
@@ -181,6 +186,6 @@ export class QuickMapsService {
   ): Promise<void> {
     return this.currentDataService
       .getDataSources(country, measure, ageGenderGroup, true)
-      .then(groups => this.setDataSource(groups[0])); // always first item
+      .then((groups) => this.setDataSource(groups[0])); // always first item
   }
 }


### PR DESCRIPTION
add in a dietary change service and connect up the card to changes in the options


Probably gone to far , not having any idea about the data, corresponding api calls, and when they will need to be made, but it shows how some option changes can result in a new API  call and some can just re-use the current data and apply the newly selected value to it.