### PR TITLE
Allow missing data options in quickmaps to fail gracefully 

### DIFF
--- a/src/app/pages/quickMaps/components/sideNavContent/sideNavContent.component.html
+++ b/src/app/pages/quickMaps/components/sideNavContent/sideNavContent.component.html
@@ -140,5 +140,6 @@
 
 <div class="footer-row" [class.show]="showGoButton"
   [ngClass]="(quickMapsService.slim.obs | async) ? 'slim-sidenav heading' : ''">
-  <button mat-flat-button color="primary" form="quickMapsForm" (click)="submitForm()">View results</button>
+  <button mat-flat-button color="primary" form="quickMapsForm" (click)="submitForm()"
+    [disabled]="btnViewResultsActive === false">View results</button>
 </div>

--- a/src/app/pages/quickMaps/components/sideNavContent/sideNavContent.component.ts
+++ b/src/app/pages/quickMaps/components/sideNavContent/sideNavContent.component.ts
@@ -286,7 +286,7 @@ export class SideNavContentComponent {
     setTimeout(() => {
       void this.routeGuardService.getRequiredNavRoute().then((requiredRoute: AppRoute) => {
         if (null != requiredRoute) {
-          console.debug('Should Nav', requiredRoute);
+          // console.debug('Should Nav', requiredRoute);
           this.navigate(requiredRoute);
         }
       });

--- a/src/app/pages/quickMaps/components/sideNavContent/sideNavContent.component.ts
+++ b/src/app/pages/quickMaps/components/sideNavContent/sideNavContent.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { AbstractControl, FormBuilder, FormControl, FormGroup, ValidationErrors, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
@@ -22,49 +22,45 @@ import { DietDataSource } from 'src/app/apiAndObjects/objects/dietDataSource';
 import { DietDataService } from 'src/app/services/dietData.service';
 import { BiomarkerDataService } from 'src/app/services/biomarkerData.service';
 import { Named } from 'src/app/apiAndObjects/objects/named.interface';
+import { DialogService } from 'src/app/components/dialogs/dialog.service';
 @Unsubscriber('subscriptions')
 @Component({
   selector: 'app-side-nav-content',
   templateUrl: './sideNavContent.component.html',
   styleUrls: ['./sideNavContent.component.scss'],
 })
-export class SideNavContentComponent implements OnInit {
+export class SideNavContentComponent {
   @Input() showGoButton: boolean; // indicates if we're on the location select page or not
   public readonly ROUTES = AppRoutes;
   public readonly MICRONUTRIENT_TYPE_ENUM = MicronutrientType;
   public readonly MICRONUTRIENT_MEASURE_TYPE_ENUM = MicronutrientMeasureType;
   public readonly GEOGRAPHY_TYPE_ENUM = GeographyTypes;
-
   public countriesDictionary: Dictionary;
   public regionDictionary: Dictionary;
   public micronutrientsDictionary: Dictionary;
   public ageGenderGroupsDictionary: Dictionary;
-
   public measureDietEnabled = false;
   public measureBiomarkerEnabled = false;
-
   public selectedGeographyType: GeographyTypes;
   public selectedMndType: MicronutrientType;
-
   public geographyOptionArray: Array<DictionaryItem>;
   public selectMNDsFiltered = new Array<DictionaryItem>();
   public dataSources = new Array<Named>();
-
   public quickMapsForm: FormGroup;
-
   public sideNavToggleLock = new FormControl(false);
-
+  public btnViewResultsActive = false;
   private subscriptions = new Array<Subscription>();
 
   constructor(
-    private fb: FormBuilder,
     public dictionariesService: DictionaryService,
-    private dietDataService: DietDataService,
-    private biomarkerDataService: BiomarkerDataService,
-    private router: Router,
     public route: ActivatedRoute,
     public quickMapsService: QuickMapsService,
     public routeGuardService: QuickMapsRouteGuardService,
+    private fb: FormBuilder,
+    private dietDataService: DietDataService,
+    private biomarkerDataService: BiomarkerDataService,
+    private router: Router,
+    private dialogService: DialogService,
   ) {
     void dictionariesService
       .getDictionaries([
@@ -143,18 +139,6 @@ export class SideNavContentComponent implements OnInit {
 
         this.updateDataMeasureOptions();
       });
-  }
-
-  ngOnInit(): void {
-    // If selections are made that invalidates the current page, navigate
-    this.subscriptions.push(
-      this.quickMapsService.parameterChangedObs.subscribe(() => {
-        // only if not showing the "view results" button (on location select page)
-        if (!this.showGoButton) {
-          this.checkCurrentRouteValid();
-        }
-      }),
-    );
   }
 
   public mndChange(type: MicronutrientType): void {
@@ -262,10 +246,29 @@ export class SideNavContentComponent implements OnInit {
     }
     void dataSourcePromise.then((options: Array<Named>) => {
       this.dataSources = options;
-
-      // if only one option, preselect
-      if (1 === options.length) {
-        this.quickMapsForm.get('dataSource').setValue(options[0]);
+      if (null != country && null != micronutrient && null != measure) {
+        if (options.length === 0) {
+          if (!this.showGoButton) {
+            // valid data --> invalid data
+            this.navigate(AppRoutes.QUICK_MAPS_NO_RESULTS);
+          } else {
+            // location page with invalid data
+            this.btnViewResultsActive = false;
+          }
+        } else if (options.length >= 1) {
+          this.quickMapsForm.get('dataSource').setValue(options[0]);
+          if (!this.showGoButton) {
+            // valid data --> valid data
+            void this.routeGuardService.getRequiredNavRoute().then((requiredRoute: AppRoute) => {
+              if (null != requiredRoute) {
+                this.navigate(requiredRoute);
+              }
+            });
+          } else {
+            // location page with valid data
+            this.btnViewResultsActive = true;
+          }
+        }
       }
     });
   }
@@ -283,7 +286,7 @@ export class SideNavContentComponent implements OnInit {
     setTimeout(() => {
       void this.routeGuardService.getRequiredNavRoute().then((requiredRoute: AppRoute) => {
         if (null != requiredRoute) {
-          // console.debug('Should Nav', requiredRoute);
+          console.debug('Should Nav', requiredRoute);
           this.navigate(requiredRoute);
         }
       });

--- a/src/app/pages/quickMaps/pages/baselineDetails/mapView/mapView.component.ts
+++ b/src/app/pages/quickMaps/pages/baselineDetails/mapView/mapView.component.ts
@@ -206,6 +206,7 @@ export class MapViewComponent implements AfterViewInit {
           this.absoluteRange = this.absoluteDefaultRange;
         }
         if (null == data) {
+          void this.dialogService.openInvalidParametersDialog();
           throw new Error('data error');
         }
         this.errorSrc.next(false);
@@ -215,6 +216,7 @@ export class MapViewComponent implements AfterViewInit {
           type: 'FeatureCollection',
           features: data.data.map((item) => item.toFeature()),
         };
+
         this.initialiseMapAbsolute();
         this.initialiseMapThreshold();
         this.areaBounds = this.absoluteDataLayer.getBounds();
@@ -332,7 +334,7 @@ export class MapViewComponent implements AfterViewInit {
   //
   private getTooltip(feature: FEATURE_TYPE): string {
     const props = feature.properties;
-    console.log(props);
+
     if (this.quickMapsService.dietDataSource.get().dataLevel === DataLevel.HOUSEHOLD) {
       const dietarySupplySF = this.sigFig.transform(props.dietarySupply, 6);
       return `

--- a/src/app/pages/quickMaps/pages/locationSelect/locationSelect.component.ts
+++ b/src/app/pages/quickMaps/pages/locationSelect/locationSelect.component.ts
@@ -96,7 +96,7 @@ export class LocationSelectComponent implements AfterViewInit {
 
     this.selectedFeatureLayer = layer;
     if (null != this.selectedFeatureLayer) {
-      console.log('layer type', this.selectedFeatureLayer);
+      // console.log('layer type', this.selectedFeatureLayer);
       this.selectedFeatureLayer.setStyle({
         weight: 5,
         color: '#703AA3',

--- a/src/app/pages/quickMaps/pages/noResults/noResults.component.html
+++ b/src/app/pages/quickMaps/pages/noResults/noResults.component.html
@@ -1,0 +1,5 @@
+<div class="centredContent">
+  <img class="header-image" src="/assets/images/webp/maps-min.webp">
+  <h2 class="mat-headline">We couldnt find any results</h2>
+  <h3 class="mat-title">There are no results found for this selection. Please select another option.</h3>
+</div>

--- a/src/app/pages/quickMaps/pages/noResults/noResults.component.scss
+++ b/src/app/pages/quickMaps/pages/noResults/noResults.component.scss
@@ -1,0 +1,23 @@
+@import 'src/assets/scss/_colour.scss';
+
+.centredContent {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  padding: 40px;
+  text-align: center;
+  height: 100%;
+
+  img {
+    max-width: 350px;
+    margin: 30px;
+  }
+}
+
+@media (max-width: 800px) {
+  .centredContent {
+    margin-top: 30px;
+    margin-bottom: 300px;
+  }
+}

--- a/src/app/pages/quickMaps/pages/noResults/noResults.component.ts
+++ b/src/app/pages/quickMaps/pages/noResults/noResults.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-quickmaps-no-results',
+  templateUrl: './noResults.component.html',
+  styleUrls: ['./noResults.component.scss'],
+})
+export class NoResultsComponent {}

--- a/src/app/pages/quickMaps/quickMaps-routing.module.ts
+++ b/src/app/pages/quickMaps/quickMaps-routing.module.ts
@@ -7,6 +7,7 @@ import { BiomarkerComponent } from './pages/biomarkers/biomarker.component';
 import { CostEffectivenessComponent } from './pages/costEffectiveness/costEffectiveness.component';
 import { DietaryChangeComponent } from './pages/dietaryChange/dietaryChange.component';
 import { LocationSelectComponent } from './pages/locationSelect/locationSelect.component';
+import { NoResultsComponent } from './pages/noResults/noResults.component';
 import { ProjectionComponent } from './pages/projection/projection.component';
 import { QuickMapsComponent } from './quickMaps.component';
 import { QuickMapsRouteGuardService } from './quickMapsRouteGuard.service';
@@ -27,6 +28,19 @@ const routes: Routes = [
           hideQuickMapsHeader: true,
           showLightFooter: true,
           showQuickMapsGoButton: true,
+        } as RouteData,
+      },
+      {
+        path: AppRoutes.QUICK_MAPS_NO_RESULTS.getRouterPath(),
+        component: NoResultsComponent,
+        data: {
+          appRoute: AppRoutes.QUICK_MAPS_NO_RESULTS,
+          title: 'Quick MAPS',
+          keywords: 'Micronutrients, maps, policy, quick maps, form, selection',
+          description: 'Quick Maps no results found',
+          hideQuickMapsHeader: true,
+          showLightFooter: true,
+          showQuickMapsGoButton: false,
         } as RouteData,
       },
       {

--- a/src/app/pages/quickMaps/quickMaps.module.ts
+++ b/src/app/pages/quickMaps/quickMaps.module.ts
@@ -21,8 +21,9 @@ import { PipesModule } from 'src/app/pipes/pipes.module';
 import { DietaryChangeModule } from './pages/dietaryChange/dietaryChange.module';
 import { DialogService } from 'src/app/components/dialogs/dialog.service';
 import { CostEffectivenessModule } from './pages/costEffectiveness/costEffectiveness.module';
+import { NoResultsComponent } from './pages/noResults/noResults.component';
 @NgModule({
-  declarations: [QuickMapsComponent, LocationSelectComponent],
+  declarations: [QuickMapsComponent, LocationSelectComponent, NoResultsComponent],
   imports: [
     CommonModule,
     QuickMapsRoutingModule,

--- a/src/app/routes/routes.ts
+++ b/src/app/routes/routes.ts
@@ -72,6 +72,11 @@ export class AppRoutes {
     segments: '',
     parent: AppRoutes.QUICK_MAPS,
   };
+  public static readonly QUICK_MAPS_NO_RESULTS = {
+    ...BASE_ROUTE,
+    segments: 'noResults',
+    parent: AppRoutes.QUICK_MAPS,
+  };
   public static readonly QUICK_MAPS_DIET = {
     ...BASE_ROUTE,
     segments: 'diet',


### PR DESCRIPTION
Adds some basic validation of options which contain data and when none available, redirect users to an informative page. This should be re-visited in light of UX as there are many ways to either pre-validate (only show param options which are valid, therefore user can't make a 'mistake') or light-touch UI/UX features like toast indicators to keep user informed about what is happening and why something may not be working/results seem different to expectation.

- if selecting a new location, if there is no data available grey out/disable the view results button
- when viewing a country data, if user changes the side bar parameters, if there is no data available show a Not Found page with some basic information on what to do Currently placeholder text.

closes #689 
### To test:

- [ ] location select, pick an area with data and view results button should be active
- [ ] location select, pick an area with no data and view results button should be disabled
- [ ] viewing valid data in quick maps, select params with no data and should navigate to Not Found page
- [ ] viewing valid data in quick maps, select params with valid data and should navigate to correct data page