### PR TITLE
Force only two input decimals to be used in specific inputs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,7 +10,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: GoogleCloudPlatform/release-please-action@v3.1.4
+      - uses: GoogleCloudPlatform/release-please-action@v3.2.8
         with:
           release-type: node
           package-name: release-please-action

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,7 +31,10 @@
     "titleBar.activeBackground": "#9c90a4",
     "titleBar.activeForeground": "#15202b",
     "titleBar.inactiveBackground": "#9c90a499",
-    "titleBar.inactiveForeground": "#15202b99"
+    "titleBar.inactiveForeground": "#15202b99",
+    "statusBar.border": "#9c90a4",
+    "tab.activeBorder": "#b5acbb",
+    "titleBar.border": "#9c90a4"
   },
   "peacock.color": "#9c90a4"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,10 +31,7 @@
     "titleBar.activeBackground": "#9c90a4",
     "titleBar.activeForeground": "#15202b",
     "titleBar.inactiveBackground": "#9c90a499",
-    "titleBar.inactiveForeground": "#15202b99",
-    "statusBar.border": "#9c90a4",
-    "tab.activeBorder": "#b5acbb",
-    "titleBar.border": "#9c90a4"
+    "titleBar.inactiveForeground": "#15202b99"
   },
   "peacock.color": "#9c90a4"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,23 +15,23 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "workbench.colorCustomizations": {
-    "activityBar.activeBackground": "#b5acbb",
-    "activityBar.activeBorder": "#8f6930",
-    "activityBar.background": "#b5acbb",
+    "activityBar.activeBackground": "#b47ce8",
+    "activityBar.activeBorder": "#f1d0ae",
+    "activityBar.background": "#b47ce8",
     "activityBar.foreground": "#15202b",
     "activityBar.inactiveForeground": "#15202b99",
-    "activityBarBadge.background": "#8f6930",
-    "activityBarBadge.foreground": "#e7e7e7",
-    "sash.hoverBorder": "#b5acbb",
-    "statusBar.background": "#9c90a4",
-    "statusBar.foreground": "#15202b",
-    "statusBarItem.hoverBackground": "#83748d",
-    "statusBarItem.remoteBackground": "#9c90a4",
-    "statusBarItem.remoteForeground": "#15202b",
-    "titleBar.activeBackground": "#9c90a4",
-    "titleBar.activeForeground": "#15202b",
-    "titleBar.inactiveBackground": "#9c90a499",
-    "titleBar.inactiveForeground": "#15202b99"
+    "activityBarBadge.background": "#f1d0ae",
+    "activityBarBadge.foreground": "#15202b",
+    "sash.hoverBorder": "#b47ce8",
+    "statusBar.background": "#9b51e0",
+    "statusBar.foreground": "#e7e7e7",
+    "statusBarItem.hoverBackground": "#b47ce8",
+    "statusBarItem.remoteBackground": "#9b51e0",
+    "statusBarItem.remoteForeground": "#e7e7e7",
+    "titleBar.activeBackground": "#9b51e0",
+    "titleBar.activeForeground": "#e7e7e7",
+    "titleBar.inactiveBackground": "#9b51e099",
+    "titleBar.inactiveForeground": "#e7e7e799"
   },
-  "peacock.color": "#9c90a4"
+  "peacock.color": "#9b51e0"
 }

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -16,3 +16,9 @@
 // When a command from ./commands is ready to use, import with `import './commands'` syntax
 import './commands';
 import 'cypress-axe';
+
+Cypress.on('uncaught:exception', () => {
+  // returning false here prevents Cypress from
+  // failing the test
+  return false;
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "micronutrient-support-tool",
-  "version": "1.3.2",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3412,7 +3412,7 @@
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
     "@types/leaflet": {
@@ -4460,7 +4460,7 @@
     "array-ify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
-      "integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
+      "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
       "dev": true
     },
     "array-includes": {
@@ -4497,7 +4497,7 @@
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
       "dev": true
     },
     "asn1": {
@@ -4512,13 +4512,13 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
       "dev": true
     },
     "ast-types-flow": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
-      "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
+      "integrity": "sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==",
       "dev": true
     },
     "astral-regex": {
@@ -4535,7 +4535,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
     },
     "at-least-node": {
@@ -4567,7 +4567,7 @@
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
       "dev": true
     },
     "aws4": {
@@ -4720,13 +4720,13 @@
     "batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
-      "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
+      "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
       "dev": true
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
       "dev": true,
       "requires": {
         "tweetnacl": "^0.14.3"
@@ -4813,7 +4813,7 @@
     "bonjour": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
-      "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
+      "integrity": "sha512-RaVTblr+OnEli0r/ud8InrU7D+G0y6aJhlxaLa6Pwty4+xoxboF1BsUI45tujvRpbj9dQVoglChqonGAsjEBYg==",
       "dev": true,
       "requires": {
         "array-flatten": "^2.1.0",
@@ -4827,7 +4827,7 @@
     "boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "dev": true
     },
     "brace-expansion": {
@@ -4874,7 +4874,7 @@
     "buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
       "dev": true
     },
     "buffer-from": {
@@ -4907,13 +4907,13 @@
     "builtins": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
-      "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
+      "integrity": "sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ==",
       "dev": true
     },
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+      "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
       "dev": true
     },
     "cacache": {
@@ -5000,7 +5000,7 @@
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
       "dev": true
     },
     "chalk": {
@@ -5062,7 +5062,7 @@
     "chartjs-plugin-annotation": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/chartjs-plugin-annotation/-/chartjs-plugin-annotation-0.5.7.tgz",
-      "integrity": "sha1-G/DjAZmmqf+Yic4PN6HnVagNEL8=",
+      "integrity": "sha512-tKN5KLc69unyZGTvSdhVQEyAOhVNnSkFCCgefZhO4UaqFfABZGFU/d9p6WM2KB0eXFs/rR3Jayh7dvyASC7K0A==",
       "requires": {
         "chart.js": "^2.4.0"
       }
@@ -5070,7 +5070,7 @@
     "check-more-types": {
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
-      "integrity": "sha1-FCD/sQ/URNz8ebQ4kbv//TKoRgA=",
+      "integrity": "sha512-Pj779qHxV2tuapviy1bSZNEL1maXr13bPYpsvSDB68HlYcYuhlDrmGd63i0JHMCLKzc7rUSNIrpdJlhVlNwrxA==",
       "dev": true
     },
     "chokidar": {
@@ -5207,7 +5207,7 @@
     "clone": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
       "dev": true
     },
     "clone-deep": {
@@ -5258,7 +5258,7 @@
         "aria-query": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-3.0.0.tgz",
-          "integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
+          "integrity": "sha512-majUxHgLehQTeSA+hClx+DY09OVUqG3GtezWkF1krgLGNdlDu9l9V8DaqNMWbq4Eddc8wsyDA0hpDUtnYxQEXw==",
           "dev": true,
           "requires": {
             "ast-types-flow": "0.0.7",
@@ -5277,7 +5277,7 @@
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
           "dev": true
         },
         "sprintf-js": {
@@ -5311,7 +5311,7 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
         }
       }
     },
@@ -5373,7 +5373,7 @@
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "dev": true
     },
     "compare-func": {
@@ -5428,7 +5428,7 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
           "dev": true
         }
       }
@@ -5436,7 +5436,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
     "connect": {
@@ -5478,7 +5478,7 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
           "dev": true
         },
         "on-finished": {
@@ -5507,7 +5507,7 @@
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
       "dev": true
     },
     "content-disposition": {
@@ -5586,7 +5586,7 @@
     "cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "dev": true
     },
     "copy-anything": {
@@ -5684,7 +5684,7 @@
     "corser": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
-      "integrity": "sha1-jtolLsqrWEDc2XXOuQ2TcMgZ/4c=",
+      "integrity": "sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==",
       "dev": true
     },
     "cosmiconfig": {
@@ -5906,7 +5906,7 @@
     "cssauron": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/cssauron/-/cssauron-1.4.0.tgz",
-      "integrity": "sha1-pmAt/34EqDBtwNuaVR6S6LVmKtg=",
+      "integrity": "sha512-Ht70DcFBh+/ekjVrYS2PlDMdSQEl3OFNmjK6lcn49HptBgilXf/Zwg4uFh9Xn0pX3Q8YOkSjIFOfK2osvdqpBw==",
       "dev": true,
       "requires": {
         "through": "X.X.X"
@@ -5927,13 +5927,13 @@
     "cuint": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
-      "integrity": "sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs=",
+      "integrity": "sha512-d4ZVpCW31eWwCMe1YT3ur7mUDnTXbgwyzaL320DrcRT45rfjYxkt5QWLrmOJ+/UEAI2+fQgKe/fCjR8l4TpRgw==",
       "dev": true
     },
     "custom-event": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
-      "integrity": "sha1-XQKkaFCt8bSjF5RqOSj8y1v9BCU=",
+      "integrity": "sha512-GAj5FOq0Hd+RsCGVJxZuKaIDXDf3h6GQoNEjFgbLLI/trgtavwUbSnZ5pVfg27DVCaWjIohryS0JFwIJyT2cMg==",
       "dev": true
     },
     "cypress": {
@@ -6122,7 +6122,7 @@
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
       "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
@@ -6152,13 +6152,13 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
       "dev": true
     },
     "decamelize-keys": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
-      "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+      "integrity": "sha512-ocLWuYzRPoS9bfiSdDd3cxvrzovVMZnRDVEzAs+hWIVXGDbHxWMECij2OBuyB/An0FFW/nLuq6Kv1i/YC5Qfzg==",
       "dev": true,
       "requires": {
         "decamelize": "^1.1.0",
@@ -6168,7 +6168,7 @@
         "map-obj": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+          "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
           "dev": true
         }
       }
@@ -6176,7 +6176,7 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==",
       "dev": true
     },
     "deep-equal": {
@@ -6217,7 +6217,7 @@
     "defaults": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "integrity": "sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==",
       "dev": true,
       "requires": {
         "clone": "^1.0.2"
@@ -6286,13 +6286,13 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "dev": true
     },
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
       "dev": true
     },
     "depd": {
@@ -6327,7 +6327,7 @@
     "di": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz",
-      "integrity": "sha1-gGZJMmzqp8qjMG112YXqJ0i6kTw=",
+      "integrity": "sha512-uJaamHkagcZtHPqCIHZxnFrXlunQXgBOsZSUOWwFw31QJCAbyTBoHMW75YOTur5ZNx8pIeAKgf6GWIgaqqiLhA==",
       "dev": true
     },
     "diff": {
@@ -6348,7 +6348,7 @@
     "dns-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
-      "integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0=",
+      "integrity": "sha512-z+paD6YUQsk+AbGCEM4PrOXSss5gd66QfcVBFTKR/HpFL9jCqikS94HYwKww6fQyO7IxrIIyUu+g0Ka9tUS2Cg==",
       "dev": true
     },
     "dns-packet": {
@@ -6364,7 +6364,7 @@
     "dns-txt": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
-      "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
+      "integrity": "sha512-Ix5PrWjphuSoUXV/Zv5gaFHjnaJtb02F2+Si3Ht9dyJ87+Z/lMmy+dpNHtTGraNK958ndXq2i+GLkWsWHcKaBQ==",
       "dev": true,
       "requires": {
         "buffer-indexof": "^1.0.0"
@@ -6391,7 +6391,7 @@
     "dom-serialize": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/dom-serialize/-/dom-serialize-2.2.1.tgz",
-      "integrity": "sha1-ViromZ9Evl6jB29UGdzVnrQ6yVs=",
+      "integrity": "sha512-Yra4DbvoW7/Z6LBN560ZwXMjoNOSAN2wRsKFGc4iBeso+mpIA6qj1vfdf9HpMaKAqG6wXTy+1SYEzmNpKXOSsQ==",
       "dev": true,
       "requires": {
         "custom-event": "~1.0.0",
@@ -6414,7 +6414,7 @@
     "dom-to-image": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/dom-to-image/-/dom-to-image-2.6.0.tgz",
-      "integrity": "sha1-ilA2CAiMh7HCL5A0rgMuGJiVWGc="
+      "integrity": "sha512-Dt0QdaHmLpjURjU7Tnu3AgYSF2LuOmksSGsUcE6ItvJoCWTBEmiMXcqBdNSAm9+QbbwD7JMoVsuuKX6ZVQv1qA=="
     },
     "domelementtype": {
       "version": "2.3.0",
@@ -6480,7 +6480,7 @@
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
       "dev": true,
       "requires": {
         "jsbn": "~0.1.0",
@@ -6490,7 +6490,7 @@
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "dev": true
     },
     "ejs": {
@@ -6523,7 +6523,7 @@
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "dev": true
     },
     "encoding": {
@@ -6617,7 +6617,7 @@
     "ent": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
-      "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0=",
+      "integrity": "sha512-GHrMyVZQWvTIdDtpiEXdHZnFQKzeO09apj8Cbl4pKWy4i0Oprcq17usfDt5aO63swf0JOeMWjWQE/LzgSRuWpA==",
       "dev": true
     },
     "entities": {
@@ -6861,13 +6861,13 @@
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true
     },
     "eslint": {
@@ -7342,7 +7342,7 @@
     "etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "dev": true
     },
     "event-stream": {
@@ -7412,7 +7412,7 @@
         "pify": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
           "dev": true
         }
       }
@@ -7528,7 +7528,7 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
       "dev": true
     },
     "fast-deep-equal": {
@@ -7576,7 +7576,7 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
     "fastest-levenshtein": {
@@ -7611,7 +7611,7 @@
     "fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
       "dev": true,
       "requires": {
         "pend": "~1.2.0"
@@ -7761,7 +7761,7 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
       "dev": true
     },
     "form-data": {
@@ -7790,13 +7790,13 @@
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
       "dev": true
     },
     "from": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
+      "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g=="
     },
     "fs-constants": {
       "version": "1.0.0",
@@ -7834,7 +7834,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
     "fsevents": {
@@ -7865,7 +7865,7 @@
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
       "dev": true
     },
     "functions-have-names": {
@@ -7947,7 +7947,7 @@
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
       "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
@@ -7998,7 +7998,7 @@
     "global-dirs": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
-      "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+      "integrity": "sha512-NknMLn7F2J7aflwFOlGdNIuCDpN3VGoSoB+aap3KABFWbHVn1TCgFC+np23J8W2BiZbjfEw3BFBycSMv1AFblg==",
       "dev": true,
       "requires": {
         "ini": "^1.3.4"
@@ -8077,7 +8077,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true
     },
     "has-property-descriptors": {
@@ -8107,7 +8107,7 @@
     "has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
       "dev": true
     },
     "hdr-histogram-js": {
@@ -8145,7 +8145,7 @@
     "hpack.js": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
-      "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
+      "integrity": "sha512-zJxVehUdMGIKsRaNt7apO2Gqp0BdqW5yaiGHXXmbpvxgBYVZnAql+BJb4RO5ad2MgpbZKn5G6nMnegrH1FcNYQ==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
@@ -8258,7 +8258,7 @@
     "http-deceiver": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
-      "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc=",
+      "integrity": "sha512-LmpOGxTfbpgtGVxJrj5k7asXHCgNZp5nLfp+hWc8QQRqtb7fUy6kRY3BO1h9ddF6yIPYUARgxGOwB42DnxIaNw==",
       "dev": true
     },
     "http-errors": {
@@ -8419,7 +8419,7 @@
     "humanize-ms": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
       "dev": true,
       "requires": {
         "ms": "^2.0.0"
@@ -8470,7 +8470,7 @@
     "image-size": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
-      "integrity": "sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=",
+      "integrity": "sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ==",
       "dev": true,
       "optional": true
     },
@@ -8501,7 +8501,7 @@
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true
     },
     "indent-string": {
@@ -8519,7 +8519,7 @@
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "dev": true,
       "requires": {
         "once": "^1.3.0",
@@ -8659,7 +8659,7 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true
     },
     "is-bigint": {
@@ -8741,7 +8741,7 @@
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true
     },
     "is-fullwidth-code-point": {
@@ -8789,13 +8789,13 @@
     "is-lambda": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
-      "integrity": "sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU=",
+      "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
       "dev": true
     },
     "is-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
-      "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
+      "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
       "dev": true
     },
     "is-negative-zero": {
@@ -8897,7 +8897,7 @@
     "is-text-path": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
-      "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
+      "integrity": "sha512-xFuJpne9oFz5qDaodwmmG08e3CawH/2ZV8Qqza1Ko7Sk8POWbkRdwIoAWVhqvq0XeUzANEhKo2n0IXUGBm7A/w==",
       "dev": true,
       "requires": {
         "text-extensions": "^1.0.0"
@@ -8906,7 +8906,7 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
       "dev": true
     },
     "is-unicode-supported": {
@@ -8942,7 +8942,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true
     },
     "isbinaryfile": {
@@ -8954,19 +8954,19 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true
     },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
       "dev": true
     },
     "istanbul-lib-coverage": {
@@ -9210,7 +9210,7 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
       "dev": true
     },
     "jsdoc-type-pratt-parser": {
@@ -9252,13 +9252,13 @@
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "dev": true
     },
     "json5": {
@@ -9286,7 +9286,7 @@
     "jsonparse": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
+      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
       "dev": true
     },
     "jsprim": {
@@ -9458,7 +9458,7 @@
     "lazy-ass": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
-      "integrity": "sha1-eZllXoZGwX8In90YfRUNMyTVRRM=",
+      "integrity": "sha512-cc8oEVoctTvsFZ/Oje/kGnHbpWHYBe8IAJe4C0QNc3t8uM/0Y8+erSz/7Y1ALuXTEZTMvxXwO6YbX1ey3ujiZw==",
       "dev": true
     },
     "leaflet": {
@@ -9602,7 +9602,7 @@
     "lodash.assign": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+      "integrity": "sha512-hFuH8TY+Yji7Eja3mGiuAxBqLagejScbG8GbG0j6o9vzn0YL14My+ktnqtZgFTosKymC9/44wP6s7xyuLfnClw=="
     },
     "lodash.debounce": {
       "version": "4.0.8",
@@ -9619,7 +9619,7 @@
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "dev": true
     },
     "log-symbols": {
@@ -9827,12 +9827,12 @@
     "map-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
-      "integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg="
+      "integrity": "sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ=="
     },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
       "dev": true
     },
     "memfs": {
@@ -9916,7 +9916,7 @@
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
       "dev": true
     },
     "merge-options": {
@@ -9942,7 +9942,7 @@
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
       "dev": true
     },
     "micromatch": {
@@ -9991,7 +9991,7 @@
     "mingo": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/mingo/-/mingo-1.3.3.tgz",
-      "integrity": "sha1-aSLE0Ufvx3GgFCWixMj3eER4xUY="
+      "integrity": "sha512-Y4wGTD/M7AMqF8QxKaBGps+axq/Z48hdtRAeiKtInkEXMLzUWUwT0OPDzrB26xrav9GF1AOYJfwVWPcLwnkgTA=="
     },
     "mini-css-extract-plugin": {
       "version": "2.5.3",
@@ -10156,7 +10156,7 @@
     "moment-es6": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/moment-es6/-/moment-es6-1.0.0.tgz",
-      "integrity": "sha1-VS/PQF1iVlsKH+hObB5peseTMt8=",
+      "integrity": "sha512-DeFuL4VMEGDSRyuhwPEFrIy0BxlRGk3yaEkJYnHKY50dLg+u5llQwK5Bjk/Rm5iSf8BuatnI0nODjHXhLzcKBw==",
       "requires": {
         "moment": "*"
       }
@@ -10186,7 +10186,7 @@
     "multicast-dns-service-types": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
-      "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
+      "integrity": "sha512-cnAsSVxIDsYt0v7HmC0hWZFwwXSh+E6PgCrREDuN/EsjgLwA5XRmlMHhSiDPrt6HxY1gTivEa/Zh7GtODoLevQ==",
       "dev": true
     },
     "mute-stream": {
@@ -10204,7 +10204,7 @@
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
     "needle": {
@@ -10572,7 +10572,7 @@
     "normalize-range": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-      "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
+      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
       "dev": true
     },
     "npm-bundled": {
@@ -10850,7 +10850,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "dev": true
     },
     "object-inspect": {
@@ -10922,7 +10922,7 @@
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "requires": {
         "wrappy": "1"
@@ -11033,13 +11033,13 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
       "dev": true
     },
     "ospath": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/ospath/-/ospath-1.2.2.tgz",
-      "integrity": "sha1-EnZjl3Sj+O8lcvf+QoDg6kVQwHs=",
+      "integrity": "sha512-o6E5qJV5zkAbIDNhGSIlyOhScKXgQrSRMilfph0clDfM0nEnBOlKlH4sWDmG95BW/CvwNz0vmm7dJVtU2KlMiA==",
       "dev": true
     },
     "p-limit": {
@@ -11243,7 +11243,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true
     },
     "path-key": {
@@ -11261,7 +11261,7 @@
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
       "dev": true
     },
     "path-type": {
@@ -11273,7 +11273,7 @@
     "pause-stream": {
       "version": "0.0.11",
       "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+      "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
       "requires": {
         "through": "~2.3"
       }
@@ -11281,13 +11281,13 @@
     "pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "dev": true
     },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
       "dev": true
     },
     "picocolors": {
@@ -11773,7 +11773,7 @@
     "promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-      "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
+      "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
       "dev": true
     },
     "promise-retry": {
@@ -11815,13 +11815,13 @@
     "proxy-from-env": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
-      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
+      "integrity": "sha512-F2JHgJQ1iqwnHDcQjVBsq3n/uoaFL+iPW/eAeL7kVxy/2RrWaN4WroKjjvbsoRtv0ftelNyC01bjRhn/bhcf4A==",
       "dev": true
     },
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
+      "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
       "dev": true
     },
     "psl": {
@@ -11849,7 +11849,7 @@
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
       "dev": true
     },
     "qjobs": {
@@ -11925,7 +11925,7 @@
     "read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
-      "integrity": "sha1-5mTvMRYRZsl1HNvo28+GtftY93Q=",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
       "dev": true,
       "requires": {
         "pify": "^2.3.0"
@@ -11934,7 +11934,7 @@
         "pify": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
           "dev": true
         }
       }
@@ -12141,7 +12141,7 @@
     "relateurl": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
-      "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
+      "integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==",
       "dev": true
     },
     "renderkid": {
@@ -12160,7 +12160,7 @@
     "request-progress": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
-      "integrity": "sha1-TKdUCBx/7GP1BeT6qCWqBs1mnb4=",
+      "integrity": "sha512-MnWzEHHaxHO2iWiQuHrUPBi/1WeBf5PkxQqNyNvLl9VAYSdXkP8tQ3pBSeCPD+yw0v0Aq1zosWLz0BdeXpWwZg==",
       "dev": true,
       "requires": {
         "throttleit": "^1.0.0"
@@ -12169,7 +12169,7 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true
     },
     "require-from-string": {
@@ -12181,7 +12181,7 @@
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true
     },
     "resolve": {
@@ -12418,13 +12418,13 @@
     "secure-compare": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
-      "integrity": "sha1-8aAymzCLIh+uN7mXTz1XjQypmeM=",
+      "integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==",
       "dev": true
     },
     "select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
-      "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=",
+      "integrity": "sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==",
       "dev": true
     },
     "selfsigned": {
@@ -12448,7 +12448,7 @@
     "semver-dsl": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/semver-dsl/-/semver-dsl-1.0.1.tgz",
-      "integrity": "sha1-02eN5VVeimH2Ke7QJTZq5fJzQKA=",
+      "integrity": "sha512-e8BOaTo007E3dMuQQTnPdalbKTABKNS7UxoBIDnwOqRa+QwMrCPjynB8zAlPF6xlqUfdLPPLIJ13hJNmhtq8Ng==",
       "dev": true,
       "requires": {
         "semver": "^5.3.0"
@@ -12520,7 +12520,7 @@
     "serve-index": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
-      "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
+      "integrity": "sha512-pXHfKNP4qujrtteMrSBb0rc8HJ9Ms/GrXwcUtUtD5s4ewDJI8bT3Cz2zTVRMKtri49pLx2e0Ya8ziP5Ya2pZZw==",
       "dev": true,
       "requires": {
         "accepts": "~1.3.4",
@@ -12550,7 +12550,7 @@
         "http-errors": {
           "version": "1.6.3",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-          "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+          "integrity": "sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==",
           "dev": true,
           "requires": {
             "depd": "~1.1.2",
@@ -12562,13 +12562,13 @@
         "inherits": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
           "dev": true
         },
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
           "dev": true
         },
         "setprototypeof": {
@@ -12600,7 +12600,7 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "dev": true
     },
     "setprototypeof": {
@@ -12914,7 +12914,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
     "sshpk": {
@@ -12952,7 +12952,7 @@
     "stream-combiner": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
-      "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
+      "integrity": "sha512-6yHMqgLYDzQDcAkL+tjJDC5nSNuNIx0vZtRZeiPh7Saef7VHX9H5Ijn9l2VIol2zaNYlYEX6KyuT/237A58qEQ==",
       "requires": {
         "duplexer": "~0.1.1",
         "through": "~2.3.4"
@@ -13044,7 +13044,7 @@
     "strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "dev": true
     },
     "strip-final-newline": {
@@ -13223,19 +13223,19 @@
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
     "throttleit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
-      "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
+      "integrity": "sha512-rkTVqu6IjfQ/6+uNuuc3sZek4CEYxTJom3IktzgdSxcZqdARuebbA/f4QmAxMQIxqq9ZLEUkSYqvuk1I6VKq4g==",
       "dev": true
     },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
     },
     "through2": {
       "version": "4.0.2",
@@ -13269,7 +13269,7 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
       "dev": true
     },
     "to-regex-range": {
@@ -13480,7 +13480,7 @@
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
       "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
@@ -13489,7 +13489,7 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
       "dev": true
     },
     "type-check": {
@@ -13621,7 +13621,7 @@
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "dev": true
     },
     "untildify": {
@@ -13667,19 +13667,19 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
     },
     "utila": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
-      "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=",
+      "integrity": "sha512-Z0DbgELS9/L/75wZbro8xAnT50pBVFQZ+hUEueGDU5FN51YSCYM+jdxsfCiHjwNP/4LCDD0i/graKpeBnOXKRA==",
       "dev": true
     },
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "dev": true
     },
     "uuid": {
@@ -13712,7 +13712,7 @@
     "validate-npm-package-name": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
-      "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
+      "integrity": "sha512-M6w37eVCMMouJ9V/sdPGnC5H4uDr73/+xdq0FBLO3TFFX1+7wiUY6Es328NN+y43tmY+doUdN9g9J21vqB7iLw==",
       "dev": true,
       "requires": {
         "builtins": "^1.0.3"
@@ -13721,13 +13721,13 @@
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "dev": true
     },
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
       "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
@@ -13746,7 +13746,7 @@
     "void-elements": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
-      "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=",
+      "integrity": "sha512-qZKX4RnBzH2ugr8Lxa7x+0V6XD9Sb/ouARtiasEQCHB1EVU4NXtmHsDDrx1dO4ne5fc3J6EW05BP1Dl0z0iung==",
       "dev": true
     },
     "watchpack": {
@@ -13771,7 +13771,7 @@
     "wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
       "dev": true,
       "requires": {
         "defaults": "^1.0.3"
@@ -14164,7 +14164,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
     "ws": {
@@ -14232,7 +14232,7 @@
     "yauzl": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
       "dev": true,
       "requires": {
         "buffer-crc32": "~0.2.3",

--- a/src/app/components/dialogs/baselineDescriptionDialog/baselineDescriptionDialog.component.html
+++ b/src/app/components/dialogs/baselineDescriptionDialog/baselineDescriptionDialog.component.html
@@ -9,11 +9,11 @@
     <mat-card-title><strong>Consumption Data:</strong> {{ dataSource.consumptionDataName }}</mat-card-title>
     <mat-card-subtitle>{{ dataSource.consumptionDataDesc }}</mat-card-subtitle>
     <mat-card-actions align="end">
-      <a mat-raised-button disabled="!dataSoure.consumptionDataMetaId"
+      <a mat-stroked-button disabled="!dataSoure.consumptionDataMetaId"
         href="https://metadata.micronutrient.support/geonetwork/srv/eng/catalog.search#/metadata/{{ dataSource.consumptionDataMetaId }}"
         target="_blank">
         View Metadata Record</a>
-      <button disabled mat-raised-button>Download Dataset</button>
+      <button disabled mat-stroked-button>Download Dataset</button>
     </mat-card-actions>
   </mat-card>
 
@@ -21,11 +21,11 @@
     <mat-card-title><strong>Composition Data:</strong> {{ dataSource.compositionDataName }}</mat-card-title>
     <mat-card-subtitle>{{ dataSource.compositionDataDesc }}</mat-card-subtitle>
     <mat-card-actions align="end">
-      <a mat-raised-button disabled="!dataSoure.compositionDataMetaId"
+      <a mat-stroked-button disabled="!dataSoure.compositionDataMetaId"
         href="https://metadata.micronutrient.support/geonetwork/srv/eng/catalog.search#/metadata/{{ dataSource.compositionDataMetaId }}"
         target="_blank">
         View Metadata Record</a>
-      <button disabled mat-raised-button>Download Dataset</button>
+      <button disabled mat-stroked-button>Download Dataset</button>
     </mat-card-actions>
   </mat-card>
 

--- a/src/app/components/dialogs/ceResetDialog/ceResetDialog.component.html
+++ b/src/app/components/dialogs/ceResetDialog/ceResetDialog.component.html
@@ -1,14 +1,14 @@
 <div class="DeletionDialog">
-    <h2>Reset All</h2>
-    <p>Are you sure you want to reset all values in this step?</p>
+  <h2>Reset All</h2>
+  <p>Are you sure you want to reset all values in this step?</p>
 
 
 
 
-    <div class="button-group" mat-dialog-actions>
-        <button mat-raised-button type=" button" class="btn btn-primary" (click)="closeDialog()">Cancel</button>
+  <div class="button-group" mat-dialog-actions>
+    <button mat-stroked-button type=" button" class="btn btn-primary" (click)="closeDialog()">Cancel</button>
 
-        <button mat-raised-button color="warn" (click)="resetAll()">Yes, reset all</button>
+    <button mat-stroked-button color="warn" (click)="resetAll()">Yes, reset all</button>
 
-    </div>
+  </div>
 </div>

--- a/src/app/components/dialogs/costEffectivenessSelectionDialog/costEffectivenessSelectionDialog.component.html
+++ b/src/app/components/dialogs/costEffectivenessSelectionDialog/costEffectivenessSelectionDialog.component.html
@@ -57,7 +57,7 @@
     <button mat-stroked-button type="button" (click)="closeDialog()">
       Cancel
     </button>
-    <button form="form" mat-raised-button color="primary" (click)="createIntervention()" class="btn-proceed"
+    <button form="form" mat-stroked-button color="primary" (click)="createIntervention()" class="btn-proceed"
       [disabled]="(proceed.asObservable() | async) === false">
       {{ tabID === 'copy' ? 'Copy & edit' : 'Load' }}
     </button>

--- a/src/app/components/dialogs/dialog.module.ts
+++ b/src/app/components/dialogs/dialog.module.ts
@@ -25,6 +25,7 @@ import { IframeDialogComponent } from './iFrameDialog/dialogIframe.component';
 import { WelcomeDialogComponent } from './welcomeDialog/dialogWelcome.component';
 import { SectionSummaryRecurringCostReviewDialogComponent } from './sectionSummaryRecurringCostReviewDialog/sectionSummaryRecurringCostReviewDialog.component';
 import { PipesModule } from 'src/app/pipes/pipes.module';
+import { DirectivesModule } from 'src/app/directives/directives.module';
 @NgModule({
   declarations: [
     BaseDialogComponent,
@@ -55,6 +56,7 @@ import { PipesModule } from 'src/app/pipes/pipes.module';
     FormsModule,
     ReactiveFormsModule,
     PipesModule,
+    DirectivesModule,
   ],
   exports: [BaseDialogComponent],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],

--- a/src/app/components/dialogs/mapSettingsDialog/mapSettingsDialog.component.html
+++ b/src/app/components/dialogs/mapSettingsDialog/mapSettingsDialog.component.html
@@ -61,10 +61,10 @@
       </div>
 
       <div *ngIf="optionList.selectedOptions.selected[0]?.value === 'general'" class="button-wrapper">
-        <button mat-raised-button [disabled]="selectionList?.selectedOptions.selected[0] == null"
+        <button mat-stroked-button [disabled]="selectionList?.selectedOptions.selected[0] == null"
           (click)="applyChanges()">Apply
           Changes</button>
-        <button mat-raised-button (click)="cancel()">Cancel</button>
+        <button mat-stroked-button (click)="cancel()">Cancel</button>
       </div>
     </div>
   </mat-drawer-container>

--- a/src/app/components/dialogs/mnAdditionDialog/mnAdditionDialog.component.html
+++ b/src/app/components/dialogs/mnAdditionDialog/mnAdditionDialog.component.html
@@ -1,19 +1,19 @@
 <div class="MnAdditionDialog">
-    <h2>Add micronutrient</h2>
-    <p>Select what micronutrient you want to add</p>
-    <mat-form-field appearance="fill">
-        <mat-select>
-            <mat-option (onSelectionChange)="mnSelectionChange($event)" *ngFor="let mnd of mNsFiltered" [value]="mnd">{{
-                mnd.name }}</mat-option>
-        </mat-select>
-        <!-- <mat-error>Please select MND ({{groupMND.value}})</mat-error> -->
-    </mat-form-field>
+  <h2>Add micronutrient</h2>
+  <p>Select what micronutrient you want to add</p>
+  <mat-form-field appearance="fill">
+    <mat-select>
+      <mat-option (onSelectionChange)="mnSelectionChange($event)" *ngFor="let mnd of mNsFiltered" [value]="mnd">{{
+        mnd.name }}</mat-option>
+    </mat-select>
+    <!-- <mat-error>Please select MND ({{groupMND.value}})</mat-error> -->
+  </mat-form-field>
 
 
 
 
-    <div class="button-group" mat-dialog-actions>
-        <button mat-raised-button type=" button" class="btn btn-primary" (click)="closeDialog()">Cancel</button>
-        <button mat-raised-button class="primary-button" (click)="addMN()">Add micronutrient</button>
-    </div>
+  <div class="button-group" mat-dialog-actions>
+    <button mat-stroked-button type=" button" class="btn btn-primary" (click)="closeDialog()">Cancel</button>
+    <button mat-stroked-button class="primary-button" (click)="addMN()">Add micronutrient</button>
+  </div>
 </div>

--- a/src/app/components/dialogs/scenarioChangeWarning/scenarioChangeWarning.component.html
+++ b/src/app/components/dialogs/scenarioChangeWarning/scenarioChangeWarning.component.html
@@ -1,9 +1,9 @@
 <app-base-dialog [data]="data" [title]="'Are you sure you want to change scenario?'">
-    <div class="wrapper">
-        <p>The current scenario will be lost.</p>
-        <span class="button-wrapper">
-            <button mat-raised-button (click)="closeDialog()">Cancel</button>
-            <button mat-raised-button color="warn" (click)="allowChange()">OK</button>
-        </span>
-    </div>
+  <div class="wrapper">
+    <p>The current scenario will be lost.</p>
+    <span class="button-wrapper">
+      <button mat-stroked-button (click)="closeDialog()">Cancel</button>
+      <button mat-stroked-button color="warn" (click)="allowChange()">OK</button>
+    </span>
+  </div>
 </app-base-dialog>

--- a/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.html
+++ b/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.html
@@ -9,54 +9,180 @@
         <td mat-cell *matCellDef="let element"> {{element.name}} </td>
         <td mat-footer-cell *matFooterCellDef>Total</td>
       </ng-container>
-      <ng-container matColumnDef="year0">
+      <!-- <ng-container matColumnDef="year0">
         <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2021</th>
         <td mat-cell *matCellDef="let element">{{element.year0 | currencyExtended}}</td>
         <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year0') | currencyExtended}} </td>
+      </ng-container> -->
+      <ng-container matColumnDef="year0">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2021</th>
+        <td class="column-title" mat-cell *matCellDef="let element">
+          <div *ngIf="element.rowUnits === 'number'">
+            <input type="number" matInput required [value]=element.year0.toFixed(2)>
+          </div>
+          <div *ngIf="element.rowUnits === 'US dollars'">
+            <span>$</span><input type="number" appDecimalInput required [value]=element.year0.toFixed(2)>
+          </div>
+          <div *ngIf="element.rowUnits === 'percent'">
+            <input type="number" [value]="element.year0 * 100"
+              (input)="element.year0 = $any($event.target).value / 100">
+          </div>
+        </td>
+        <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year0') | currencyExtended}} </td>
       </ng-container>
+      <!-- year1 -->
       <ng-container matColumnDef="year1">
         <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2022</th>
-        <td mat-cell *matCellDef="let element">{{element.year1 | currencyExtended}}</td>
+        <td class="column-title" mat-cell *matCellDef="let element">
+          <div *ngIf="element.rowUnits === 'number'">
+            <input type="number" matInput required [value]=element.year1.toFixed(2)>
+          </div>
+          <div *ngIf="element.rowUnits === 'US dollars'">
+            <span>$</span><input type="number" matInput required [value]=element.year1.toFixed(2)>
+          </div>
+          <div *ngIf="element.rowUnits === 'percent'">
+            <input type="number" [value]="element.year1 * 100"
+              (input)="element.year1 = $any($event.target).value / 100">
+          </div>
+        </td>
         <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year1') | currencyExtended}} </td>
       </ng-container>
+      <!-- year2 -->
       <ng-container matColumnDef="year2">
         <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2023</th>
-        <td mat-cell *matCellDef="let element">{{element.year2 | currencyExtended}}</td>
+        <td class="column-title" mat-cell *matCellDef="let element">
+          <div *ngIf="element.rowUnits === 'number'">
+            <input type="number" matInput required [value]=element.year2.toFixed(2)>
+          </div>
+          <div *ngIf="element.rowUnits === 'US dollars'">
+            <span>$</span><input type="number" matInput required [value]=element.year2.toFixed(2)>
+          </div>
+          <div *ngIf="element.rowUnits === 'percent'">
+            <input type="number" [value]="element.year2 * 100"
+              (input)="element.year2 = $any($event.target).value / 100">
+          </div>
+        </td>
         <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year2') | currencyExtended}} </td>
       </ng-container>
+      <!-- year3 -->
       <ng-container matColumnDef="year3">
         <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2024</th>
-        <td mat-cell *matCellDef="let element">{{element.year3 | currencyExtended}}</td>
+        <td class="column-title" mat-cell *matCellDef="let element">
+          <div *ngIf="element.rowUnits === 'number'">
+            <input type="number" matInput required [value]=element.year3.toFixed(2)>
+          </div>
+          <div *ngIf="element.rowUnits === 'US dollars'">
+            <span>$</span><input type="number" matInput required [value]=element.year3.toFixed(2)>
+          </div>
+          <div *ngIf="element.rowUnits === 'percent'">
+            <input type="number" [value]="element.year3 * 100"
+              (input)="element.year3 = $any($event.target).value / 100">
+          </div>
+        </td>
         <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year3') | currencyExtended}} </td>
       </ng-container>
+      <!-- year4 -->
       <ng-container matColumnDef="year4">
         <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2025</th>
-        <td mat-cell *matCellDef="let element">{{element.year4 | currencyExtended}}</td>
+        <td class="column-title" mat-cell *matCellDef="let element">
+          <div *ngIf="element.rowUnits === 'number'">
+            <input type="number" matInput required [value]=element.year4.toFixed(2)>
+          </div>
+          <div *ngIf="element.rowUnits === 'US dollars'">
+            <span>$</span><input type="number" matInput required [value]=element.year4.toFixed(2)>
+          </div>
+          <div *ngIf="element.rowUnits === 'percent'">
+            <input type="number" [value]="element.year4 * 100"
+              (input)="element.year4 = $any($event.target).value / 100">
+          </div>
+        </td>
         <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year4') | currencyExtended}} </td>
       </ng-container>
+      <!-- year5 -->
       <ng-container matColumnDef="year5">
         <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2026</th>
-        <td mat-cell *matCellDef="let element">{{element.year5 | currencyExtended}}</td>
+        <td class="column-title" mat-cell *matCellDef="let element">
+          <div *ngIf="element.rowUnits === 'number'">
+            <input type="number" matInput required [value]=element.year5.toFixed(2)>
+          </div>
+          <div *ngIf="element.rowUnits === 'US dollars'">
+            <span>$</span><input type="number" matInput required [value]=element.year5.toFixed(2)>
+          </div>
+          <div *ngIf="element.rowUnits === 'percent'">
+            <input type="number" [value]="element.year4 * 100"
+              (input)="element.year5 = $any($event.target).value / 100">
+          </div>
+        </td>
         <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year5') | currencyExtended}} </td>
       </ng-container>
+      <!-- year6 -->
       <ng-container matColumnDef="year6">
         <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2027</th>
-        <td mat-cell *matCellDef="let element">{{element.year6 | currencyExtended}}</td>
+        <td class="column-title" mat-cell *matCellDef="let element">
+          <div *ngIf="element.rowUnits === 'number'">
+            <input type="number" matInput required [value]=element.year6.toFixed(2)>
+          </div>
+          <div *ngIf="element.rowUnits === 'US dollars'">
+            <span>$</span><input type="number" matInput required [value]=element.year6.toFixed(2)>
+          </div>
+          <div *ngIf="element.rowUnits === 'percent'">
+            <input type="number" [value]="element.year6 * 100"
+              (input)="element.year6 = $any($event.target).value / 100">
+          </div>
+        </td>
         <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year6') | currencyExtended}} </td>
       </ng-container>
+      <!-- year7 -->
       <ng-container matColumnDef="year7">
         <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2028</th>
-        <td mat-cell *matCellDef="let element">{{element.year7 | currencyExtended}}</td>
+        <td class="column-title" mat-cell *matCellDef="let element">
+          <div *ngIf="element.rowUnits === 'number'">
+            <input type="number" matInput required [value]=element.year7.toFixed(2)>
+          </div>
+          <div *ngIf="element.rowUnits === 'US dollars'">
+            <span>$</span>
+            <!-- <input type="number" matInput required [value]=element.year7> -->
+            <input appDecimalInput [(ngModel)]="element.year7">
+          </div>
+          <div *ngIf="element.rowUnits === 'percent'">
+            <input type="number" [value]="element.year4 * 100"
+              (input)="element.year7 = $any($event.target).value / 100">
+          </div>
+        </td>
         <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year7') | currencyExtended}} </td>
       </ng-container>
+      <!-- year8 -->
       <ng-container matColumnDef="year8">
         <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2029</th>
-        <td mat-cell *matCellDef="let element">{{element.year8 | currencyExtended}}</td>
+        <td class="column-title" mat-cell *matCellDef="let element">
+          <div *ngIf="element.rowUnits === 'number'">
+            <input type="number" matInput required [value]=element.year8.toFixed(2)>
+          </div>
+          <div *ngIf="element.rowUnits === 'US dollars'">
+            <span>$</span><input type="number" matInput required [value]=element.year8.toFixed(2)>
+          </div>
+          <div *ngIf="element.rowUnits === 'percent'">
+            <input type="number" [value]="element.year4 * 100"
+              (input)="element.year8 = $any($event.target).value / 100">
+          </div>
+        </td>
         <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year8') | currencyExtended}} </td>
       </ng-container>
+      <!-- year9 -->
       <ng-container matColumnDef="year9">
         <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2030</th>
-        <td mat-cell *matCellDef="let element">{{element.year9 | currencyExtended}}</td>
+        <td class="column-title" mat-cell *matCellDef="let element">
+          <div *ngIf="element.rowUnits === 'number'">
+            <input type="number" matInput required [value]=element.year9.toFixed(2)>
+          </div>
+          <div *ngIf="element.rowUnits === 'US dollars'">
+            <span>$</span><input type="number" matInput required [value]=element.year9.toFixed(2)>
+          </div>
+          <div *ngIf="element.rowUnits === 'percent'">
+            <input type="number" [value]="element.year4 * 100"
+              (input)="element.year9 = $any($event.target).value / 100">
+          </div>
+        </td>
         <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year9') | currencyExtended}} </td>
       </ng-container>
       <tr mat-header-row *matHeaderRowDef="displayHeaders;"></tr>

--- a/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.html
+++ b/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.html
@@ -185,9 +185,8 @@
       <tr mat-footer-row *matFooterRowDef="displayHeaders"></tr>
     </table>
     <div class="button-container">
-      <button mat-raised-button (click)="dialogData.close()">Back</button>
-      <button mat-raised-button color="primary">Confirm current values and return to recurring cost
-        summary</button>
+      <button mat-stroked-button (click)="dialogData.close()">Back</button>
+      <button class="confirm" mat-stroked-button color="primary" (click)="dialogData.close()">Confirm</button>
     </div>
   </div>
 </app-base-dialog>

--- a/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.html
+++ b/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.html
@@ -7,188 +7,182 @@
       <ng-container matColumnDef="name">
         <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">Years of start-up or scale-up</th>
         <td mat-cell *matCellDef="let element"> {{element.name}} </td>
-        <td mat-footer-cell *matFooterCellDef>Total</td>
+        <!-- <td mat-footer-cell *matFooterCellDef>Total</td> -->
       </ng-container>
-      <!-- <ng-container matColumnDef="year0">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2021</th>
-        <td mat-cell *matCellDef="let element">{{element.year0 | currencyExtended}}</td>
-        <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year0') | currencyExtended}} </td>
-      </ng-container> -->
       <ng-container matColumnDef="year0">
         <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2021</th>
         <td class="column-title" mat-cell *matCellDef="let element">
           <div *ngIf="element.rowUnits === 'number'">
-            <input type="number" matInput required [value]=element.year0.toFixed(2)>
+            <input type="text" appDecimalInput required [value]=element.year0.toFixed(2)>
           </div>
           <div *ngIf="element.rowUnits === 'US dollars'">
-            <span>$</span><input type="number" appDecimalInput required [value]=element.year0.toFixed(2)>
+            <span>$</span><input type="text" appDecimalInput required [value]=element.year0.toFixed(2)>
           </div>
           <div *ngIf="element.rowUnits === 'percent'">
-            <input type="number" [value]="element.year0 * 100"
-              (input)="element.year0 = $any($event.target).value / 100">
+            <input type="text" [value]="element.year0 * 100" (input)="element.year0 = $any($event.target).value / 100"
+              appDecimalInput>
           </div>
         </td>
-        <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year0') | currencyExtended}} </td>
+        <!-- <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year0') | currencyExtended}} </td> -->
       </ng-container>
       <!-- year1 -->
       <ng-container matColumnDef="year1">
         <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2022</th>
         <td class="column-title" mat-cell *matCellDef="let element">
           <div *ngIf="element.rowUnits === 'number'">
-            <input type="number" matInput required [value]=element.year1.toFixed(2)>
+            <input type="text" appDecimalInput required [value]=element.year1.toFixed(2)>
           </div>
           <div *ngIf="element.rowUnits === 'US dollars'">
-            <span>$</span><input type="number" matInput required [value]=element.year1.toFixed(2)>
+            <span>$</span><input type="text" appDecimalInput required [value]=element.year1.toFixed(2)>
           </div>
           <div *ngIf="element.rowUnits === 'percent'">
-            <input type="number" [value]="element.year1 * 100"
-              (input)="element.year1 = $any($event.target).value / 100">
+            <input type="text" [value]="element.year1 * 100" (input)="element.year1 = $any($event.target).value / 100"
+              appDecimalInput>
           </div>
         </td>
-        <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year1') | currencyExtended}} </td>
+        <!-- <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year1') | currencyExtended}} </td> -->
       </ng-container>
       <!-- year2 -->
       <ng-container matColumnDef="year2">
         <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2023</th>
         <td class="column-title" mat-cell *matCellDef="let element">
           <div *ngIf="element.rowUnits === 'number'">
-            <input type="number" matInput required [value]=element.year2.toFixed(2)>
+            <input type="text" appDecimalInput required [value]=element.year2.toFixed(2)>
           </div>
           <div *ngIf="element.rowUnits === 'US dollars'">
-            <span>$</span><input type="number" matInput required [value]=element.year2.toFixed(2)>
+            <span>$</span><input type="text" appDecimalInput required [value]=element.year2.toFixed(2)>
           </div>
           <div *ngIf="element.rowUnits === 'percent'">
-            <input type="number" [value]="element.year2 * 100"
-              (input)="element.year2 = $any($event.target).value / 100">
+            <input type="text" [value]="element.year2 * 100" (input)="element.year2 = $any($event.target).value / 100"
+              appDecimalInput>
           </div>
         </td>
-        <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year2') | currencyExtended}} </td>
+        <!-- <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year2') | currencyExtended}} </td> -->
       </ng-container>
       <!-- year3 -->
       <ng-container matColumnDef="year3">
         <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2024</th>
         <td class="column-title" mat-cell *matCellDef="let element">
           <div *ngIf="element.rowUnits === 'number'">
-            <input type="number" matInput required [value]=element.year3.toFixed(2)>
+            <input type="text" appDecimalInput required [value]=element.year3.toFixed(2)>
           </div>
           <div *ngIf="element.rowUnits === 'US dollars'">
-            <span>$</span><input type="number" matInput required [value]=element.year3.toFixed(2)>
+            <span>$</span><input type="text" appDecimalInput required [value]=element.year3.toFixed(2)>
           </div>
           <div *ngIf="element.rowUnits === 'percent'">
-            <input type="number" [value]="element.year3 * 100"
-              (input)="element.year3 = $any($event.target).value / 100">
+            <input type="text" [value]="element.year3 * 100" (input)="element.year3 = $any($event.target).value / 100"
+              appDecimalInput>
           </div>
         </td>
-        <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year3') | currencyExtended}} </td>
+        <!-- <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year3') | currencyExtended}} </td> -->
       </ng-container>
       <!-- year4 -->
       <ng-container matColumnDef="year4">
         <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2025</th>
         <td class="column-title" mat-cell *matCellDef="let element">
           <div *ngIf="element.rowUnits === 'number'">
-            <input type="number" matInput required [value]=element.year4.toFixed(2)>
+            <input type="text" appDecimalInput required [value]=element.year4.toFixed(2)>
           </div>
           <div *ngIf="element.rowUnits === 'US dollars'">
-            <span>$</span><input type="number" matInput required [value]=element.year4.toFixed(2)>
+            <span>$</span><input type="text" appDecimalInput required [value]=element.year4.toFixed(2)>
           </div>
           <div *ngIf="element.rowUnits === 'percent'">
-            <input type="number" [value]="element.year4 * 100"
-              (input)="element.year4 = $any($event.target).value / 100">
+            <input type="text" [value]="element.year4 * 100" (input)="element.year4 = $any($event.target).value / 100"
+              appDecimalInput>
           </div>
         </td>
-        <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year4') | currencyExtended}} </td>
+        <!-- <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year4') | currencyExtended}} </td> -->
       </ng-container>
       <!-- year5 -->
       <ng-container matColumnDef="year5">
         <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2026</th>
         <td class="column-title" mat-cell *matCellDef="let element">
           <div *ngIf="element.rowUnits === 'number'">
-            <input type="number" matInput required [value]=element.year5.toFixed(2)>
+            <input type="text" appDecimalInput required [value]=element.year5.toFixed(2)>
           </div>
           <div *ngIf="element.rowUnits === 'US dollars'">
-            <span>$</span><input type="number" matInput required [value]=element.year5.toFixed(2)>
+            <span>$</span><input type="text" appDecimalInput required [value]=element.year5.toFixed(2)>
           </div>
           <div *ngIf="element.rowUnits === 'percent'">
-            <input type="number" [value]="element.year4 * 100"
-              (input)="element.year5 = $any($event.target).value / 100">
+            <input type="text" [value]="element.year4 * 100" (input)="element.year5 = $any($event.target).value / 100"
+              appDecimalInput>
           </div>
         </td>
-        <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year5') | currencyExtended}} </td>
+        <!-- <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year5') | currencyExtended}} </td> -->
       </ng-container>
       <!-- year6 -->
       <ng-container matColumnDef="year6">
         <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2027</th>
         <td class="column-title" mat-cell *matCellDef="let element">
           <div *ngIf="element.rowUnits === 'number'">
-            <input type="number" matInput required [value]=element.year6.toFixed(2)>
+            <input type="text" appDecimalInput required [value]=element.year6.toFixed(2)>
           </div>
           <div *ngIf="element.rowUnits === 'US dollars'">
-            <span>$</span><input type="number" matInput required [value]=element.year6.toFixed(2)>
+            <span>$</span><input type="text" appDecimalInput required [value]=element.year6.toFixed(2)>
           </div>
           <div *ngIf="element.rowUnits === 'percent'">
-            <input type="number" [value]="element.year6 * 100"
-              (input)="element.year6 = $any($event.target).value / 100">
+            <input type="text" [value]="element.year6 * 100" (input)="element.year6 = $any($event.target).value / 100"
+              appDecimalInput>
           </div>
         </td>
-        <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year6') | currencyExtended}} </td>
+        <!-- <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year6') | currencyExtended}} </td> -->
       </ng-container>
       <!-- year7 -->
       <ng-container matColumnDef="year7">
         <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2028</th>
         <td class="column-title" mat-cell *matCellDef="let element">
           <div *ngIf="element.rowUnits === 'number'">
-            <input type="number" matInput required [value]=element.year7.toFixed(2)>
+            <input type="text" appDecimalInput required [value]=element.year7.toFixed(2)>
           </div>
           <div *ngIf="element.rowUnits === 'US dollars'">
             <span>$</span>
-            <!-- <input type="number" matInput required [value]=element.year7> -->
-            <input appDecimalInput [(ngModel)]="element.year7">
+            <input type="text" appDecimalInput required [value]=element.year7.toFixed(2)>
           </div>
           <div *ngIf="element.rowUnits === 'percent'">
-            <input type="number" [value]="element.year4 * 100"
-              (input)="element.year7 = $any($event.target).value / 100">
+            <input type="text" [value]="element.year4 * 100" (input)="element.year7 = $any($event.target).value / 100"
+              appDecimalInput>
           </div>
         </td>
-        <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year7') | currencyExtended}} </td>
+        <!-- <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year7') | currencyExtended}} </td> -->
       </ng-container>
       <!-- year8 -->
       <ng-container matColumnDef="year8">
         <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2029</th>
         <td class="column-title" mat-cell *matCellDef="let element">
           <div *ngIf="element.rowUnits === 'number'">
-            <input type="number" matInput required [value]=element.year8.toFixed(2)>
+            <input type="text" appDecimalInput required [value]=element.year8.toFixed(2)>
           </div>
           <div *ngIf="element.rowUnits === 'US dollars'">
-            <span>$</span><input type="number" matInput required [value]=element.year8.toFixed(2)>
+            <span>$</span><input type="text" appDecimalInput required [value]=element.year8.toFixed(2)>
           </div>
           <div *ngIf="element.rowUnits === 'percent'">
-            <input type="number" [value]="element.year4 * 100"
-              (input)="element.year8 = $any($event.target).value / 100">
+            <input type="text" [value]="element.year4 * 100" (input)="element.year8 = $any($event.target).value / 100"
+              appDecimalInput>
           </div>
         </td>
-        <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year8') | currencyExtended}} </td>
+        <!-- <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year8') | currencyExtended}} </td> -->
       </ng-container>
       <!-- year9 -->
       <ng-container matColumnDef="year9">
         <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2030</th>
         <td class="column-title" mat-cell *matCellDef="let element">
           <div *ngIf="element.rowUnits === 'number'">
-            <input type="number" matInput required [value]=element.year9.toFixed(2)>
+            <input type="text" appDecimalInput required [value]=element.year9.toFixed(2)>
           </div>
           <div *ngIf="element.rowUnits === 'US dollars'">
-            <span>$</span><input type="number" matInput required [value]=element.year9.toFixed(2)>
+            <span>$</span><input type="text" appDecimalInput required [value]=element.year9.toFixed(2)>
           </div>
           <div *ngIf="element.rowUnits === 'percent'">
-            <input type="number" [value]="element.year4 * 100"
-              (input)="element.year9 = $any($event.target).value / 100">
+            <input type="text" [value]="element.year4 * 100" (input)="element.year9 = $any($event.target).value / 100"
+              appDecimalInput>
           </div>
         </td>
-        <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year9') | currencyExtended}} </td>
+        <!-- <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year9') | currencyExtended}} </td> -->
       </ng-container>
       <tr mat-header-row *matHeaderRowDef="displayHeaders;"></tr>
       <tr mat-row *matRowDef="let row; columns: displayHeaders"></tr>
       <tr class="mat-row" *matNoDataRow></tr>
-      <tr mat-footer-row *matFooterRowDef="displayHeaders"></tr>
+      <!-- <tr mat-footer-row *matFooterRowDef="displayHeaders"></tr> -->
     </table>
     <div class="button-container">
       <button mat-raised-button (click)="dialogData.close()">Back</button>

--- a/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.html
+++ b/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.html
@@ -7,7 +7,7 @@
       <ng-container matColumnDef="name">
         <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">Years of start-up or scale-up</th>
         <td mat-cell *matCellDef="let element"> {{element.name}} </td>
-        <!-- <td mat-footer-cell *matFooterCellDef>Total</td> -->
+        <td mat-footer-cell *matFooterCellDef>Total</td>
       </ng-container>
       <ng-container matColumnDef="year0">
         <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2021</th>
@@ -23,7 +23,7 @@
               appDecimalInput>
           </div>
         </td>
-        <!-- <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year0') | currencyExtended}} </td> -->
+        <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year0') | currencyExtended}} </td>
       </ng-container>
       <!-- year1 -->
       <ng-container matColumnDef="year1">
@@ -40,7 +40,7 @@
               appDecimalInput>
           </div>
         </td>
-        <!-- <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year1') | currencyExtended}} </td> -->
+        <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year1') | currencyExtended}} </td>
       </ng-container>
       <!-- year2 -->
       <ng-container matColumnDef="year2">
@@ -57,7 +57,7 @@
               appDecimalInput>
           </div>
         </td>
-        <!-- <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year2') | currencyExtended}} </td> -->
+        <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year2') | currencyExtended}} </td>
       </ng-container>
       <!-- year3 -->
       <ng-container matColumnDef="year3">
@@ -74,7 +74,7 @@
               appDecimalInput>
           </div>
         </td>
-        <!-- <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year3') | currencyExtended}} </td> -->
+        <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year3') | currencyExtended}} </td>
       </ng-container>
       <!-- year4 -->
       <ng-container matColumnDef="year4">
@@ -91,7 +91,7 @@
               appDecimalInput>
           </div>
         </td>
-        <!-- <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year4') | currencyExtended}} </td> -->
+        <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year4') | currencyExtended}} </td>
       </ng-container>
       <!-- year5 -->
       <ng-container matColumnDef="year5">
@@ -108,7 +108,7 @@
               appDecimalInput>
           </div>
         </td>
-        <!-- <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year5') | currencyExtended}} </td> -->
+        <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year5') | currencyExtended}} </td>
       </ng-container>
       <!-- year6 -->
       <ng-container matColumnDef="year6">
@@ -125,7 +125,7 @@
               appDecimalInput>
           </div>
         </td>
-        <!-- <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year6') | currencyExtended}} </td> -->
+        <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year6') | currencyExtended}} </td>
       </ng-container>
       <!-- year7 -->
       <ng-container matColumnDef="year7">
@@ -143,7 +143,7 @@
               appDecimalInput>
           </div>
         </td>
-        <!-- <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year7') | currencyExtended}} </td> -->
+        <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year7') | currencyExtended}} </td>
       </ng-container>
       <!-- year8 -->
       <ng-container matColumnDef="year8">
@@ -160,7 +160,7 @@
               appDecimalInput>
           </div>
         </td>
-        <!-- <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year8') | currencyExtended}} </td> -->
+        <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year8') | currencyExtended}} </td>
       </ng-container>
       <!-- year9 -->
       <ng-container matColumnDef="year9">
@@ -177,12 +177,12 @@
               appDecimalInput>
           </div>
         </td>
-        <!-- <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year9') | currencyExtended}} </td> -->
+        <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year9') | currencyExtended}} </td>
       </ng-container>
       <tr mat-header-row *matHeaderRowDef="displayHeaders;"></tr>
       <tr mat-row *matRowDef="let row; columns: displayHeaders"></tr>
       <tr class="mat-row" *matNoDataRow></tr>
-      <!-- <tr mat-footer-row *matFooterRowDef="displayHeaders"></tr> -->
+      <tr mat-footer-row *matFooterRowDef="displayHeaders"></tr>
     </table>
     <div class="button-container">
       <button mat-raised-button (click)="dialogData.close()">Back</button>

--- a/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.scss
+++ b/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.scss
@@ -1,10 +1,19 @@
 @import 'src/assets/scss/_colour.scss';
 
 .button-container {
-  width: 50%;
+  width: 100%;
   display: flex;
-  justify-content: space-around;
+  justify-content: flex-end;
   margin: 1em 0;
+
+  button {
+    margin: 0 5px 0 5px;
+  }
+
+  .confirm {
+    background-color: $color_primary;
+    color: white;
+  }
 }
 
 table {

--- a/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.scss
+++ b/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.scss
@@ -30,7 +30,7 @@ input {
   font-size: 100%;
   margin: 0;
   box-sizing: border-box;
-  width: 98%;
+  width: 60%;
   padding: 5px;
   height: 30px;
   border-radius: 5px;

--- a/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.scss
+++ b/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.scss
@@ -24,3 +24,16 @@ table {
     font-weight: 600;
   }
 }
+input {
+  // display: block;
+  font-family: inherit;
+  font-size: 100%;
+  margin: 0;
+  box-sizing: border-box;
+  width: 50%;
+  padding: 5px;
+  height: 30px;
+  border-radius: 5px;
+  border: black 0.5px solid;
+  text-align: center;
+}

--- a/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.scss
+++ b/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.scss
@@ -30,7 +30,7 @@ input {
   font-size: 100%;
   margin: 0;
   box-sizing: border-box;
-  width: 50%;
+  width: 98%;
   padding: 5px;
   height: 30px;
   border-radius: 5px;

--- a/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.ts
+++ b/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.ts
@@ -1,8 +1,7 @@
-import { Component, Inject, Injectable, Self } from '@angular/core';
+import { Component, Inject, Injectable } from '@angular/core';
 import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatTableDataSource } from '@angular/material/table';
 import { RecurringCosts, RecurringCostBreakdown } from 'src/app/apiAndObjects/objects/interventionRecurringCosts';
-import { DecimalInputDirective } from 'src/app/directives/decimalInput.directive';
 import { DialogData } from '../baseDialogService.abstract';
 @Injectable({ providedIn: 'root' })
 @Component({
@@ -31,13 +30,9 @@ export class SectionRecurringCostReviewDialogComponent {
   constructor(
     @Inject(MAT_DIALOG_DATA)
     public dialogData: DialogData<RecurringCosts>,
-  ) // private decDirective: DecimalInputDirective,
-  {
+  ) {
     this.dataSource = new MatTableDataSource(dialogData.dataIn.costBreakdown);
     this.title = dialogData.dataIn.section;
-    console.log('recurringCosts:', this.dataSource.data);
-    console.log('recurringCosts Average salary of commercial monitor year7:', this.dataSource.data[0].year7.toFixed(2));
-    // console.log('CustomAppComponent: Injected directive: ', this.decDirective);
   }
 
   public getTotalCost(yearKey: string): number {

--- a/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.ts
+++ b/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.ts
@@ -1,9 +1,10 @@
-import { Component, Inject } from '@angular/core';
+import { Component, Inject, Injectable, Self } from '@angular/core';
 import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatTableDataSource } from '@angular/material/table';
 import { RecurringCosts, RecurringCostBreakdown } from 'src/app/apiAndObjects/objects/interventionRecurringCosts';
+import { DecimalInputDirective } from 'src/app/directives/decimalInput.directive';
 import { DialogData } from '../baseDialogService.abstract';
-
+@Injectable({ providedIn: 'root' })
 @Component({
   selector: 'app-section-recurring-cost-review-dialog',
   templateUrl: './sectionRecurringCostReviewDialog.component.html',
@@ -27,9 +28,16 @@ export class SectionRecurringCostReviewDialogComponent {
     'year9',
   ];
 
-  constructor(@Inject(MAT_DIALOG_DATA) public dialogData: DialogData<RecurringCosts>) {
+  constructor(
+    @Inject(MAT_DIALOG_DATA)
+    public dialogData: DialogData<RecurringCosts>,
+  ) // private decDirective: DecimalInputDirective,
+  {
     this.dataSource = new MatTableDataSource(dialogData.dataIn.costBreakdown);
     this.title = dialogData.dataIn.section;
+    console.log('recurringCosts:', this.dataSource.data);
+    console.log('recurringCosts Average salary of commercial monitor year7:', this.dataSource.data[0].year7.toFixed(2));
+    // console.log('CustomAppComponent: Injected directive: ', this.decDirective);
   }
 
   public getTotalCost(yearKey: string): number {

--- a/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.ts
+++ b/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.ts
@@ -36,6 +36,9 @@ export class SectionRecurringCostReviewDialogComponent {
   }
 
   public getTotalCost(yearKey: string): number {
-    return this.dataSource.data.map((costBreakdown) => costBreakdown[yearKey]).reduce((acc, value) => acc + value, 0);
+    // Only calculate the cost for items specifed as US Dollars.
+    // TODO: update this to factor in percentage modifiers
+    const filterItemsInDollars = this.dataSource.data.filter((cost) => cost.rowUnits === 'US dollars');
+    return filterItemsInDollars.map((costBreakdown) => costBreakdown[yearKey]).reduce((acc, value) => acc + value, 0);
   }
 }

--- a/src/app/components/dialogs/sectionStartUpCostReviewDialog/sectionStartUpCostReviewDialog.component.html
+++ b/src/app/components/dialogs/sectionStartUpCostReviewDialog/sectionStartUpCostReviewDialog.component.html
@@ -52,9 +52,8 @@
       <tr mat-footer-row *matFooterRowDef="displayHeaders"></tr>
     </table>
     <div class="button-container">
-      <button mat-raised-button (click)="dialogData.close()">Back</button>
-      <button mat-raised-button color="primary">Confirm current values and return to recurring cost
-        summary</button>
+      <button mat-stroked-button (click)="dialogData.close()">Back</button>
+      <button class="confirm" mat-stroked-button color="primary" (click)="dialogData.close()">Confirm</button>
     </div>
   </div>
 </app-base-dialog>

--- a/src/app/components/dialogs/sectionStartUpCostReviewDialog/sectionStartUpCostReviewDialog.component.html
+++ b/src/app/components/dialogs/sectionStartUpCostReviewDialog/sectionStartUpCostReviewDialog.component.html
@@ -9,16 +9,43 @@
         <td mat-cell *matCellDef="let element"> {{element.name}} </td>
         <td mat-footer-cell *matFooterCellDef>Total</td>
       </ng-container>
+
       <ng-container matColumnDef="year0">
         <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2021</th>
-        <td mat-cell *matCellDef="let element">{{element.year0 | currencyExtended}}</td>
+        <!-- <td mat-cell *matCellDef="let element">{{element.year0 | currencyExtended}}</td> -->
+        <td class="column-title" mat-cell *matCellDef="let element">
+          <div *ngIf="element.rowUnits === 'number'">
+            <input type="text" appDecimalInput required [value]=element.year0.toFixed(2)>
+          </div>
+          <div *ngIf="element.rowUnits === 'US dollars'">
+            <span>$</span><input type="text" appDecimalInput required [value]=element.year0.toFixed(2)>
+          </div>
+          <div *ngIf="element.rowUnits === 'percent'">
+            <input type="text" [value]="element.year0 * 100" (input)="element.year0 = $any($event.target).value / 100"
+              appDecimalInput>
+          </div>
+        </td>
         <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year0') | currencyExtended}} </td>
       </ng-container>
+
       <ng-container matColumnDef="year1">
         <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2022</th>
-        <td mat-cell *matCellDef="let element">{{element.year1 | currencyExtended}}</td>
+        <!-- <td mat-cell *matCellDef="let element">{{element.year1 | currencyExtended}}</td> -->
+        <td class="column-title" mat-cell *matCellDef="let element">
+          <div *ngIf="element.rowUnits === 'number'">
+            <input type="text" appDecimalInput required [value]=element.year1.toFixed(2)>
+          </div>
+          <div *ngIf="element.rowUnits === 'US dollars'">
+            <span>$</span><input type="text" appDecimalInput required [value]=element.year1.toFixed(2)>
+          </div>
+          <div *ngIf="element.rowUnits === 'percent'">
+            <input type="text" [value]="element.year1 * 100" (input)="element.year1 = $any($event.target).value / 100"
+              appDecimalInput>
+          </div>
+        </td>
         <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year1') | currencyExtended}} </td>
       </ng-container>
+
       <tr mat-header-row *matHeaderRowDef="displayHeaders;"></tr>
       <tr mat-row *matRowDef="let row; columns: displayHeaders"></tr>
       <tr class="mat-row" *matNoDataRow></tr>

--- a/src/app/components/dialogs/sectionStartUpCostReviewDialog/sectionStartUpCostReviewDialog.component.scss
+++ b/src/app/components/dialogs/sectionStartUpCostReviewDialog/sectionStartUpCostReviewDialog.component.scss
@@ -1,10 +1,19 @@
 @import 'src/assets/scss/_colour.scss';
 
 .button-container {
-  width: 50%;
+  width: 100%;
   display: flex;
-  justify-content: space-around;
+  justify-content: flex-end;
   margin: 1em 0;
+
+  button {
+    margin: 0 5px 0 5px;
+  }
+
+  .confirm {
+    background-color: $color_primary;
+    color: white;
+  }
 }
 
 table {

--- a/src/app/components/dialogs/sectionStartUpCostReviewDialog/sectionStartUpCostReviewDialog.component.scss
+++ b/src/app/components/dialogs/sectionStartUpCostReviewDialog/sectionStartUpCostReviewDialog.component.scss
@@ -24,3 +24,16 @@ table {
     font-weight: 600;
   }
 }
+input {
+  // display: block;
+  font-family: inherit;
+  font-size: 100%;
+  margin: 0;
+  box-sizing: border-box;
+  width: 60%;
+  padding: 5px;
+  height: 30px;
+  border-radius: 5px;
+  border: black 0.5px solid;
+  text-align: center;
+}

--- a/src/app/components/dialogs/sectionSummaryRecurringCostReviewDialog/sectionSummaryRecurringCostReviewDialog.component.scss
+++ b/src/app/components/dialogs/sectionSummaryRecurringCostReviewDialog/sectionSummaryRecurringCostReviewDialog.component.scss
@@ -1,10 +1,19 @@
 @import 'src/assets/scss/_colour.scss';
 
 .button-container {
-  width: 50%;
+  width: 100%;
   display: flex;
-  justify-content: flex-start;
+  justify-content: flex-end;
   margin: 1em 0;
+
+  button {
+    margin: 0 5px 0 5px;
+  }
+
+  .confirm {
+    background-color: $color_primary;
+    color: white;
+  }
 }
 
 table {

--- a/src/app/components/dialogs/welcomeDialog/dialogWelcome.component.html
+++ b/src/app/components/dialogs/welcomeDialog/dialogWelcome.component.html
@@ -34,7 +34,7 @@
     </p>
 
     <p class="text-center welcome-text">
-      <button mat-raised-button color="primary" (click)="openQuickMapsTour($event)">View a tour of Quick MAPS</button>
+      <button mat-stroked-button color="primary" (click)="openQuickMapsTour($event)">View a tour of Quick MAPS</button>
     </p>
   </div>
 

--- a/src/app/directives/decimalInput.directive.ts
+++ b/src/app/directives/decimalInput.directive.ts
@@ -1,16 +1,6 @@
 import { Directive, ElementRef, HostListener } from '@angular/core';
-
-// import { NG_VALIDATORS } from '@angular/forms';
 @Directive({
   selector: '[appDecimalInput]',
-
-  // providers: [
-  //   {
-  //     provide: NG_VALIDATORS,
-  //     useExisting: DecimalInputDirective,
-  //     multi: true,
-  //   },
-  // ],
 })
 export class DecimalInputDirective {
   title = 'Directive';
@@ -20,18 +10,19 @@ export class DecimalInputDirective {
   // Allow key codes for special events. Reflect :
   // Backspace, tab, end, home
   private specialKeys: Array<string> = ['Backspace', 'Tab', 'End', 'Home', 'ArrowLeft', 'ArrowRight', 'Del', 'Delete'];
+
   constructor(private el: ElementRef) {}
+
   @HostListener('keydown', ['$event'])
   onKeyDown(event: KeyboardEvent) {
-    console.log(this.el.nativeElement.value);
+    // console.log(this.el.nativeElement.value);
     // Allow Backspace, tab, end, and home keys
     if (this.specialKeys.indexOf(event.key) !== -1) {
       return;
     }
     const current: string = this.el.nativeElement.value;
     const position = this.el.nativeElement.selectionStart;
-    // const position = this.el.nativeElement[0];
-    console.log('directive working?', this.el.nativeElement[0]);
+
     const next: string = [
       current.slice(0, position),
       event.key == 'Decimal' ? '.' : event.key,

--- a/src/app/directives/decimalInput.directive.ts
+++ b/src/app/directives/decimalInput.directive.ts
@@ -1,0 +1,44 @@
+import { Directive, ElementRef, HostListener } from '@angular/core';
+
+// import { NG_VALIDATORS } from '@angular/forms';
+@Directive({
+  selector: '[appDecimalInput]',
+
+  // providers: [
+  //   {
+  //     provide: NG_VALIDATORS,
+  //     useExisting: DecimalInputDirective,
+  //     multi: true,
+  //   },
+  // ],
+})
+export class DecimalInputDirective {
+  title = 'Directive';
+  // Allow numbers with 2 decimal figures
+  // eslint-disable-next-line @typescript-eslint/no-inferrable-types
+  private regex: RegExp = new RegExp(/^\d*\.?\d{0,2}$/g);
+  // Allow key codes for special events. Reflect :
+  // Backspace, tab, end, home
+  private specialKeys: Array<string> = ['Backspace', 'Tab', 'End', 'Home', 'ArrowLeft', 'ArrowRight', 'Del', 'Delete'];
+  constructor(private el: ElementRef) {}
+  @HostListener('keydown', ['$event'])
+  onKeyDown(event: KeyboardEvent) {
+    console.log(this.el.nativeElement.value);
+    // Allow Backspace, tab, end, and home keys
+    if (this.specialKeys.indexOf(event.key) !== -1) {
+      return;
+    }
+    const current: string = this.el.nativeElement.value;
+    const position = this.el.nativeElement.selectionStart;
+    // const position = this.el.nativeElement[0];
+    console.log('directive working?', this.el.nativeElement[0]);
+    const next: string = [
+      current.slice(0, position),
+      event.key == 'Decimal' ? '.' : event.key,
+      current.slice(position),
+    ].join('');
+    if (next && !String(next).match(this.regex)) {
+      event.preventDefault();
+    }
+  }
+}

--- a/src/app/directives/directives.module.ts
+++ b/src/app/directives/directives.module.ts
@@ -1,12 +1,13 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { DecimalInputDirective } from './decimalInput.directive';
 import { FeatureFlagDisableDirective } from './feature-flag-disable';
 import { FeatureFlagDirective } from './feature-flag.directive';
 import { TourStageDirective } from './tour-stage-directive';
 
 @NgModule({
-  declarations: [FeatureFlagDirective, FeatureFlagDisableDirective, TourStageDirective],
+  declarations: [FeatureFlagDirective, FeatureFlagDisableDirective, TourStageDirective, DecimalInputDirective],
   imports: [CommonModule],
-  exports: [FeatureFlagDirective, FeatureFlagDisableDirective, TourStageDirective],
+  exports: [FeatureFlagDirective, FeatureFlagDisableDirective, TourStageDirective, DecimalInputDirective],
 })
 export class DirectivesModule {}

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -15,7 +15,8 @@
         <h2>MAPS will be a web-hosted tool, communicating estimates of dietary micronutrient (MN) supplies and
           deficiency
           risks at national and sub-national scales in Africa. </h2>
-        <button mat-raised-button color="primary" [routerLink]="ROUTES.MAPS_TOOL | route">Maps Tool Portal</button>
+        <button class="cta-button" mat-stroked-button color="primary" [routerLink]="ROUTES.MAPS_TOOL | route">Maps Tool
+          Portal</button>
         <img src="/assets/images/maps-logo-full-greyscale.svg" alt="BMGF MAPS Logo" class="logo">
       </div>
       <div class="mdc-layout-grid__cell--span-6">
@@ -34,7 +35,7 @@
           <div class="text text-center">
             <h2>Educational Resources</h2>
             <p>Educational resources related to the MAPS tool</p>
-            <button mat-button color="primary" [routerLink]="ROUTES.EDUCATIONAL_RESOURCES | route">View</button>
+            <button mat-stroked-button color="primary" [routerLink]="ROUTES.EDUCATIONAL_RESOURCES | route">View</button>
           </div>
 
         </div>
@@ -45,7 +46,7 @@
           <div class="text text-center">
             <h2>Project Objectives</h2>
             <p>Project goals and ambitions for the future</p>
-            <button mat-button color="primary" [routerLink]="ROUTES.PROJECT_OBJECTIVES | route">View</button>
+            <button mat-stroked-button color="primary" [routerLink]="ROUTES.PROJECT_OBJECTIVES | route">View</button>
           </div>
         </div>
       </div>
@@ -62,7 +63,8 @@
           projections. The user can also explore cost and effectiveness options to reduce micronutrient deficiencies
           through model functionalities. Please note, some functionality is still under pre-release development. Please
           contact us for more details.</p>
-        <button mat-raised-button color="primary" [routerLink]="ROUTES.MAPS_TOOL | route">Maps Tool Portal</button>
+        <button class="cta-button" mat-stroked-button color="primary" [routerLink]="ROUTES.MAPS_TOOL | route">Maps Tool
+          Portal</button>
       </div>
       <div class="mdc-layout-grid__cell--span-6">
         <img class="homeCellImage" src="/assets/images/webp/maps-min.webp" alt="placeholder">

--- a/src/app/pages/home/home.component.scss
+++ b/src/app/pages/home/home.component.scss
@@ -1,3 +1,5 @@
+@import 'src/assets/scss/_colour.scss';
+
 .homeCell {
   box-sizing: border-box;
 }
@@ -12,4 +14,9 @@
   display: block;
   width: 9em;
   margin-top: 1em;
+}
+
+.cta-button {
+  background-color: $color_primary;
+  color: white;
 }

--- a/src/app/pages/mapsTool/mapsTool.component.html
+++ b/src/app/pages/mapsTool/mapsTool.component.html
@@ -34,7 +34,7 @@
             <h2>Quick MAPS</h2>
             <p>Launch the MAPS Tool using default mode settings to explore micronutrient deficiencies risks in your
               geography of interest and possible interventions to reduce the risk of micronutrient deficiencies</p>
-            <button mat-button color="primary" [routerLink]="ROUTES.QUICK_MAPS | route">View</button>
+            <button mat-stroked-button color="primary" [routerLink]="ROUTES.QUICK_MAPS | route">View</button>
           </div>
 
         </div>
@@ -45,7 +45,7 @@
           <div class="text text-center">
             <h2>My MAPS</h2>
             <p>Log-in to create or access your stored workspace, including uploading your own data</p>
-            <button mat-button color="primary" disabled>Coming Soon</button>
+            <button mat-stroked-button color="primary" disabled>Coming Soon</button>
           </div>
         </div>
       </div>
@@ -56,7 +56,7 @@
           <div class="text text-center">
             <h2>Choices in MAPS</h2>
             <p>Launch the MAPS Tool with data and model selection options enabled for you to make customised choices</p>
-            <button mat-button color="primary" disabled>Coming Soon</button>
+            <button mat-stroked-button color="primary" disabled>Coming Soon</button>
           </div>
         </div>
       </div>
@@ -67,7 +67,7 @@
           <div class="text text-center">
             <h2>Sharing MAPS</h2>
             <p>Log-in to a shared MAPS Tool workspace</p>
-            <button mat-button color="primary" disabled>Coming Soon</button>
+            <button mat-stroked-button color="primary" disabled>Coming Soon</button>
           </div>
         </div>
       </div>

--- a/src/app/pages/quickMaps/components/download/download.component.html
+++ b/src/app/pages/quickMaps/components/download/download.component.html
@@ -2,26 +2,26 @@
   <div class="element-container">
     <i class="fas fa-file-image"></i>
     <a [href]="chartDownloadPNG" target="_blank" referrerpolicy="no-referrer-when-downgrade">
-      <button [disabled]="!chartDownloadPNG ? true : null" mat-raised-button color="primary">Save as .png</button>
+      <button [disabled]="!chartDownloadPNG ? true : null" mat-stroked-button color="primary">Save as .png</button>
     </a>
     <p>PNG image of the visualisation that can be used in reports and presentations</p>
   </div>
   <div class="element-container">
     <i class="fas fa-file-image"></i>
     <a [href]="chartDownloadPDF" target="_blank" referrerpolicy="no-referrer-when-downgrade">
-      <button [disabled]="!chartDownloadPDF ? true : null" mat-raised-button color="primary">Save as .pdf</button>
+      <button [disabled]="!chartDownloadPDF ? true : null" mat-stroked-button color="primary">Save as .pdf</button>
     </a>
     <p>Adobe PDF document of the visualisation that can be used for editing and redesigning the chart</p>
   </div>
   <div class="element-container">
     <i class="fas fa-file-csv"></i>
-    <button [disabled]="dataArray?.length<1 ||dataArray== null" mat-raised-button color="primary"
+    <button [disabled]="dataArray?.length<1 ||dataArray== null" mat-stroked-button color="primary"
       (click)="exportToCsv()">Save as .csv</button>
     <p>CSV File containing the data used in this visualisation</p>
   </div>
   <!-- <div class="element-container">
     <i class="fas fa-file-image"></i>
-    <button mat-raised-button color="primary" (click)="exportMapPDF()">Export map as
+    <button mat-stroked-button color="primary" (click)="exportMapPDF()">Export map as
       .pdf</button>
     <p>Adobe PDF document of the map visualisation</p>
   </div> -->
@@ -32,8 +32,8 @@
     <strong>Suggested citation for this output: </strong>
     <p>MAPS ({{year}}) The Micronutrient Action Policy Support (MAPS) Tool project. https://tool.micronutrient.support/
       Accessed: {{ formattedDate}}</p>
-    <button mat-raised-button color="primary" cdkCopyToClipboard="{{copyPlainText}}">Copy plain text citation</button>
-    <button mat-raised-button color="primary" cdkCopyToClipboard="{{copyBibTex}}">Copy BibTex citation</button>
+    <button mat-stroked-button color="primary" cdkCopyToClipboard="{{copyPlainText}}">Copy plain text citation</button>
+    <button mat-stroked-button color="primary" cdkCopyToClipboard="{{copyBibTex}}">Copy BibTex citation</button>
 
   </div>
 </div>

--- a/src/app/pages/quickMaps/components/quickMapsHeader.component/quickMapsHeader.component.html
+++ b/src/app/pages/quickMaps/components/quickMapsHeader.component/quickMapsHeader.component.html
@@ -9,7 +9,7 @@
     </div>
   </div>
   <div class="item">
-    <button mat-raised-button class="shareButton"
+    <button mat-stroked-button class="shareButton"
       (click)="
         share(
           'Micronutrient Action Policy Support (MAPS) Tool',
@@ -21,11 +21,11 @@
 </div>
 
 <div class="mode-select" *ngIf="(quickMapsService.measure.obs | async) === MEASURE_TYPES.DIET">
-  <a class="mode-select-button quickmaps-baseline-link" mat-raised-button
+  <a class="mode-select-button quickmaps-baseline-link" mat-stroked-button
     [routerLink]="ROUTES.QUICK_MAPS_BASELINE | route" [queryParams]="route.queryParams | async"
     routerLinkActive="active-route">Baseline
   </a>
-  <a class="mode-select-button quickmaps-projection-link" mat-raised-button [routerLink]="
+  <a class="mode-select-button quickmaps-projection-link" mat-stroked-button [routerLink]="
       (quickMapsService.micronutrient.obs | async)?.isInImpact ? (ROUTES.QUICK_MAPS_PROJECTION | route) : null
     " [queryParams]="route.queryParams | async" routerLinkActive="active-route"
     [disabled]="!(quickMapsService.micronutrient.obs | async)?.isInImpact" appTour tourName="Quick MAPS Baseline Data"
@@ -33,16 +33,17 @@
     tourPosition="auto" tourStage="6">Explore projections to 2050
   </a>
   <a [disabled]=" featureFlagsServive.isDisabled('CE-Enable')" class="mode-select-button quickmaps-uncertainty-link"
-    mat-raised-button [routerLink]="ROUTES.QUICK_MAPS_UNCERTAINTY | route" [queryParams]="route.queryParams | async"
+    mat-stroked-button [routerLink]="ROUTES.QUICK_MAPS_UNCERTAINTY | route" [queryParams]="route.queryParams | async"
     routerLinkActive="active-route">Explore uncertainty
   </a>
-  <a class="mode-select-button quickmaps-dieray-change-link" mat-raised-button
+  <a class="mode-select-button quickmaps-dieray-change-link" mat-stroked-button
     [routerLink]="ROUTES.QUICK_MAPS_DIETARY_CHANGE | route" [queryParams]="route.queryParams | async"
     routerLinkActive="active-route" appTour tourName="Quick MAPS Baseline Data"
     tourDescription="'Sandbox' mode to explore the effect on dietary micronutrient supply of changes to the composition or consumption of certain food items"
     tourTitle="Simple Dietary Change Scenarios" tourPosition="auto" tourStage="7">Simple dietary change scenarios</a>
+
   <a [disabled]=" featureFlagsServive.isDisabled('CE-Enable')"
-    class="mode-select-button quickmaps-cost-effectivness-link" mat-raised-button
+    class="mode-select-button quickmaps-cost-effectivness-link" mat-stroked-button
     [routerLink]="ROUTES.QUICK_MAPS_COST_EFFECTIVENESS | route" [queryParams]="route.queryParams | async"
     routerLinkActive="active-route">Explore cost
     effectiveness scenarios</a>

--- a/src/app/pages/quickMaps/pages/biomarkers/biomarkerStatus/statusDownload/statusDownload.component.html
+++ b/src/app/pages/quickMaps/pages/biomarkers/biomarkerStatus/statusDownload/statusDownload.component.html
@@ -1,39 +1,39 @@
 <div class="container-row">
-    <div class="element-container">
-        <i class="fas fa-file-image"></i>
-        <a [href]="chartDownloadPNG" target="_blank" referrerpolicy="no-referrer-when-downgrade">
-            <button [disabled]="!chartDownloadPNG ? true : null" mat-raised-button color="primary">Save as .png</button>
-        </a>
-        <p>PNG image of the visualisation that can be used in reports and presentations</p>
-    </div>
-    <div class="element-container">
-        <i class="fas fa-file-image"></i>
-        <a [href]="chartDownloadPDF" target="_blank" referrerpolicy="no-referrer-when-downgrade">
-            <button [disabled]="!chartDownloadPDF ? true : null" mat-raised-button color="primary">Save as .pdf</button>
+  <div class="element-container">
+    <i class="fas fa-file-image"></i>
+    <a [href]="chartDownloadPNG" target="_blank" referrerpolicy="no-referrer-when-downgrade">
+      <button [disabled]="!chartDownloadPNG ? true : null" mat-stroked-button color="primary">Save as .png</button>
+    </a>
+    <p>PNG image of the visualisation that can be used in reports and presentations</p>
+  </div>
+  <div class="element-container">
+    <i class="fas fa-file-image"></i>
+    <a [href]="chartDownloadPDF" target="_blank" referrerpolicy="no-referrer-when-downgrade">
+      <button [disabled]="!chartDownloadPDF ? true : null" mat-stroked-button color="primary">Save as .pdf</button>
 
-        </a>
-        <p>Adobe PDF document of the visualisation that can be used for editing and redesigning the chart</p>
-    </div>
-    <div class="element-container">
-        <i class="fas fa-file-csv"></i>
-        <button [disabled]="dataArray?.length<1 ||dataArray== null" mat-raised-button color="primary"></button>
+    </a>
+    <p>Adobe PDF document of the visualisation that can be used for editing and redesigning the chart</p>
+  </div>
+  <div class="element-container">
+    <i class="fas fa-file-csv"></i>
+    <button [disabled]="dataArray?.length<1 ||dataArray== null" mat-stroked-button color="primary"></button>
 
 
-        <p>CSV File containing the data used in this visualisation</p>
-    </div>
+    <p>CSV File containing the data used in this visualisation</p>
+  </div>
 
-    <br>
-    <br>
-    <div>
-        <strong>Suggested citation for this output: </strong>
-        <p>MAPS ({{year}}) The Micronutrient Action Policy Support (MAPS) Tool project.
-            https://tool.micronutrient.support/
-            Accessed: {{ formattedDate}}</p>
-        <button mat-raised-button color="primary" cdkCopyToClipboard="{{copyPlainText}}">Copy plain text
-            citation</button>
-        <button mat-raised-button color="primary" cdkCopyToClipboard="{{copyBibTex}}">Copy BibTex citation</button>
+  <br>
+  <br>
+  <div>
+    <strong>Suggested citation for this output: </strong>
+    <p>MAPS ({{year}}) The Micronutrient Action Policy Support (MAPS) Tool project.
+      https://tool.micronutrient.support/
+      Accessed: {{ formattedDate}}</p>
+    <button mat-stroked-button color="primary" cdkCopyToClipboard="{{copyPlainText}}">Copy plain text
+      citation</button>
+    <button mat-stroked-button color="primary" cdkCopyToClipboard="{{copyBibTex}}">Copy BibTex citation</button>
 
-    </div>
+  </div>
 
 </div>
 

--- a/src/app/pages/quickMaps/pages/costEffectiveness/components/interventionComparison/interventionComparison.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/components/interventionComparison/interventionComparison.component.html
@@ -1,31 +1,31 @@
 <div class="info-wrapper">
-    <span class="centre-align">
-        <h2>Select interventions to compare</h2>
-    </span>
-    <span>
-        You have saved effectiveness predictions and cost estimates for the intervention listed below. Click the boxes
-        for interventions you would like to include in a comparison of cost-effectiveness.
-    </span>
-    <div class="interventions">
-        <span class="select-all">Existing Interventions <button mat-flat-button color="primary">Select
-                All</button></span>
-        <ng-container *ngFor="let intervention of interventions">
-            <span class="intervention">
-                <mat-checkbox color="primary" value="{{intervention.name}}">{{intervention.name}}</mat-checkbox>
-                <span>
-                    <button mat-flat-button>
-                        <mat-icon>clear</mat-icon> Delete
-                    </button>
-                    <button mat-flat-button color="primary">
-                        <mat-icon>edit</mat-icon> Edit
-                    </button>
-                </span>
-            </span>
-        </ng-container>
-    </div>
-    <span class="centre-align">
-        <button (click)="compareScenario()" mat-raised-button color="primary">
-            Compare
-        </button>
-    </span>
+  <span class="centre-align">
+    <h2>Select interventions to compare</h2>
+  </span>
+  <span>
+    You have saved effectiveness predictions and cost estimates for the intervention listed below. Click the boxes
+    for interventions you would like to include in a comparison of cost-effectiveness.
+  </span>
+  <div class="interventions">
+    <span class="select-all">Existing Interventions <button mat-flat-button color="primary">Select
+        All</button></span>
+    <ng-container *ngFor="let intervention of interventions">
+      <span class="intervention">
+        <mat-checkbox color="primary" value="{{intervention.name}}">{{intervention.name}}</mat-checkbox>
+        <span>
+          <button mat-flat-button>
+            <mat-icon>clear</mat-icon> Delete
+          </button>
+          <button mat-flat-button color="primary">
+            <mat-icon>edit</mat-icon> Edit
+          </button>
+        </span>
+      </span>
+    </ng-container>
+  </div>
+  <span class="centre-align">
+    <button (click)="compareScenario()" mat-stroked-button color="primary">
+      Compare
+    </button>
+  </span>
 </div>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/components/interventionCreation/interventionCreation.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/components/interventionCreation/interventionCreation.component.html
@@ -8,7 +8,7 @@
     assumptions) intervention. Additional interventions can be added after the predicted effectiveness of the first
     intervention has been displayed and stored.
   </span>
-  <button mat-raised-button color="primary" (click)="openCESelectionDialog()">
+  <button mat-stroked-button color="primary" (click)="openCESelectionDialog()">
     Add intervention
   </button>
 </div>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview.module.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview.module.ts
@@ -38,6 +38,7 @@ import { InterventionStepDetailsComponent } from './interventionReview/utilities
 import { ComponentsModule } from 'src/app/components/components.module';
 import { MicroNutrientsInPremixTableComponent } from './interventionReview/utilities/microNutrientsInPremixTable/microNutrientsInPremixTable.component';
 import { PremixTableRowComponent } from './interventionReview/utilities/microNutrientsInPremixTable/premixTableRow/premixTableRow.component';
+import { DirectivesModule } from 'src/app/directives/directives.module';
 
 @NgModule({
   declarations: [
@@ -79,6 +80,7 @@ import { PremixTableRowComponent } from './interventionReview/utilities/microNut
     FormsModule,
     PipesModule,
     ComponentsModule,
+    DirectivesModule,
   ],
   providers: [QuickMapsService, ExportService, PipesModule, DialogService, InterventionSideNavContentService],
   exports: [],

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionBaseline/interventionBaseline.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionBaseline/interventionBaseline.component.html
@@ -18,7 +18,7 @@
       <ng-container matColumnDef="baseline_value">
         <td mat-cell *matCellDef="let element">
           <div class="double-cell">
-            <input type="number" matInput required [value]=element.year0>
+            <input type="text" appDecimalInput required [value]=element.year0.toFixed(2)>
             <span matPrefix>%&nbsp;</span>
             <span>
               <button mat-button color="primary">
@@ -74,7 +74,7 @@
             fortification (mg/kg) </th>
           <td mat-cell *matCellDef="let element">
             <div class="double-cell">
-              <input type="number" matInput required [value]="selectedCompound?.targetVal">
+              <input type="text" appDecimalInput required [value]="selectedCompound?.targetVal.toFixed(2)">
               <span>
                 <button mat-button color="primary">
                   GFDx <mat-icon>arrow_right_alt</mat-icon>
@@ -109,7 +109,8 @@
             (mg/kg) among fortifiable food vehicle at point of fortificationn </th>
           <td mat-cell *matCellDef="let element">
             <div class="double-cell">
-              <input type="number" matInput required [(ngModel)]="optionalUserEnteredAverageAtPointOfFortification">
+              <input type="text" appDecimalInput required
+                [(ngModel)]="optionalUserEnteredAverageAtPointOfFortification">
               <span>
                 <button mat-button color="primary">
                   GFDx <mat-icon>arrow_right_alt</mat-icon>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionBaseline/interventionBaseline.component.scss
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionBaseline/interventionBaseline.component.scss
@@ -27,23 +27,6 @@
     width: 100%;
   }
 }
-// .subheader-container {
-//   display: flex;
-//   border: 1px solid $color_primary;
-//   border-radius: 5px;
-//   background-color: white;
-//   display: flex;
-//   justify-content: space-evenly;
-//   align-items: center;
-//   width: 50%;
-//   margin: 10px;
-
-//   & .wideItem {
-//     flex-grow: 1;
-//     // display: flex;
-//     margin: 1em 0.5em;
-//   }
-// }
 
 table {
   width: 95%;

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCompliance/interventionCompliance.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCompliance/interventionCompliance.component.html
@@ -21,7 +21,7 @@
         <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2022</th>
         <td mat-cell *matCellDef="let element">
           <!-- <mat-form-field class="example-full-width"> -->
-          <input matInput type="number" [value]="formatNumberForDisplay(element.year1)">
+          <input appDecimalInput type="text" [value]="formatNumberForDisplay(element.year1)">
           <!-- <mat-icon matSuffix>percent</mat-icon> -->
           <!-- </mat-form-field> -->
         </td>
@@ -30,7 +30,7 @@
         <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2023</th>
         <td mat-cell *matCellDef="let element">
           <!-- <mat-form-field class="example-full-width"> -->
-          <input matInput type="number" [value]="formatNumberForDisplay(element.year2)">
+          <input appDecimalInput type="text" [value]="formatNumberForDisplay(element.year2)">
           <!-- <mat-icon matSuffix>percent</mat-icon> -->
           <!-- </mat-form-field> -->
         </td>
@@ -39,7 +39,7 @@
         <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2024</th>
         <td mat-cell *matCellDef="let element">
           <!-- <mat-form-field class="example-full-width"> -->
-          <input matInput type="number" [value]="formatNumberForDisplay(element.year3)">
+          <input appDecimalInput type="text" [value]="formatNumberForDisplay(element.year3)">
           <!-- <mat-icon matSuffix>percent</mat-icon> -->
           <!-- </mat-form-field> -->
         </td>
@@ -48,7 +48,7 @@
         <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2025</th>
         <td mat-cell *matCellDef="let element">
           <!-- <mat-form-field class="example-full-width"> -->
-          <input matInput type="number" [value]="formatNumberForDisplay(element.year4)">
+          <input appDecimalInput type="text" [value]="formatNumberForDisplay(element.year4)">
           <!-- <mat-icon matSuffix>percent</mat-icon> -->
           <!-- </mat-form-field> -->
         </td>
@@ -57,7 +57,7 @@
         <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2026</th>
         <td mat-cell *matCellDef="let element">
           <!-- <mat-form-field class="example-full-width"> -->
-          <input matInput type="number" [value]="formatNumberForDisplay(element.year5)">
+          <input appDecimalInput type="text" [value]="formatNumberForDisplay(element.year5)">
           <!-- <mat-icon matSuffix>percent</mat-icon> -->
           <!-- </mat-form-field> -->
         </td>
@@ -66,7 +66,7 @@
         <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2027</th>
         <td mat-cell *matCellDef="let element">
           <!-- <mat-form-field class="example-full-width"> -->
-          <input matInput type="number" [value]="formatNumberForDisplay(element.year6)">
+          <input appDecimalInput type="text" [value]="formatNumberForDisplay(element.year6)">
           <!-- <mat-icon matSuffix>percent</mat-icon> -->
           <!-- </mat-form-field> -->
         </td>
@@ -75,7 +75,7 @@
         <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2028</th>
         <td mat-cell *matCellDef="let element">
           <!-- <mat-form-field class="example-full-width"> -->
-          <input matInput type="number" [value]="formatNumberForDisplay(element.year7)">
+          <input appDecimalInput type="text" [value]="formatNumberForDisplay(element.year7)">
           <!-- <mat-icon matSuffix>percent</mat-icon> -->
           <!-- </mat-form-field> -->
         </td>
@@ -84,7 +84,7 @@
         <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2029</th>
         <td mat-cell *matCellDef="let element">
           <!-- <mat-form-field class="example-full-width"> -->
-          <input matInput type="number" [value]="formatNumberForDisplay(element.year8)">
+          <input appDecimalInput type="text" [value]="formatNumberForDisplay(element.year8)">
           <!-- <mat-icon matSuffix>percent</mat-icon> -->
           <!-- </mat-form-field> -->
         </td>
@@ -93,7 +93,7 @@
         <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2030</th>
         <td mat-cell *matCellDef="let element">
           <!-- <mat-form-field class="example-full-width"> -->
-          <input matInput type="number" [value]="formatNumberForDisplay(element.year9)">
+          <input appDecimalInput type="text" [value]="formatNumberForDisplay(element.year9)">
           <!-- <mat-icon matSuffix>percent</mat-icon> -->
           <!-- </mat-form-field> -->
         </td>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.html
@@ -14,10 +14,10 @@
         <th class="column-title" mat-header-cell *matHeaderCellDef> 2021 </th>
         <td class="column-title" mat-cell *matCellDef="let element">
           <div *ngIf="element.rowUnits === 'number'">
-            <input type="number" matInput required [value]=element.year0>
+            <input type="text" appDecimalInput required [value]=element.year0>
           </div>
           <div *ngIf="element.rowUnits === 'percent'">
-            <input type="number" [value]="element.year0 * 100"
+            <input type="text" appDecimalInput [value]="element.year0 * 100"
               (input)="element.year0 = $any($event.target).value / 100">
           </div>
         </td>
@@ -26,10 +26,10 @@
         <th class="column-title" mat-header-cell *matHeaderCellDef> 2022 </th>
         <td class="column-title" mat-cell *matCellDef="let element">
           <div *ngIf="element.rowUnits === 'number'">
-            <input type="number" matInput required [value]=element.year1>
+            <input type="text" appDecimalInput required [value]=element.year1>
           </div>
           <div *ngIf="element.rowUnits === 'percent'">
-            <input type="number" [value]="element.year1 * 100"
+            <input type="text" appDecimalInput [value]="element.year1 * 100"
               (input)="element.year1 = $any($event.target).value / 100">
           </div>
         </td>
@@ -38,10 +38,10 @@
         <th class="column-title" mat-header-cell *matHeaderCellDef> 2023 </th>
         <td class="column-title" mat-cell *matCellDef="let element">
           <div *ngIf="element.rowUnits === 'number'">
-            <input type="number" matInput required [value]=element.year2>
+            <input type="text" appDecimalInput required [value]=element.year2>
           </div>
           <div *ngIf="element.rowUnits === 'percent'">
-            <input type="number" [value]="element.year2 * 100"
+            <input type="text" appDecimalInput [value]="element.year2 * 100"
               (input)="element.year2 = $any($event.target).value / 100">
           </div>
         </td>
@@ -50,10 +50,10 @@
         <th class="column-title" mat-header-cell *matHeaderCellDef> 2024 </th>
         <td class="column-title" mat-cell *matCellDef="let element">
           <div *ngIf="element.rowUnits === 'number'">
-            <input type="number" matInput required [value]=element.year3>
+            <input type="text" appDecimalInput required [value]=element.year3>
           </div>
           <div *ngIf="element.rowUnits === 'percent'">
-            <input type="number" [value]="element.year3 * 100"
+            <input type="text" appDecimalInput [value]="element.year3 * 100"
               (input)="element.year3 = $any($event.target).value / 100">
           </div>
         </td>
@@ -62,10 +62,10 @@
         <th class="column-title" mat-header-cell *matHeaderCellDef> 2025 </th>
         <td class="column-title" mat-cell *matCellDef="let element">
           <div *ngIf="element.rowUnits === 'number'">
-            <input type="number" matInput required [value]=element.year4>
+            <input type="text" appDecimalInput required [value]=element.year4>
           </div>
           <div *ngIf="element.rowUnits === 'percent'">
-            <input type="number" [value]="element.year4 * 100"
+            <input type="text" appDecimalInput [value]="element.year4 * 100"
               (input)="element.year4 = $any($event.target).value / 100">
           </div>
         </td>
@@ -74,10 +74,10 @@
         <th class="column-title" mat-header-cell *matHeaderCellDef> 2026 </th>
         <td class="column-title" mat-cell *matCellDef="let element">
           <div *ngIf="element.rowUnits === 'number'">
-            <input type="number" matInput required [value]=element.year5>
+            <input type="text" appDecimalInput required [value]=element.year5>
           </div>
           <div *ngIf="element.rowUnits === 'percent'">
-            <input type="number" [value]="element.year5 * 100"
+            <input type="text" appDecimalInput [value]="element.year5 * 100"
               (input)="element.year5 = $any($event.target).value / 100">
           </div>
         </td>
@@ -86,10 +86,10 @@
         <th class="column-title" mat-header-cell *matHeaderCellDef> 2027</th>
         <td class="column-title" mat-cell *matCellDef="let element">
           <div *ngIf="element.rowUnits === 'number'">
-            <input type="number" matInput required [value]=element.year6>
+            <input type="text" appDecimalInput required [value]=element.year6>
           </div>
           <div *ngIf="element.rowUnits === 'percent'">
-            <input type="number" [value]="element.year6 * 100"
+            <input type="text" appDecimalInput [value]="element.year6 * 100"
               (input)="element.year6 = $any($event.target).value / 100">
           </div>
         </td>
@@ -98,10 +98,10 @@
         <th class="column-title" mat-header-cell *matHeaderCellDef> 2028 </th>
         <td class="column-title" mat-cell *matCellDef="let element">
           <div *ngIf="element.rowUnits === 'number'">
-            <input type="number" matInput required [value]=element.year7>
+            <input type="text" appDecimalInput required [value]=element.year7>
           </div>
           <div *ngIf="element.rowUnits === 'percent'">
-            <input type="number" [value]="element.year7 * 100"
+            <input type="text" appDecimalInput [value]="element.year7 * 100"
               (input)="element.year7 = $any($event.target).value / 100">
           </div>
         </td>
@@ -110,10 +110,10 @@
         <th class="column-title" mat-header-cell *matHeaderCellDef> 2029 </th>
         <td class="column-title" mat-cell *matCellDef="let element">
           <div *ngIf="element.rowUnits === 'number'">
-            <input type="number" matInput required [value]=element.year8>
+            <input type="text" appDecimalInput required [value]=element.year8>
           </div>
           <div *ngIf="element.rowUnits === 'percent'">
-            <input type="number" [value]="element.year8 * 100"
+            <input type="text" appDecimalInput [value]="element.year8 * 100"
               (input)="element.year8 = $any($event.target).value / 100">
           </div>
         </td>
@@ -122,10 +122,10 @@
         <th class="column-title" mat-header-cell *matHeaderCellDef> 2030 </th>
         <td class="column-title" mat-cell *matCellDef="let element">
           <div *ngIf="element.rowUnits === 'number'">
-            <input type="number" matInput required [value]=element.year9>
+            <input type="text" appDecimalInput required [value]=element.year9>
           </div>
           <div *ngIf="element.rowUnits === 'percent'">
-            <input type="number" [value]="element.year9 * 100"
+            <input type="text" appDecimalInput [value]="element.year9 * 100"
               (input)="element.year9 = $any($event.target).value / 100">
           </div>
         </td>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionMonitoringInformation/interventionMonitoringInformation.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionMonitoringInformation/interventionMonitoringInformation.component.html
@@ -14,10 +14,10 @@
         <th class="column-title" mat-header-cell *matHeaderCellDef> 2021 </th>
         <td class="column-title" mat-cell *matCellDef="let element">
           <div *ngIf="element.rowUnits === 'number'">
-            <input type="number" matInput required [value]=element.year0>
+            <input type="text" appDecimalInput required [value]=element.year0>
           </div>
           <div *ngIf="element.rowUnits === 'percent'">
-            <input type="number" [value]="element.year0 * 100"
+            <input type="text" appDecimalInput [value]="element.year0 * 100"
               (input)="element.year0 = $any($event.target).value / 100">
           </div>
         </td>
@@ -26,10 +26,10 @@
         <th class="column-title" mat-header-cell *matHeaderCellDef> 2022 </th>
         <td class="column-title" mat-cell *matCellDef="let element">
           <div *ngIf="element.rowUnits === 'number'">
-            <input type="number" matInput required [value]=element.year1>
+            <input type="text" appDecimalInput required [value]=element.year1>
           </div>
           <div *ngIf="element.rowUnits === 'percent'">
-            <input type="number" [value]="element.year1 * 100"
+            <input type="text" appDecimalInput [value]="element.year1 * 100"
               (input)="element.year1 = $any($event.target).value / 100">
           </div>
         </td>
@@ -38,10 +38,10 @@
         <th class="column-title" mat-header-cell *matHeaderCellDef> 2023 </th>
         <td class="column-title" mat-cell *matCellDef="let element">
           <div *ngIf="element.rowUnits === 'number'">
-            <input type="number" matInput required [value]=element.year2>
+            <input type="text" appDecimalInput required [value]=element.year2>
           </div>
           <div *ngIf="element.rowUnits === 'percent'">
-            <input type="number" [value]="element.year2 * 100"
+            <input type="text" appDecimalInput [value]="element.year2 * 100"
               (input)="element.year2 = $any($event.target).value / 100">
           </div>
         </td>
@@ -50,10 +50,10 @@
         <th class="column-title" mat-header-cell *matHeaderCellDef> 2024 </th>
         <td class="column-title" mat-cell *matCellDef="let element">
           <div *ngIf="element.rowUnits === 'number'">
-            <input type="number" matInput required [value]=element.year3>
+            <input type="text" appDecimalInput required [value]=element.year3>
           </div>
           <div *ngIf="element.rowUnits === 'percent'">
-            <input type="number" [value]="element.year3 * 100"
+            <input type="text" appDecimalInput [value]="element.year3 * 100"
               (input)="element.year3 = $any($event.target).value / 100">
           </div>
         </td>
@@ -62,10 +62,10 @@
         <th class="column-title" mat-header-cell *matHeaderCellDef> 2025 </th>
         <td class="column-title" mat-cell *matCellDef="let element">
           <div *ngIf="element.rowUnits === 'number'">
-            <input type="number" matInput required [value]=element.year4>
+            <input type="text" appDecimalInput required [value]=element.year4>
           </div>
           <div *ngIf="element.rowUnits === 'percent'">
-            <input type="number" [value]="element.year4 * 100"
+            <input type="text" appDecimalInput [value]="element.year4 * 100"
               (input)="element.year4 = $any($event.target).value / 100">
           </div>
         </td>
@@ -74,10 +74,10 @@
         <th class="column-title" mat-header-cell *matHeaderCellDef> 2026 </th>
         <td class="column-title" mat-cell *matCellDef="let element">
           <div *ngIf="element.rowUnits === 'number'">
-            <input type="number" matInput required [value]=element.year5>
+            <input type="text" appDecimalInput required [value]=element.year5>
           </div>
           <div *ngIf="element.rowUnits === 'percent'">
-            <input type="number" [value]="element.year5 * 100"
+            <input type="text" appDecimalInput [value]="element.year5 * 100"
               (input)="element.year5 = $any($event.target).value / 100">
           </div>
         </td>
@@ -86,10 +86,10 @@
         <th class="column-title" mat-header-cell *matHeaderCellDef> 2027</th>
         <td class="column-title" mat-cell *matCellDef="let element">
           <div *ngIf="element.rowUnits === 'number'">
-            <input type="number" matInput required [value]=element.year6>
+            <input type="text" appDecimalInput required [value]=element.year6>
           </div>
           <div *ngIf="element.rowUnits === 'percent'">
-            <input type="number" [value]="element.year6 * 100"
+            <input type="text" appDecimalInput [value]="element.year6 * 100"
               (input)="element.year6 = $any($event.target).value / 100">
           </div>
         </td>
@@ -98,10 +98,10 @@
         <th class="column-title" mat-header-cell *matHeaderCellDef> 2028 </th>
         <td class="column-title" mat-cell *matCellDef="let element">
           <div *ngIf="element.rowUnits === 'number'">
-            <input type="number" matInput required [value]=element.year7>
+            <input type="text" appDecimalInput required [value]=element.year7>
           </div>
           <div *ngIf="element.rowUnits === 'percent'">
-            <input type="number" [value]="element.year7 * 100"
+            <input type="text" appDecimalInput [value]="element.year7 * 100"
               (input)="element.year7 = $any($event.target).value / 100">
           </div>
         </td>
@@ -110,10 +110,10 @@
         <th class="column-title" mat-header-cell *matHeaderCellDef> 2029 </th>
         <td class="column-title" mat-cell *matCellDef="let element">
           <div *ngIf="element.rowUnits === 'number'">
-            <input type="number" matInput required [value]=element.year8>
+            <input type="text" appDecimalInput required [value]=element.year8>
           </div>
           <div *ngIf="element.rowUnits === 'percent'">
-            <input type="number" [value]="element.year8 * 100"
+            <input type="text" appDecimalInput [value]="element.year8 * 100"
               (input)="element.year8 = $any($event.target).value / 100">
           </div>
         </td>
@@ -122,10 +122,10 @@
         <th class="column-title" mat-header-cell *matHeaderCellDef> 2030 </th>
         <td class="column-title" mat-cell *matCellDef="let element">
           <div *ngIf="element.rowUnits === 'number'">
-            <input type="number" matInput required [value]=element.year9>
+            <input type="text" appDecimalInput required [value]=element.year9>
           </div>
           <div *ngIf="element.rowUnits === 'percent'">
-            <input type="number" [value]="element.year9 * 100"
+            <input type="text" appDecimalInput [value]="element.year9 * 100"
               (input)="element.year9 = $any($event.target).value / 100">
           </div>
         </td>

--- a/src/app/pages/quickMaps/pages/dietaryChange/components/options/options.component.html
+++ b/src/app/pages/quickMaps/pages/dietaryChange/components/options/options.component.html
@@ -97,7 +97,7 @@
               <span *ngIf="changeItem.noData">No Data</span>
             </span>
             <div class="flex-row">
-              <button mat-raised-button type="button" class="btn btn-danger"
+              <button mat-stroked-button type="button" class="btn btn-danger"
                 [disabled]="null == (changeItem | cast: NumberChangeItem).currentValue"
                 (click)="changeScenarioValue(changeItem, changeItem.scenarioValue * 0.95)">-5%</button>
               <div class="mat-form-field-scenario">
@@ -108,7 +108,7 @@
                 </mat-form-field>
 
               </div>
-              <button mat-raised-button type=" button" class="btn btn-success"
+              <button mat-stroked-button type=" button" class="btn btn-success"
                 (click)="changeScenarioValue(changeItem, changeItem.scenarioValue * 1.05)"
                 [disabled]="null == (changeItem | cast: NumberChangeItem).currentValue">+5%</button>
             </div>
@@ -145,7 +145,7 @@
             </div>
           </ng-template>
           <span *ngIf="isLast">
-            <button mat-raised-button [disabled]="!changeItem.isComplete" (click)="addChangeItem()"
+            <button mat-stroked-button [disabled]="!changeItem.isComplete" (click)="addChangeItem()"
               aria-label="Add food item">
               <mat-icon aria-label="Add food item">add_circle_outline</mat-icon>
               Add food Item

--- a/src/app/pages/styleGuide/styleGuide.component.html
+++ b/src/app/pages/styleGuide/styleGuide.component.html
@@ -1,134 +1,134 @@
 <div class="container">
-    <h1>Style Guide</h1>
-    <br>
-    <h2>Colours</h2>
-    <div class="colours">
-        <div class="circle" style="background-color: #323130;">#323130</div>
-        <div class="circle" style="background-color: #4F4F4F;">#4F4F4F</div>
-        <div class="circle" style="background-color: #703AA3;">#703AA3</div>
-        <div class="circle" style="background-color: #9B51E0;">#9B51E0</div>
-        <div class="circle" style="background-color: #1D3557;">#1D3557</div>
-        <div class="circle" style="background-color: #F1FAEE;">#F1FAEE</div>
-        <div class="circle" style="background-color: #FFFFFF;">#FFFFFF</div>
+  <h1>Style Guide</h1>
+  <br>
+  <h2>Colours</h2>
+  <div class="colours">
+    <div class="circle" style="background-color: #323130;">#323130</div>
+    <div class="circle" style="background-color: #4F4F4F;">#4F4F4F</div>
+    <div class="circle" style="background-color: #703AA3;">#703AA3</div>
+    <div class="circle" style="background-color: #9B51E0;">#9B51E0</div>
+    <div class="circle" style="background-color: #1D3557;">#1D3557</div>
+    <div class="circle" style="background-color: #F1FAEE;">#F1FAEE</div>
+    <div class="circle" style="background-color: #FFFFFF;">#FFFFFF</div>
+  </div>
+  <h2>Headings</h2>
+  <div class="headings">
+    <h1>H1 text</h1>
+    <h2>H2 text</h2>
+    <h3>H3 text</h3>
+    <h4>H4 text</h4>
+    <h5>H5 text</h5>
+    <h6>H6 text</h6>
+  </div>
+  <h2>MatMenus</h2>
+  <div class="menus">
+    <button mat-stroked-button [matMenuTriggerFor]="menu" aria-label="Example icon-button with a menu">
+      Menu Example
+    </button>
+    <mat-menu #menu="matMenu" class="mat-menu">
+      <button mat-menu-item>
+        Example 1
+      </button>
+      <button mat-menu-item>
+        Example 2
+      </button>
+      <button mat-menu-item>
+        Example 3
+      </button>
+      <button mat-menu-item>
+        Example 4
+      </button>
+    </mat-menu>
+  </div>
+  <h2>Button Toggle, Select & Tooltip</h2>
+  <div class="button-toggle">
+    <div>
+      <mat-button-toggle-group name="example" aria-label="example">
+        <mat-button-toggle value="bold">Example 1</mat-button-toggle>
+        <mat-button-toggle value="italic">Example 2</mat-button-toggle>
+        <mat-button-toggle value="underline">Example 3</mat-button-toggle>
+      </mat-button-toggle-group>
     </div>
-    <h2>Headings</h2>
-    <div class="headings">
-        <h1>H1 text</h1>
-        <h2>H2 text</h2>
-        <h3>H3 text</h3>
-        <h4>H4 text</h4>
-        <h5>H5 text</h5>
-        <h6>H6 text</h6>
+    <div>
+      <mat-form-field appearance="fill">
+        <mat-select formControl="toppings" multiple>
+          <mat-option *ngFor="let topping of toppingList" [value]="topping">{{topping}}</mat-option>
+          <mat-error>somthing</mat-error>
+        </mat-select>
+      </mat-form-field>
     </div>
-    <h2>MatMenus</h2>
-    <div class="menus">
-        <button mat-raised-button [matMenuTriggerFor]="menu" aria-label="Example icon-button with a menu">
-            Menu Example
-        </button>
-        <mat-menu #menu="matMenu" class="mat-menu">
-            <button mat-menu-item>
-                Example 1
-            </button>
-            <button mat-menu-item>
-                Example 2
-            </button>
-            <button mat-menu-item>
-                Example 3
-            </button>
-            <button mat-menu-item>
-                Example 4
-            </button>
-        </mat-menu>
+    <div>
+      <i class="fas fa-question-circle" matTooltip="Example tool tip help icon" style="color: #828282;"></i>
     </div>
-    <h2>Button Toggle, Select & Tooltip</h2>
-    <div class="button-toggle">
-        <div>
-            <mat-button-toggle-group name="example" aria-label="example">
-                <mat-button-toggle value="bold">Example 1</mat-button-toggle>
-                <mat-button-toggle value="italic">Example 2</mat-button-toggle>
-                <mat-button-toggle value="underline">Example 3</mat-button-toggle>
-            </mat-button-toggle-group>
-        </div>
-        <div>
-            <mat-form-field appearance="fill">
-                <mat-select formControl="toppings" multiple>
-                    <mat-option *ngFor="let topping of toppingList" [value]="topping">{{topping}}</mat-option>
-                    <mat-error>somthing</mat-error>
-                </mat-select>
-            </mat-form-field>
-        </div>
-        <div>
-            <i class="fas fa-question-circle" matTooltip="Example tool tip help icon" style="color: #828282;"></i>
-        </div>
 
 
-    </div>
-    <h2>Buttons</h2>
-    <div class="buttons">
-        <section>
-            <div class="example-label">Basic</div>
-            <div class="example-button-row">
-                <button mat-button>Basic</button>
-                <button mat-button color="primary">Primary</button>
-                <button mat-button color="accent">Accent</button>
-                <button mat-button color="warn">Warn</button>
-                <button mat-button disabled>Disabled</button>
-            </div>
-        </section>
-        <section>
-            <div class="example-label">Raised</div>
-            <div class="example-button-row">
-                <button mat-raised-button>Basic</button>
-                <button mat-raised-button color="primary">Primary</button>
-                <button mat-raised-button color="accent">Accent</button>
-                <button mat-raised-button color="warn">Warn</button>
-                <button mat-raised-button disabled>Disabled</button>
-            </div>
-        </section>
-        <section>
-            <div class="example-label">Stroked</div>
-            <div class="example-button-row">
-                <button mat-stroked-button>Basic</button>
-                <button mat-stroked-button color="primary">Primary</button>
-                <button mat-stroked-button color="accent">Accent</button>
-                <button mat-stroked-button color="warn">Warn</button>
-                <button mat-stroked-button disabled>Disabled</button>
-            </div>
-        </section>
-        <section>
-            <div class="example-label">Flat</div>
-            <div class="example-button-row">
-                <button mat-flat-button>Basic</button>
-                <button mat-flat-button color="primary">Primary</button>
-                <button mat-flat-button color="accent">Accent</button>
-                <button mat-flat-button color="warn">Warn</button>
-                <button mat-flat-button disabled>Disabled</button>
-            </div>
-        </section>
-        <section>
-            <div class="example-label">Icon</div>
-            <div class="example-button-row">
-                <div class="example-flex-container">
-                    <button mat-icon-button aria-label="Example icon button with a vertical three dot icon">
-                        <i class="fas fa-expand"></i>
-                    </button>
-                    <button mat-icon-button aria-label="Example icon button with a vertical three dot icon">
-                        <i class="fas fa-cog"></i>
-                    </button>
-                    <button mat-icon-button color="primary" aria-label="Example icon button with a home icon">
-                        <i class="fas fa-home"></i>
-                    </button>
-                    <button mat-icon-button color="accent" aria-label="Example icon button with a menu icon">
-                        <i class="fas fa-bars"></i>
-                    </button>
-                    <button mat-icon-button color="warn" aria-label="Example icon button with a heart icon">
-                        <i class="fas fa-arrow-down"></i>
-                    </button>
-                    <button mat-icon-button disabled aria-label="Example icon button with a open in new tab icon">
-                        <i class="fas fa-ellipsis-v"></i>
-                    </button>
-                </div>
-            </div>
-        </section>
-    </div>
+  </div>
+  <h2>Buttons</h2>
+  <div class="buttons">
+    <section>
+      <div class="example-label">Basic</div>
+      <div class="example-button-row">
+        <button mat-button>Basic</button>
+        <button mat-button color="primary">Primary</button>
+        <button mat-button color="accent">Accent</button>
+        <button mat-button color="warn">Warn</button>
+        <button mat-button disabled>Disabled</button>
+      </div>
+    </section>
+    <section>
+      <div class="example-label">Raised</div>
+      <div class="example-button-row">
+        <button mat-stroked-button>Basic</button>
+        <button mat-stroked-button color="primary">Primary</button>
+        <button mat-stroked-button color="accent">Accent</button>
+        <button mat-stroked-button color="warn">Warn</button>
+        <button mat-stroked-button disabled>Disabled</button>
+      </div>
+    </section>
+    <section>
+      <div class="example-label">Stroked</div>
+      <div class="example-button-row">
+        <button mat-stroked-button>Basic</button>
+        <button mat-stroked-button color="primary">Primary</button>
+        <button mat-stroked-button color="accent">Accent</button>
+        <button mat-stroked-button color="warn">Warn</button>
+        <button mat-stroked-button disabled>Disabled</button>
+      </div>
+    </section>
+    <section>
+      <div class="example-label">Flat</div>
+      <div class="example-button-row">
+        <button mat-flat-button>Basic</button>
+        <button mat-flat-button color="primary">Primary</button>
+        <button mat-flat-button color="accent">Accent</button>
+        <button mat-flat-button color="warn">Warn</button>
+        <button mat-flat-button disabled>Disabled</button>
+      </div>
+    </section>
+    <section>
+      <div class="example-label">Icon</div>
+      <div class="example-button-row">
+        <div class="example-flex-container">
+          <button mat-icon-button aria-label="Example icon button with a vertical three dot icon">
+            <i class="fas fa-expand"></i>
+          </button>
+          <button mat-icon-button aria-label="Example icon button with a vertical three dot icon">
+            <i class="fas fa-cog"></i>
+          </button>
+          <button mat-icon-button color="primary" aria-label="Example icon button with a home icon">
+            <i class="fas fa-home"></i>
+          </button>
+          <button mat-icon-button color="accent" aria-label="Example icon button with a menu icon">
+            <i class="fas fa-bars"></i>
+          </button>
+          <button mat-icon-button color="warn" aria-label="Example icon button with a heart icon">
+            <i class="fas fa-arrow-down"></i>
+          </button>
+          <button mat-icon-button disabled aria-label="Example icon button with a open in new tab icon">
+            <i class="fas fa-ellipsis-v"></i>
+          </button>
+        </div>
+      </div>
+    </section>
+  </div>
 </div>

--- a/src/app/pipes/currency-extended.pipe.ts
+++ b/src/app/pipes/currency-extended.pipe.ts
@@ -11,10 +11,6 @@ export class CurrencyExtendedPipe extends CurrencyPipe implements PipeTransform 
 
   transform(
     value: number | string,
-    // currencyCode?: string,
-    // display?: 'code' | 'symbol' | 'symbol-narrow' | string | boolean,
-    // digitsInfo?: string,
-    // locale?: string,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ): any {
     if (value === null) {

--- a/src/assets/scss/_angular_material_components.scss
+++ b/src/assets/scss/_angular_material_components.scss
@@ -53,7 +53,7 @@ mat-button-toggle.mat-button-toggle-checked.mat-button-toggle-appearance-standar
 }
 
 // Buttons
-button.mat-raised-button,
+button.mat-stroked-button,
 button.mat-flat-button,
 button.mat-stroked-button,
 button.mat-icon-button {

--- a/src/assets/scss/_card.scss
+++ b/src/assets/scss/_card.scss
@@ -22,7 +22,7 @@
 }
 
 .basic-card .text > button {
-  border: 0;
+  // border: 0;
   width: 100%;
 }
 

--- a/src/assets/scss/_tabs.scss
+++ b/src/assets/scss/_tabs.scss
@@ -10,32 +10,6 @@
 .mat-tab-group {
   margin: 1rem 0rem;
 
-  .mat-tab-header {
-    border-bottom: none;
-
-    .mat-tab-labels {
-      .mat-tab-label {
-        opacity: 1;
-        width: 100%;
-
-        &.cdk-program-focused {
-          &:not(.mat-tab-disabled) {
-            background-color: mat-color($_primary_pallete, A700);
-          }
-        }
-      }
-
-      .mat-tab-label-active {
-        background: mat-color($_primary_pallete, A700);
-
-        .mat-tab-label-content {
-          color: #ffffff;
-          font-weight: 600;
-        }
-      }
-    }
-  }
-
   .mat-tab-body {
     overflow: hidden;
 


### PR DESCRIPTION
- forked from @Sveouu branch `origin/sr_recurring_costs_dialog`
- directive was not being called so moved import out of the component and into the parent module
- inputs do not enforce the directive of 2 decimal places when `type="number"` so using `text`
- column totals calculated by only using items with `rowType = US Dollars`. Note: will need to update to allow modifier inputs e.g. multiple total by a percentage
- standardised buttons to be flat (stroked) instead of raised
- rollback some tab ui changes which were breaking other parts of the ui
- fixed intervention dialog buttons to match ui and be less verbose
- PauliusPurple:tm: added to VSCode Peacock


### TO DO
- if the changes are valid, roll out to other inputs needing this (@bgsandan are all inputs desirable to be 2 decimal places?)