### PR TITLE
feat: after new pr auto rebase all open dependabot prs

### DIFF
--- a/.github/workflows/dependabot-auto-rebase.yml
+++ b/.github/workflows/dependabot-auto-rebase.yml
@@ -1,0 +1,16 @@
+name: Auto rebase open Dependabot PRs
+on:
+  push:
+  release:
+    types: [published]
+jobs:
+  auto-rebase:
+    name: rebase dependabot PRs
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/develop' || github.event == 'release'
+    timeout-minutes: 5
+    steps:
+      - name: rebase
+        uses: "bbeesley/gha-auto-dependabot-rebase@main"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Currently dependabot doesnt auto rebase open PRs after updates to Develop branch. This action triggers rebase for all dependabot PRs to ensure they are up to date.