### PR TITLE
fix: get intervention sub routing almost working

### DIFF
--- a/src/app/pages/quickMaps/pages/costEffectiveness/components/intervention/intervention.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/components/intervention/intervention.component.html
@@ -37,7 +37,7 @@
           <button mat-raised-button type=" button" class="btn btn-primary">Delete</button>
         </div>
         <div class="button-container">
-          <button mat-raised-button color="primary" [routerLink]="ROUTES.INTERVENTION_REVIEW | route">Review</button>
+          <a mat-raised-button color="primary" [routerLink]="ROUTES.INTERVENTION_REVIEW_BASELINE | route">Review</a>
         </div>
       </div>
 

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview-routing.module.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview-routing.module.ts
@@ -18,7 +18,7 @@ const routes: Routes = [
     component: InterventionReviewComponent,
     children: [
       {
-        path: AppRoutes.INTERVENTION_REVIEW_ASSUMPTIONS_REVIEW.getRouterPath(),
+        path: AppRoutes.INTERVENTION_REVIEW_BASELINE.getRouterPath(),
         component: InterventionBaselineComponent,
         data: {
           appRoute: AppRoutes.INTERVENTION_REVIEW_BASELINE,

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview-routing.module.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview-routing.module.ts
@@ -18,7 +18,7 @@ const routes: Routes = [
     component: InterventionReviewComponent,
     children: [
       {
-        path: '',
+        path: AppRoutes.INTERVENTION_REVIEW_ASSUMPTIONS_REVIEW.getRouterPath(),
         component: InterventionBaselineComponent,
         data: {
           appRoute: AppRoutes.INTERVENTION_REVIEW_BASELINE,

--- a/src/app/pages/quickMaps/pages/costEffectiveness/pages/interventionCompliance/interventionCompliance.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/pages/interventionCompliance/interventionCompliance.component.html
@@ -1,2 +1,2 @@
-<div id="bing">compliance<button mat-raised-button color="primary"
-    [routerLink]="ROUTES.INTERVENTION_REVIEW_BASELINE | route">Review</button></div>
+<div id="bing">compliance<a mat-raised-button color="primary"
+        [routerLink]="ROUTES.INTERVENTION_REVIEW_ASSUMPTIONS_REVIEW | route">Review</a></div>

--- a/src/app/pages/quickMaps/quickMaps-routing.module.ts
+++ b/src/app/pages/quickMaps/quickMaps-routing.module.ts
@@ -112,10 +112,10 @@ const routes: Routes = [
     loadChildren: () =>
       import('./pages/costEffectiveness/interventionReview.module').then((m) => m.InterventionReviewModule),
   },
-  {
-    path: '**',
-    redirectTo: '',
-  },
+  // {
+  //   path: '**',
+  //   redirectTo: '',
+  // },
 ];
 
 @NgModule({

--- a/src/app/pages/quickMaps/quickMaps-routing.module.ts
+++ b/src/app/pages/quickMaps/quickMaps-routing.module.ts
@@ -108,14 +108,14 @@ const routes: Routes = [
     ],
   },
   {
-    path: AppRoutes.INTERVENTION_REVIEW.getRouterPath(),
+    path: AppRoutes.QUICK_MAPS_COST_EFFECTIVENESS.getRouterPath() + '**',
     loadChildren: () =>
       import('./pages/costEffectiveness/interventionReview.module').then((m) => m.InterventionReviewModule),
   },
-  {
-    path: '**',
-    redirectTo: '',
-  },
+  // {
+  //   path: '**',
+  //   redirectTo: '',
+  // },
 ];
 
 @NgModule({

--- a/src/app/pages/quickMaps/quickMaps-routing.module.ts
+++ b/src/app/pages/quickMaps/quickMaps-routing.module.ts
@@ -112,10 +112,10 @@ const routes: Routes = [
     loadChildren: () =>
       import('./pages/costEffectiveness/interventionReview.module').then((m) => m.InterventionReviewModule),
   },
-  // {
-  //   path: '**',
-  //   redirectTo: '',
-  // },
+  {
+    path: '**',
+    redirectTo: '',
+  },
 ];
 
 @NgModule({

--- a/src/app/pages/quickMaps/quickMaps.module.ts
+++ b/src/app/pages/quickMaps/quickMaps.module.ts
@@ -22,6 +22,7 @@ import { DietaryChangeModule } from './pages/dietaryChange/dietaryChange.module'
 import { DialogService } from 'src/app/components/dialogs/dialog.service';
 import { CostEffectivenessModule } from './pages/costEffectiveness/costEffectiveness.module';
 import { NoResultsComponent } from './pages/noResults/noResults.component';
+import { InterventionReviewModule } from './pages/costEffectiveness/interventionReview.module';
 @NgModule({
   declarations: [QuickMapsComponent, LocationSelectComponent, NoResultsComponent],
   imports: [
@@ -41,6 +42,7 @@ import { NoResultsComponent } from './pages/noResults/noResults.component';
     PipesModule,
     DietaryChangeModule,
     CostEffectivenessModule,
+    InterventionReviewModule,
   ],
   providers: [QuickMapsService, QuickMapsRouteGuardService, ExportService, PipesModule, DialogService],
 })

--- a/src/app/pages/quickMaps/quickMapsRouteGuard.service.ts
+++ b/src/app/pages/quickMaps/quickMapsRouteGuard.service.ts
@@ -99,7 +99,6 @@ export class QuickMapsRouteGuardService implements CanActivate {
    */
   private getRequiredNavForMeasureValidation(snapshot: ActivatedRouteSnapshot): Promise<AppRoute> {
     const appRoute = (snapshot.data as RouteData).appRoute;
-    return Promise.resolve(appRoute);
     // console.debug('validateMeasureForRoute', measure, snapshot);
 
     return this.quickMapsParameters.getMeasure(snapshot.queryParamMap).then((measure) => {

--- a/src/app/pages/quickMaps/quickMapsRouteGuard.service.ts
+++ b/src/app/pages/quickMaps/quickMapsRouteGuard.service.ts
@@ -99,6 +99,7 @@ export class QuickMapsRouteGuardService implements CanActivate {
    */
   private getRequiredNavForMeasureValidation(snapshot: ActivatedRouteSnapshot): Promise<AppRoute> {
     const appRoute = (snapshot.data as RouteData).appRoute;
+    return Promise.resolve(appRoute);
     // console.debug('validateMeasureForRoute', measure, snapshot);
 
     return this.quickMapsParameters.getMeasure(snapshot.queryParamMap).then((measure) => {

--- a/src/app/routes/routes.ts
+++ b/src/app/routes/routes.ts
@@ -124,37 +124,37 @@ export class AppRoutes {
   public static readonly INTERVENTION_REVIEW_ASSUMPTIONS_REVIEW = {
     ...BASE_ROUTE,
     segments: 'intervention-assumptions-review',
-    parent: AppRoutes.INTERVENTION_REVIEW,
+    parent: AppRoutes.QUICK_MAPS_COST_EFFECTIVENESS,
   };
   public static readonly INTERVENTION_REVIEW_COMPLIANCE = {
     ...BASE_ROUTE,
     segments: 'intervention-compliance',
-    parent: AppRoutes.INTERVENTION_REVIEW,
+    parent: AppRoutes.QUICK_MAPS_COST_EFFECTIVENESS,
   };
   public static readonly INTERVENTION_REVIEW_COST_SUMMARY = {
     ...BASE_ROUTE,
     segments: 'intervention-cost-summary',
-    parent: AppRoutes.INTERVENTION_REVIEW,
+    parent: AppRoutes.QUICK_MAPS_COST_EFFECTIVENESS,
   };
   public static readonly INTERVENTION_REVIEW_INDUSTRY_INFORMATION = {
     ...BASE_ROUTE,
     segments: 'intervention-industry-information',
-    parent: AppRoutes.INTERVENTION_REVIEW,
+    parent: AppRoutes.QUICK_MAPS_COST_EFFECTIVENESS,
   };
   public static readonly INTERVENTION_REVIEW_MONITORING_INFORMATION = {
     ...BASE_ROUTE,
     segments: 'intervention-monitoring-information',
-    parent: AppRoutes.INTERVENTION_REVIEW,
+    parent: AppRoutes.QUICK_MAPS_COST_EFFECTIVENESS,
   };
   public static readonly INTERVENTION_REVIEW_RECURRING_COSTS = {
     ...BASE_ROUTE,
     segments: 'intervention-recurring-costs',
-    parent: AppRoutes.INTERVENTION_REVIEW,
+    parent: AppRoutes.QUICK_MAPS_COST_EFFECTIVENESS,
   };
   public static readonly INTERVENTION_REVIEW_STARTUP_SCALEUP_COSTS = {
     ...BASE_ROUTE,
     segments: 'intervention-startup-scaleup-costs',
-    parent: AppRoutes.INTERVENTION_REVIEW,
+    parent: AppRoutes.QUICK_MAPS_COST_EFFECTIVENESS,
   };
 }
 

--- a/src/app/routes/routes.ts
+++ b/src/app/routes/routes.ts
@@ -119,7 +119,7 @@ export class AppRoutes {
   public static readonly INTERVENTION_REVIEW_BASELINE = {
     ...BASE_ROUTE,
     segments: 'intervention-baseline',
-    parent: AppRoutes.INTERVENTION_REVIEW,
+    parent: AppRoutes.QUICK_MAPS_COST_EFFECTIVENESS,
   };
   public static readonly INTERVENTION_REVIEW_ASSUMPTIONS_REVIEW = {
     ...BASE_ROUTE,


### PR DESCRIPTION
*   Import `InterventionReviewModule` into the QuickMAPS module :star: 
*   Update parents of intervention pages to be the cost-effectivness module rather than intervention\_review
*   Replace some buttons with anchor links to aid in browser preview/debugging of urls
*   Fix review link in compliance page

All intervention pages (except intervention-baseline) work:

e.g. http://localhost:8100/quick-maps/diet/cost-effectiveness/intervention-compliance

http://localhost:8100/quick-maps/diet/cost-effectiveness/intervention-startup-scaleup-costs

Need to sort baseline still :shrug: