### PR TITLE
Card error UI improvement and notification tweak

### DIFF
--- a/src/app/components/card/card.component.html
+++ b/src/app/components/card/card.component.html
@@ -19,12 +19,9 @@
     </mat-toolbar>
 
     <div *ngIf="error" class="centredContent">
-      <!-- <div class="centredContent"> -->
-      <!-- <img class="header-image" src="/assets/images/webp/maps-min.webp"> -->
       <h2 class="mat-headline">Content unavailable</h2>
       <h3 class="mat-title">We are unable to display this content right now. Please adjust your search or try again
         soon.</h3>
-      <!-- </div> -->
     </div>
     <div *ngIf="!error" mat-align-tabs="center" class="card-content-wrapper">
       <ng-content></ng-content>

--- a/src/app/components/card/card.component.html
+++ b/src/app/components/card/card.component.html
@@ -18,7 +18,14 @@
       </button>
     </mat-toolbar>
 
-    <span *ngIf="error">Error...</span>
+    <div *ngIf="error" class="centredContent">
+      <!-- <div class="centredContent"> -->
+      <!-- <img class="header-image" src="/assets/images/webp/maps-min.webp"> -->
+      <h2 class="mat-headline">Content unavailable</h2>
+      <h3 class="mat-title">We are unable to display this content right now. Please adjust your search or try again
+        soon.</h3>
+      <!-- </div> -->
+    </div>
     <div *ngIf="!error" mat-align-tabs="center" class="card-content-wrapper">
       <ng-content></ng-content>
       <div *ngIf="loading" class="loading-indicator">

--- a/src/app/components/card/card.component.scss
+++ b/src/app/components/card/card.component.scss
@@ -1,3 +1,5 @@
+@import 'src/assets/scss/_colour.scss';
+
 :host {
   display: flex;
   flex-direction: column;
@@ -53,4 +55,26 @@ mat-toolbar {
   min-height: 0;
   display: flex;
   flex-direction: column;
+}
+
+.centredContent {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  padding: 40px;
+  text-align: center;
+  height: 100%;
+
+  img {
+    max-width: 350px;
+    margin: 30px;
+  }
+}
+
+@media (max-width: 800px) {
+  .centredContent {
+    margin-top: 30px;
+    margin-bottom: 300px;
+  }
 }

--- a/src/app/components/notifications/notification.component.html
+++ b/src/app/components/notifications/notification.component.html
@@ -7,7 +7,7 @@
     </ng-container>
   </span>
   <span class="message-container">
-    <span class="message-emitted">{{notificationData.message}} <strong>{{notificationData.boldMessage}}</strong></span>
+    <span class="message-emitted"><strong>{{notificationData.message}}</strong> {{notificationData.description}}</span>
   </span>
   <button mat-mini-fab class="mat-snackbar-close  {{notificationData.type}}" (click)="snackBarRef.dismiss()">
     <i class="fas fa-times {{notificationData.type}}"></i>

--- a/src/app/components/notifications/notification.component.scss
+++ b/src/app/components/notifications/notification.component.scss
@@ -1,3 +1,5 @@
+@import 'src/assets/scss/_colour.scss';
+
 .holding-container {
   border-radius: 5px;
   color: white;
@@ -34,12 +36,12 @@
     margin-bottom: 0.2rem;
     color: #000000;
     font-family: 'Quicksand';
-    font-size: 1.4rem;
+    font-size: 16px;
     font-weight: 700;
   }
   .message-emitted {
     padding: 2px;
-    font-size: 1.2rem;
+    font-size: 16px;
     margin-left: 0.5em;
     color: #000000;
   }

--- a/src/app/components/notifications/notification.service.ts
+++ b/src/app/components/notifications/notification.service.ts
@@ -6,25 +6,32 @@ import { NotificationType } from './notificationType.enum';
 
 @Injectable()
 export class NotificationsService {
+  constructor(private newNotification: MatSnackBar) {}
 
-  constructor(private newNotification: MatSnackBar) {
-  }
-
-  public sendInformative(message: string, boldMessage?: string, duration = 3000): void {
+  public sendInformative(message: string, description?: string, duration = 3000): void {
     const notificationData: NotificationData = {
-      type: NotificationType.INFORMATION, message: message, boldMessage: boldMessage, duration: duration
+      type: NotificationType.INFORMATION,
+      message: message,
+      description: description,
+      duration: duration,
     };
     this.sendNotification(notificationData);
   }
-  public sendNegative(message: string, boldMessage?: string, duration = 12000): void {
+  public sendNegative(message: string, description?: string, duration = 12000): void {
     const notificationData: NotificationData = {
-      type: NotificationType.NEGATIVE, message: message, boldMessage: boldMessage, duration: duration
+      type: NotificationType.NEGATIVE,
+      message: message,
+      description: description,
+      duration: duration,
     };
     this.sendNotification(notificationData);
   }
-  public sendPositive(message: string, boldMessage?: string, duration = 3000): void {
+  public sendPositive(message: string, description?: string, duration = 3000): void {
     const notificationData: NotificationData = {
-      type: NotificationType.POSITIVE, message: message, boldMessage: boldMessage, duration: duration
+      type: NotificationType.POSITIVE,
+      message: message,
+      description: description,
+      duration: duration,
     };
     this.sendNotification(notificationData);
   }
@@ -32,8 +39,7 @@ export class NotificationsService {
     this.newNotification.openFromComponent(NotificationComponent, {
       panelClass: ['maps-snackbar'],
       duration: notificationData.duration,
-      data: notificationData
+      data: notificationData,
     });
   }
-
 }

--- a/src/app/components/notifications/notificationData.ts
+++ b/src/app/components/notifications/notificationData.ts
@@ -3,6 +3,6 @@ import { NotificationType } from './notificationType.enum';
 export interface NotificationData {
   type: NotificationType;
   message: string;
-  boldMessage?: string;
+  description?: string;
   duration: number;
 }


### PR DESCRIPTION
- card with erroring content now show a clearer message to say it is unavailable
- notification typography tweaked to emphasis error type/heading instead of the message.
### To test
- visit any section where there is not full data availability e.g.:
- https://preview713--micronutrientsupport-tool.netlify.app/quick-maps/diet/dietary-change?country-id=MWI&mnd-id=Ca&measure=diet&age-gender-group-id=WRA&sm=0&si=1312.01-9

### Todo
- improve the UI of the empty content with imagery or suggestions on how to 'fix'. Needs some new asset imagery for missing content 