### PR TITLE
fix: dietary change scenarios no longer errors when retrieving map colour gradient

### DIFF
--- a/src/app/pages/quickMaps/pages/dietaryChange/components/comparisonCard/scenariosMap/scenariosMap.component.ts
+++ b/src/app/pages/quickMaps/pages/dietaryChange/components/comparisonCard/scenariosMap/scenariosMap.component.ts
@@ -42,9 +42,11 @@ export class ScenariosMapComponent implements AfterViewInit {
   }
 
   @Input() set binRange(range: number[]) {
-    this.baselineRange = range;
-    this.setColorGradient(ColourPalette.getSelectedPalette(ScenariosMapComponent.COLOUR_PALETTE_ID));
-    this.refreshLegend();
+    if (null != range) {
+      this.baselineRange = range;
+      this.setColorGradient(ColourPalette.getSelectedPalette(ScenariosMapComponent.COLOUR_PALETTE_ID));
+      this.refreshLegend();
+    }
   }
 
   @Input() set scenarioData(data: Array<MnAvailibiltyItem>) {


### PR DESCRIPTION
resolves issue #694 