### PR TITLE
fix: do not create intervention item on model cancel

### DIFF
--- a/src/app/components/dialogs/costEffectivenessSelectionDialog/costEffectivenessSelectionDialog.component.ts
+++ b/src/app/components/dialogs/costEffectivenessSelectionDialog/costEffectivenessSelectionDialog.component.ts
@@ -23,9 +23,9 @@ export class CostEffectivenessSelectionDialogComponent implements OnInit {
   }
 
   public createIntervention(): void {
-    if (null != this.selectedIntervention.name) {
+    if (this.selectedIntervention) {
       this.dialogData.dataOut = this.selectedIntervention;
+      this.dialog.closeAll();
     }
-    this.dialog.closeAll();
   }
 }

--- a/src/app/pages/quickMaps/pages/costEffectiveness/components/interventionCreation/interventionCreation.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/components/interventionCreation/interventionCreation.component.ts
@@ -49,7 +49,7 @@ export class InterventionCreationComponent {
   }
   public openCESelectionDialog(): void {
     void this.dialogService.openCESelectionDialog(this.interventionsDictionaryItems).then((data: DialogData) => {
-      if (null != data) {
+      if (Object.keys(data.dataOut).length !== 0) {
         const inteventionIds = this.route.snapshot.queryParamMap.get('intIds')
           ? JSON.parse(this.route.snapshot.queryParamMap.get('intIds')).map(Number)
           : [];
@@ -58,9 +58,9 @@ export class InterventionCreationComponent {
           queryParams: { intIds: JSON.stringify([...inteventionIds, +data.dataOut.id]) },
           queryParamsHandling: 'merge',
         });
+        this.selectedInterventions.push(data.dataOut);
+        this.cdr.detectChanges();
       }
-      this.selectedInterventions.push(data.dataOut);
-      this.cdr.detectChanges();
     });
   }
 }


### PR DESCRIPTION
- intervention was still added to list of selected intervention when pressing the 'cancel' button. Fix does not add empty object.
- Checks object exists instead of if name value exists on object