### PR TITLE
Card title text does not overlap dialog button 

### DIFF
--- a/src/app/components/card/card.component.html
+++ b/src/app/components/card/card.component.html
@@ -12,11 +12,12 @@
       <button *ngIf="showInfo" (click)="functionInfo()" mat-icon-button aria-label="Info icon">
         <mat-icon>info</mat-icon>
       </button>
-      <span class="example-spacer">{{title}}</span>
+      <span class="title-spacer">{{title}}</span>
       <button *ngIf="showExpand" (click)="functionExpand()" mat-icon-button aria-label="Modal icon">
         <mat-icon>launch</mat-icon>
       </button>
     </mat-toolbar>
+
     <span *ngIf="error">Error...</span>
     <div *ngIf="!error" mat-align-tabs="center" class="card-content-wrapper">
       <ng-content></ng-content>

--- a/src/app/components/card/card.component.scss
+++ b/src/app/components/card/card.component.scss
@@ -18,10 +18,13 @@
   }
 }
 
-.example-spacer {
+.title-spacer {
   flex: 1 1 auto;
   text-align: center;
   font-size: 17px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 mat-toolbar {


### PR DESCRIPTION
- closes #682 by truncating/adding elipsis dots to card title text when text is longer than the card

### Before fix

![image](https://user-images.githubusercontent.com/4210022/143269487-503d6a21-98a4-45fe-a053-bd1cef881e25.png)

### After fix

![image](https://user-images.githubusercontent.com/4210022/143269539-c059a934-93ef-48a8-a278-20fb56dbb343.png)


