### PR TITLE
Updates to the intervention review page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "micronutrient-support-tool",
-  "version": "1.3.2",
+  "version": "1.3.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/app/pages/quickMaps/pages/costEffectiveness/components/intervention/intervention.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/components/intervention/intervention.component.html
@@ -2,7 +2,9 @@
   <mat-card>
     <mat-card-title class="int-header">
       <div class="title">
-        <strong>{{ intervention.name }}</strong>
+        <span *ngIf="!intervention.name"><strong>No intervention name set</strong></span>
+        <span *ngIf="intervention.name"><strong>{{ intervention.name }}</strong></span>
+
         <span class="int-id">ID: {{ intervention.id }}</span>
       </div>
     </mat-card-title>
@@ -11,8 +13,8 @@
       <div class="content-container">
         <div class="item-container">
           <div class="item">
-            Base year: <strong>2021</strong>
-            <!-- Base year: <strong>{{ intervention.baseYear }}</strong> -->
+            <span *ngIf="!intervention.baseYear">Base year: <strong>2021</strong></span>
+            <span *ngIf="intervention.baseYear">Base year: <strong>{{ intervention.baseYear }}</strong></span>
           </div>
           <div class="item">
             10-year total cost: <strong>{{ intervention.tenYearTotalCost | currency }}</strong>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/components/intervention/intervention.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/components/intervention/intervention.component.html
@@ -26,7 +26,8 @@
       </div>
       <div class="column-container">
         <div class="button-container">
-          <button mat-stroked-button type="button" class="btn btn-primary">Delete</button>
+          <button mat-stroked-button type="button" class="btn btn-primary"
+            (click)="removeIntervention()">Remove</button>
         </div>
         <div class="button-container">
           <a mat-flat-button color="primary" (click)="reviewIntervention()">Review</a>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/components/intervention/intervention.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/components/intervention/intervention.component.html
@@ -3,10 +3,7 @@
     <mat-card-title class="int-header">
       <div class="title">
         <strong>{{ intervention.name }}</strong>
-        <button class="edit-title">
-          <mat-icon>edit</mat-icon>
-          <span>Rename</span>
-        </button>
+        <span class="int-id">ID: {{ intervention.id }}</span>
       </div>
     </mat-card-title>
     <p class="desc">{{ intervention.description }}</p>
@@ -14,31 +11,23 @@
       <div class="content-container">
         <div class="item-container">
           <div class="item">
-            Base year: <strong>{{ intervention.baseYear }}</strong>
+            Base year: <strong>2021</strong>
+            <!-- Base year: <strong>{{ intervention.baseYear }}</strong> -->
           </div>
           <div class="item">
-            10-year total cost: <strong>${{ intervention.tenYearTotalCost }}</strong>
-          </div>
-        </div>
-        <div class="item-container">
-          <div class="item">
-            <span>Assumptions:</span>
-            <button mat-raised-button type="button" (click)="onConfirmAssumptions()"
-              [ngClass]="{ 'green' : toggleAssumptions, 'red': !toggleAssumptions }">{{ assumptionsText }}</button>
+            10-year total cost: <strong>{{ intervention.tenYearTotalCost | currency }}</strong>
           </div>
           <div class="item">
-            <span>Costs:</span>
-            <button mat-raised-button type="button" (click)="onConfirmCosts()"
-              [ngClass]="{ 'green' : toggleCosts, 'red': !toggleCosts }">{{ costsText }}</button>
+            Last updated: <strong>{{today | date:'medium'}}</strong>
           </div>
         </div>
       </div>
       <div class="column-container">
         <div class="button-container">
-          <button mat-raised-button type="button" class="btn btn-primary">Delete</button>
+          <button mat-stroked-button type="button" class="btn btn-primary">Delete</button>
         </div>
         <div class="button-container">
-          <a mat-raised-button color="primary" (click)="reviewIntervention()">Review</a>
+          <a mat-flat-button color="primary" (click)="reviewIntervention()">Review</a>
         </div>
       </div>
     </div>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/components/intervention/intervention.component.scss
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/components/intervention/intervention.component.scss
@@ -44,7 +44,7 @@
 
   .item {
     button {
-      color: #FFFFFF;
+      color: #ffffff;
       line-height: 24px;
       margin-left: 0.5rem;
       min-width: 130px;
@@ -84,6 +84,11 @@
 
 .title {
   display: flex;
+  justify-content: flex-start;
+}
+
+.int-id {
+  margin-left: 10px;
 }
 
 .edit-title {
@@ -109,9 +114,9 @@
 }
 
 .green {
-  background-color: #6FCF97;
+  background-color: #6fcf97;
 }
 
 .red {
-  background-color: #EB5757;
+  background-color: #eb5757;
 }

--- a/src/app/pages/quickMaps/pages/costEffectiveness/components/intervention/intervention.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/components/intervention/intervention.component.ts
@@ -29,11 +29,12 @@ export class InterventionComponent {
   public today: number = Date.now();
 
   public reviewIntervention(): void {
-    console.debug('id to be set from component:', this.intervention.id);
-    this.interventionDataService.setActiveInterventionId(this.intervention.id);
-    const route = this.ROUTES.INTERVENTION_REVIEW_BASELINE.getRoute();
-    const params = this.route.snapshot.queryParams;
-    void this.router.navigate(route, { queryParams: params });
+    this.interventionDataService.startReviewingIntervention(this.intervention.id);
+    // console.debug('id to be set from component:', this.intervention.id);
+    // this.interventionDataService.setActiveInterventionId(this.intervention.id);
+    // const route = this.ROUTES.INTERVENTION_REVIEW_BASELINE.getRoute();
+    // const params = this.route.snapshot.queryParams;
+    // void this.router.navigate(route, { queryParams: params });
   }
 
   onConfirmAssumptions(): void {

--- a/src/app/pages/quickMaps/pages/costEffectiveness/components/intervention/intervention.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/components/intervention/intervention.component.ts
@@ -26,6 +26,7 @@ export class InterventionComponent {
 
   public assumptionsText = 'Confirmed';
   public costsText = 'Confirmed';
+  public today: number = Date.now();
 
   public reviewIntervention(): void {
     console.debug('id to be set from component:', this.intervention.id);

--- a/src/app/pages/quickMaps/pages/costEffectiveness/components/intervention/intervention.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/components/intervention/intervention.component.ts
@@ -3,6 +3,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { InterventionsDictionaryItem } from 'src/app/apiAndObjects/objects/dictionaries/interventionDictionaryItem';
 import { AppRoutes } from 'src/app/routes/routes';
 import { InterventionDataService } from 'src/app/services/interventionData.service';
+import { InterventionCreationService } from '../interventionCreation/interventionCreation.service';
 
 @Component({
   selector: 'app-ce-intervention',
@@ -17,6 +18,7 @@ export class InterventionComponent {
 
   constructor(
     private readonly interventionDataService: InterventionDataService,
+    private interventionCreationService: InterventionCreationService,
     private readonly router: Router,
     public route: ActivatedRoute,
   ) {}
@@ -32,12 +34,16 @@ export class InterventionComponent {
     this.interventionDataService.startReviewingIntervention(this.intervention.id);
   }
 
-  onConfirmAssumptions(): void {
+  public removeIntervention() {
+    this.interventionCreationService.interventionRemove(this.intervention.id);
+  }
+
+  public onConfirmAssumptions(): void {
     this.toggleAssumptions = !this.toggleAssumptions;
     this.assumptionsText = this.toggleAssumptions ? 'Confirmed' : 'Not confirmed';
   }
 
-  onConfirmCosts(): void {
+  public onConfirmCosts(): void {
     this.toggleCosts = !this.toggleCosts;
     this.costsText = this.toggleCosts ? 'Confirmed' : 'Not confirmed';
   }

--- a/src/app/pages/quickMaps/pages/costEffectiveness/components/intervention/intervention.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/components/intervention/intervention.component.ts
@@ -30,11 +30,6 @@ export class InterventionComponent {
 
   public reviewIntervention(): void {
     this.interventionDataService.startReviewingIntervention(this.intervention.id);
-    // console.debug('id to be set from component:', this.intervention.id);
-    // this.interventionDataService.setActiveInterventionId(this.intervention.id);
-    // const route = this.ROUTES.INTERVENTION_REVIEW_BASELINE.getRoute();
-    // const params = this.route.snapshot.queryParams;
-    // void this.router.navigate(route, { queryParams: params });
   }
 
   onConfirmAssumptions(): void {

--- a/src/app/pages/quickMaps/pages/costEffectiveness/components/interventionCreation/interventionCreation.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/components/interventionCreation/interventionCreation.component.html
@@ -1,18 +1,19 @@
 <div class="info-wrapper">
-    <h2>Select an intervention</h2>
-    <span>
-        To explore the effectiveness of <strong>{{ (quickMapsService.micronutrient.obs | async)?.name }}</strong>
-        interventions in <strong>{{ (quickMapsService.country.obs | async)?.name }}</strong>, by choosing either an
-        existing (currently implemented
-        at scale*) or hypothetical/alternative (not currently implemented at scale or implemented under alternative
-        assumptions) intervention. Additional interventions can be added after the predicted effectiveness of the first
-        intervention has been displayed and stored.
-    </span>
-    <button mat-raised-button color="primary" (click)="openCESelectionDialog()">
-        Add intervention
-    </button>
+  <h2>Select an intervention</h2>
+  <span>
+    To explore the effectiveness of <strong>{{ (quickMapsService.micronutrient.obs | async)?.name }}</strong>
+    interventions in <strong>{{ (quickMapsService.country.obs | async)?.name }}</strong>, by choosing either an
+    existing (currently implemented
+    at scale*) or hypothetical/alternative (not currently implemented at scale or implemented under alternative
+    assumptions) intervention. Additional interventions can be added after the predicted effectiveness of the first
+    intervention has been displayed and stored.
+  </span>
+  <button mat-raised-button color="primary" (click)="openCESelectionDialog()">
+    Add intervention
+  </button>
 </div>
-<h2>Selected interventions</h2>
+
+<h2 *ngIf="this.selectedInterventions.length !== 0">Selected interventions</h2>
 
 <app-ce-intervention *ngFor="let intervention of selectedInterventions" [intervention]="intervention">
 </app-ce-intervention>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/components/interventionCreation/interventionCreation.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/components/interventionCreation/interventionCreation.component.ts
@@ -46,6 +46,7 @@ export class InterventionCreationComponent {
           for (const id of interventionIds) {
             await this.interventionService.getIntervention(id.toString()).then((data: unknown) => {
               this.selectedInterventions.push(data as InterventionsDictionaryItem);
+              this.interventionCreationService.updateCurrentInterventionsCount(this.selectedInterventions.length);
               this.cdr.detectChanges();
             });
           }
@@ -67,6 +68,7 @@ export class InterventionCreationComponent {
           queryParamsHandling: 'merge',
         });
         this.selectedInterventions.push(data.dataOut);
+        this.interventionCreationService.updateCurrentInterventionsCount(this.selectedInterventions.length);
         this.cdr.detectChanges();
       }
     });
@@ -77,6 +79,7 @@ export class InterventionCreationComponent {
 
     // remove from list of selected interventions
     this.selectedInterventions = this.selectedInterventions.filter((value) => value.id !== interventionToRemove);
+    this.interventionCreationService.updateCurrentInterventionsCount(this.selectedInterventions.length);
 
     // get current query param array
     const interventionIds = this.route.snapshot.queryParamMap.get('intIds')
@@ -85,11 +88,9 @@ export class InterventionCreationComponent {
 
     // remove null and zero values
     const cleanedArrayIntIds: string[] = interventionIds.filter((x: number) => x);
-    console.log(JSON.stringify(cleanedArrayIntIds));
 
     // remove the specific intervention id
     const filteredArrayIntIds: string[] = cleanedArrayIntIds.filter((value) => value !== interventionToRemove);
-    console.log(JSON.stringify(filteredArrayIntIds));
 
     // update the route queryParams
     this.router.navigate([], {

--- a/src/app/pages/quickMaps/pages/costEffectiveness/components/interventionCreation/interventionCreation.service.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/components/interventionCreation/interventionCreation.service.ts
@@ -8,11 +8,18 @@ export class InterventionCreationService {
   private readonly interventionLoadeSrc = new BehaviorSubject<void>(null);
   public readonly interventionLoadObs = this.interventionLoadeSrc.asObservable();
 
+  private readonly interventionRemovalSrc = new BehaviorSubject<string>(null);
+  public readonly interventionRemovalObs = this.interventionRemovalSrc.asObservable();
+
   constructor() {
     // add content
   }
 
   public watchInterventionLoad(): void {
     this.interventionLoadeSrc.next();
+  }
+
+  public interventionRemove(interventionIdToRemove: string): void {
+    this.interventionRemovalSrc.next(interventionIdToRemove);
   }
 }

--- a/src/app/pages/quickMaps/pages/costEffectiveness/components/interventionCreation/interventionCreation.service.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/components/interventionCreation/interventionCreation.service.ts
@@ -11,6 +11,9 @@ export class InterventionCreationService {
   private readonly interventionRemovalSrc = new BehaviorSubject<string>(null);
   public readonly interventionRemovalObs = this.interventionRemovalSrc.asObservable();
 
+  private readonly interventionsSelectedCountSrc = new BehaviorSubject<number>(null);
+  public readonly interventionsSelectedCountObs = this.interventionsSelectedCountSrc.asObservable();
+
   constructor() {
     // add content
   }
@@ -21,5 +24,9 @@ export class InterventionCreationService {
 
   public interventionRemove(interventionIdToRemove: string): void {
     this.interventionRemovalSrc.next(interventionIdToRemove);
+  }
+
+  public updateCurrentInterventionsCount(count: number): void {
+    this.interventionsSelectedCountSrc.next(count);
   }
 }

--- a/src/app/pages/quickMaps/pages/costEffectiveness/components/interventionCreation/interventionCreation.service.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/components/interventionCreation/interventionCreation.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class InterventionCreationService {
+  private readonly interventionLoadeSrc = new BehaviorSubject<void>(null);
+  public readonly interventionLoadObs = this.interventionLoadeSrc.asObservable();
+
+  constructor() {
+    // add content
+  }
+
+  public watchInterventionLoad(): void {
+    this.interventionLoadeSrc.next();
+  }
+}

--- a/src/app/pages/quickMaps/pages/costEffectiveness/components/menu/menu.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/components/menu/menu.component.html
@@ -11,7 +11,7 @@
     </mat-button-toggle>
   </mat-button-toggle-group>
   <span matTooltip="Select interventions to compare them.">
-    <mat-icon matBadge="?" matBadgeOverlap="false">shopping_basket</mat-icon>
+    <mat-icon [matBadge]="interventionCount" matBadgeOverlap="false">shopping_basket</mat-icon>
   </span>
 </div>
 <div>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/components/menu/menu.component.scss
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/components/menu/menu.component.scss
@@ -5,8 +5,9 @@
   margin-top: 1em;
   .menu-container {
     display: flex;
-    justify-content: space-evenly;
+    justify-content: space-between;
     align-items: center;
+    margin-right: 24px;
     .mat-button-toggle-group {
       width: 50%;
     }

--- a/src/app/pages/quickMaps/pages/costEffectiveness/components/menu/menu.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/components/menu/menu.component.ts
@@ -1,5 +1,6 @@
-import { Component, OnInit } from '@angular/core';
+import { ChangeDetectorRef, Component, OnInit } from '@angular/core';
 import { DialogService } from 'src/app/components/dialogs/dialog.service';
+import { InterventionCreationService } from '../interventionCreation/interventionCreation.service';
 
 @Component({
   selector: 'app-ce-menu',
@@ -7,12 +8,26 @@ import { DialogService } from 'src/app/components/dialogs/dialog.service';
   styleUrls: ['./menu.component.scss'],
 })
 export class MenuComponent implements OnInit {
-  constructor(private dialogService: DialogService) {
-    // add content
+  public interventionCount: number;
+  constructor(
+    private dialogService: DialogService,
+    private interventionCreationService: InterventionCreationService,
+    private cdr: ChangeDetectorRef,
+  ) {
+    this.interventionCreationService.interventionsSelectedCountObs.subscribe((count: number) => {
+      if (count !== null && count !== undefined) {
+        this.updateInterventionCount(count);
+      }
+    });
   }
 
   ngOnInit(): void {
-    // add content
+    this.cdr.detectChanges();
+  }
+
+  public updateInterventionCount(count: number) {
+    this.interventionCount = count;
+    this.cdr.markForCheck();
   }
 
   public openCEInfoDialog(): void {

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/components/interventionDescription/interventionDescription.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/components/interventionDescription/interventionDescription.component.html
@@ -1,4 +1,8 @@
-<p>Intervention name: {{ interventionName }}</p>
+<div class="intervention-info">
+  <span>Intervention name: <strong>{{ selectedIntervention?.name }}</strong></span>
+  <span>ID: <strong>{{ selectedIntervention?.id }}</strong></span>
+</div>
+
 <div class="intervention-summary-title">{{ (quickMapsService.micronutrient.obs | async)?.name }} intervention in {{
   (quickMapsService.country.obs | async)?.name }}</div>
 <div class="intervention-summary-panel">

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/components/interventionDescription/interventionDescription.component.scss
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/components/interventionDescription/interventionDescription.component.scss
@@ -1,5 +1,12 @@
 @import 'src/assets/scss/_colour';
 
+.intervention-info {
+  display: flex;
+  font-size: 14px;
+  padding: 5px;
+  border-bottom: 1px solid $color_primary;
+  justify-content: space-between;
+}
 .intervention-summary-title {
   flex-grow: 1;
   display: flex;

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/components/interventionDescription/interventionDescription.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/components/interventionDescription/interventionDescription.component.ts
@@ -9,13 +9,13 @@ import { InterventionDataService } from 'src/app/services/interventionData.servi
   styleUrls: ['./interventionDescription.component.scss'],
 })
 export class InterventionDescriptionComponent {
-  public interventionName = '';
+  public selectedIntervention: Intervention;
   constructor(
     public quickMapsService: QuickMapsService,
     private readonly interventionDataService: InterventionDataService,
   ) {
     this.interventionDataService
       .getIntervention(this.interventionDataService.getActiveInterventionId())
-      .then((value: Intervention) => (this.interventionName = value.name));
+      .then((selectedIntervention: Intervention) => (this.selectedIntervention = selectedIntervention));
   }
 }

--- a/src/app/services/interventionData.service.ts
+++ b/src/app/services/interventionData.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { BehaviorSubject } from 'rxjs';
 import { ApiService } from '../apiAndObjects/api/api.service';
+import { InterventionsDictionaryItem } from '../apiAndObjects/objects/dictionaries/interventionDictionaryItem';
 import { Intervention } from '../apiAndObjects/objects/intervention';
 import { InterventionBaselineAssumptions } from '../apiAndObjects/objects/interventionBaselineAssumptions';
 import { InterventionCostSummary } from '../apiAndObjects/objects/interventionCostSummary';
@@ -141,5 +142,12 @@ export class InterventionDataService {
     } else {
       return activeId;
     }
+  }
+
+  public startReviewingIntervention(interventionID: string): void {
+    this.setActiveInterventionId(interventionID);
+    const route = this.ROUTES.INTERVENTION_REVIEW_BASELINE.getRoute();
+    const params = this.route.snapshot.queryParams;
+    void this.router.navigate(route, { queryParams: params });
   }
 }

--- a/src/app/services/interventionData.service.ts
+++ b/src/app/services/interventionData.service.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { BehaviorSubject } from 'rxjs';
 import { ApiService } from '../apiAndObjects/api/api.service';
-import { InterventionsDictionaryItem } from '../apiAndObjects/objects/dictionaries/interventionDictionaryItem';
 import { Intervention } from '../apiAndObjects/objects/intervention';
 import { InterventionBaselineAssumptions } from '../apiAndObjects/objects/interventionBaselineAssumptions';
 import { InterventionCostSummary } from '../apiAndObjects/objects/interventionCostSummary';


### PR DESCRIPTION
- moved page navigation into a service
- updated intervention selection menu to better layout the buttons
- intervention count badge now updates to show currently available intervention count
- you can now delete an intervention from the list which updated the view and url query params

### To test
- adding a new intervention updates the list and the shopping basket counter
- removing an intervention updates the list and shopping basket counter
- refreshing the page will show the expected number of interventions