### PR TITLE
chore: correctly set treemap units depending on data level

### DIFF
--- a/src/app/pages/quickMaps/pages/baselineDetails/foodItems/foodItems.component.html
+++ b/src/app/pages/quickMaps/pages/baselineDetails/foodItems/foodItems.component.html
@@ -18,9 +18,16 @@
             <td mat-cell *matCellDef="let element">{{ element.foodGroupName }}</td>
           </ng-container>
           <ng-container matColumnDef="dailyMnContribution">
-            <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ (quickMapsService.micronutrient.obs |
-              async)?.id }}
-              (mg/AFE/day)</th>
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>
+              <span *ngIf="DATA_LEVEL.HOUSEHOLD === (quickMapsService.dietDataSource.obs | async)?.dataLevel">
+                {{ (quickMapsService.micronutrient.obs |
+                async)?.id }} (mg/AFE/day)
+              </span>
+              <span *ngIf="DATA_LEVEL.COUNTRY === (quickMapsService.dietDataSource.obs | async)?.dataLevel">
+                {{ (quickMapsService.micronutrient.obs |
+                async)?.id }} (mg/capita/day)
+              </span>
+            </th>
             <td mat-cell *matCellDef="let element">{{ element.dailyMnContribution | sigFig:4 }}</td>
           </ng-container>
           <tr mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></tr>

--- a/src/app/pages/quickMaps/pages/baselineDetails/foodItems/foodItems.component.ts
+++ b/src/app/pages/quickMaps/pages/baselineDetails/foodItems/foodItems.component.ts
@@ -26,6 +26,7 @@ import { NotificationsService } from 'src/app/components/notifications/notificat
 import { QuickchartService } from 'src/app/services/quickChart.service';
 import { MicronutrientDictionaryItem } from 'src/app/apiAndObjects/objects/dictionaries/micronutrientDictionaryItem';
 import { DietDataService } from 'src/app/services/dietData.service';
+import { DataLevel } from 'src/app/apiAndObjects/objects/enums/dataLevel.enum';
 @Component({
   selector: 'app-food-items',
   templateUrl: './foodItems.component.html',
@@ -47,6 +48,8 @@ export class FoodItemsComponent implements AfterViewInit {
   public displayedColumns = ['ranking', 'foodGroupName', 'dailyMnContribution'];
   public dataSource: MatTableDataSource<TopFoodSource>;
   public mnUnit = '';
+
+  public readonly DATA_LEVEL = DataLevel;
 
   private data: Array<TopFoodSource>;
 
@@ -191,7 +194,11 @@ export class FoodItemsComponent implements AfterViewInit {
               // tslint:disable-next-line: no-string-literal
               const value: string = dataItem['v'] as string;
               const mnUnit = this.mnUnit;
-              return `${label}: ${Number(value).toPrecision(4)} ${mnUnit}/AFE/day`;
+              if (this.quickMapsService.dietDataSource.get().dataLevel === DataLevel.COUNTRY) {
+                return `${label}: ${Number(value).toPrecision(4)} ${mnUnit}/capita/day`;
+              } else {
+                return `${label}: ${Number(value).toPrecision(4)} ${mnUnit}/AFE/day`;
+              }
             },
           },
         },


### PR DESCRIPTION
For country level units should be `/capita/day` e.g. https://preview726--micronutrientsupport-tool.netlify.app/quick-maps/diet/baseline?country-id=ETH&mnd-id=Ca&measure=diet&age-gender-group-id=WRA

For household level (MWI) should be `/AFE/day` e.g. https://preview726--micronutrientsupport-tool.netlify.app/quick-maps/diet/baseline?country-id=MWI&mnd-id=Ca&measure=diet&age-gender-group-id=WRA

Updated in both treemap and data table