### PR TITLE
Watching for table changes to create PATCH call

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,24 +14,5 @@
   "[json]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
-  "workbench.colorCustomizations": {
-    "activityBar.activeBackground": "#b47ce8",
-    "activityBar.activeBorder": "#f1d0ae",
-    "activityBar.background": "#b47ce8",
-    "activityBar.foreground": "#15202b",
-    "activityBar.inactiveForeground": "#15202b99",
-    "activityBarBadge.background": "#f1d0ae",
-    "activityBarBadge.foreground": "#15202b",
-    "sash.hoverBorder": "#b47ce8",
-    "statusBar.background": "#9b51e0",
-    "statusBar.foreground": "#e7e7e7",
-    "statusBarItem.hoverBackground": "#b47ce8",
-    "statusBarItem.remoteBackground": "#9b51e0",
-    "statusBarItem.remoteForeground": "#e7e7e7",
-    "titleBar.activeBackground": "#9b51e0",
-    "titleBar.activeForeground": "#e7e7e7",
-    "titleBar.inactiveBackground": "#9b51e099",
-    "titleBar.inactiveForeground": "#e7e7e799"
-  },
   "peacock.color": "#9b51e0"
 }

--- a/src/app/apiAndObjects/api/api.service.ts
+++ b/src/app/apiAndObjects/api/api.service.ts
@@ -38,6 +38,7 @@ import { GetInterventionStartupCosts } from './intervention/InterventionStartupC
 import { GetInterventionBaselineAssumptions } from './intervention/interventionBaselineAssumptions/getInterventionBaselineAssumptions';
 import { GetInterventionCostSummary } from './intervention/interventionCostSummary/getInterventionCostSummary';
 import { PostIntervention } from './intervention/intervention/postIntervention';
+import { PatchInterventionData } from './intervention/interventionData/patchInterventionData';
 
 @Injectable()
 export class ApiService extends BaseApi {
@@ -79,6 +80,7 @@ export class ApiService extends BaseApi {
       getInterventionBaselineAssumptions: new GetInterventionBaselineAssumptions(ApiService.USE_LIVE_API),
       getInterventionCostSummary: new GetInterventionCostSummary(ApiService.USE_LIVE_API),
       postIntervention: new PostIntervention(ApiService.USE_LIVE_API),
+      patchInterventionData: new PatchInterventionData(ApiService.USE_LIVE_API)
     },
     misc: {
       postFeedback: new postFeedback(ApiService.USE_LIVE_API),

--- a/src/app/apiAndObjects/api/intervention/interventionData/patchInterventionData.ts
+++ b/src/app/apiAndObjects/api/intervention/interventionData/patchInterventionData.ts
@@ -31,5 +31,5 @@ export class PatchInterventionData extends CacheableEndpoint<
 
 export interface PatchInterventionDataParams {
   interventionId: string;
-  data: Record<string, unknown>;
+  data: Array<Record<string, unknown>>;
 }

--- a/src/app/apiAndObjects/api/mapsHttpResponseHandler.ts
+++ b/src/app/apiAndObjects/api/mapsHttpResponseHandler.ts
@@ -52,32 +52,34 @@ export class MapsHttpResponseHandler {
     // TODO: Check response meta
     // TODO: Output to console?
     // console.debug(res);
-    const body = res.error; // .error is the body of the response?
-    let returnValue: ApiResponse;
-    let errorMessage = '';
+    if (res.error) {
+      const body = res.error; // .error is the body of the response?
+      let returnValue: ApiResponse;
+      let errorMessage = '';
 
-    switch (true) {
-      case res.ok === false:
-        errorMessage = res.message;
-        break;
-      case res.status === 404 && typeof body !== 'string':
-        returnValue = body;
-        break; // just an empty dataset
-      case typeof body !== 'string':
-        errorMessage = body.msg;
-        break;
-      default:
-        errorMessage = res.message;
-        break;
-    }
-    // console.debug('error message', errorMessage, returnValue, res);
+      switch (true) {
+        case res.ok === false:
+          errorMessage = res.message;
+          break;
+        case res.status === 404 && typeof body !== 'string':
+          returnValue = body;
+          break; // just an empty dataset
+        case typeof body !== 'string':
+          errorMessage = body.msg;
+          break;
+        default:
+          errorMessage = res.message;
+          break;
+      }
+      // console.debug('error message', errorMessage, returnValue, res);
 
-    if (errorMessage) {
-      console.error('API access error - ', errorMessage);
-      this.notificationsService.sendNegative('API Error - ', 'A call to retrieve data failed');
-      return Promise.reject(errorMessage);
-    } else {
-      return Promise.resolve(returnValue);
+      if (errorMessage) {
+        console.error('API access error - ', errorMessage);
+        this.notificationsService.sendNegative('API Error - ', 'A call to retrieve data failed');
+        return Promise.reject(errorMessage);
+      } else {
+        return Promise.resolve(returnValue);
+      }
     }
   }
 }

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCostSummary/interventionCostSummary.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCostSummary/interventionCostSummary.component.html
@@ -58,7 +58,7 @@
   <footer>
     <a class="intervention-navigation" mat-stroked-button
       [routerLink]="ROUTES.INTERVENTION_REVIEW_RECURRING_COSTS | route" queryParamsHandling="preserve">Back</a>
-    <a class="intervention-navigation-confirm" mat-stroked-button
-      [routerLink]="ROUTES.QUICK_MAPS_COST_EFFECTIVENESS | route" queryParamsHandling="preserve">Confirm costs</a>
+    <a class="intervention-navigation-confirm" mat-stroked-button (click)="onSubmit()"
+      queryParamsHandling="preserve">Confirm costs</a>
   </footer>
 </div>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCostSummary/interventionCostSummary.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCostSummary/interventionCostSummary.component.ts
@@ -9,7 +9,6 @@ import { InterventionDataService } from 'src/app/services/interventionData.servi
 import { InterventionSideNavContentService } from '../../components/interventionSideNavContent/interventionSideNavContent.service';
 import { Router, ActivatedRoute } from '@angular/router';
 
-
 @Component({
   selector: 'app-intervention-cost-summary',
   templateUrl: './interventionCostSummary.component.html',
@@ -35,8 +34,9 @@ export class InterventionCostSummaryComponent implements OnInit {
     private interventionDataService: InterventionDataService,
     private cdRef: ChangeDetectorRef,
     private router: Router,
-    private route: ActivatedRoute
-  ) { }
+    private route: ActivatedRoute,
+  ) {}
+
   public ngOnInit(): void {
     this.intSideNavService.setCurrentStepperPosition(this.pageStepperPosition);
     const activeInterventionId = this.interventionDataService.getActiveInterventionId();
@@ -80,23 +80,25 @@ export class InterventionCostSummaryComponent implements OnInit {
     }
   }
 
-  onSubmit(): void {
-    const interventionChanges = this.interventionDataService.getInterventionDataChanges()
+  public onSubmit(): void {
+    const interventionChanges = this.interventionDataService.getInterventionDataChanges();
     if (interventionChanges) {
-      const dataArr = []
+      const dataArr = [];
       for (const key in interventionChanges) {
         dataArr.push(interventionChanges[key]);
       }
 
-      const interventionId = this.interventionDataService.getActiveInterventionId()
-      this.interventionDataService.patchInterventionData(interventionId, dataArr).then(response => {
+      const interventionId = this.interventionDataService.getActiveInterventionId();
+      this.interventionDataService.patchInterventionData(interventionId, dataArr).then((response) => {
         console.log(response); // patch response does not have body. msg, data etc are null
       });
 
-      this.interventionDataService.setInterventionDataChanges(null)
+      this.interventionDataService.setInterventionDataChanges(null);
     }
 
     // navigate back to list of selected interventions
-    this.router.navigate(this.ROUTES.QUICK_MAPS_COST_EFFECTIVENESS.getRoute(), { queryParams: this.route.snapshot.queryParams });
+    this.router.navigate(this.ROUTES.QUICK_MAPS_COST_EFFECTIVENESS.getRoute(), {
+      queryParams: this.route.snapshot.queryParams,
+    });
   }
 }

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCostSummary/interventionCostSummary.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCostSummary/interventionCostSummary.component.ts
@@ -7,6 +7,8 @@ import { InterventionStartupCosts, StartUpScaleUpCost } from 'src/app/apiAndObje
 import { AppRoutes } from 'src/app/routes/routes';
 import { InterventionDataService } from 'src/app/services/interventionData.service';
 import { InterventionSideNavContentService } from '../../components/interventionSideNavContent/interventionSideNavContent.service';
+import { Router, ActivatedRoute } from '@angular/router';
+
 
 @Component({
   selector: 'app-intervention-cost-summary',
@@ -32,7 +34,9 @@ export class InterventionCostSummaryComponent implements OnInit {
     private intSideNavService: InterventionSideNavContentService,
     private interventionDataService: InterventionDataService,
     private cdRef: ChangeDetectorRef,
-  ) {}
+    private router: Router,
+    private route: ActivatedRoute
+  ) { }
   public ngOnInit(): void {
     this.intSideNavService.setCurrentStepperPosition(this.pageStepperPosition);
     const activeInterventionId = this.interventionDataService.getActiveInterventionId();
@@ -74,5 +78,25 @@ export class InterventionCostSummaryComponent implements OnInit {
         }),
       );
     }
+  }
+
+  onSubmit(): void {
+    const interventionChanges = this.interventionDataService.getIndustryInformationChanges()
+    if (interventionChanges) {
+      const dataArr = []
+      for (const idx in Object.keys(interventionChanges)) {
+        dataArr.push(interventionChanges[idx]);
+      }
+
+      const interventionId = this.interventionDataService.getActiveInterventionId()
+      this.interventionDataService.patchInterventionData(interventionId, dataArr).then(response => {
+        console.log(response); // patch response does not have body. msg, data etc are null
+      });
+
+      this.interventionDataService.setIndustryInformationChanges(null)
+    }
+
+    // navigate back to list of selected interventions
+    this.router.navigate(this.ROUTES.QUICK_MAPS_COST_EFFECTIVENESS.getRoute(), { queryParams: this.route.snapshot.queryParams });
   }
 }

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCostSummary/interventionCostSummary.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCostSummary/interventionCostSummary.component.ts
@@ -81,11 +81,11 @@ export class InterventionCostSummaryComponent implements OnInit {
   }
 
   onSubmit(): void {
-    const interventionChanges = this.interventionDataService.getIndustryInformationChanges()
+    const interventionChanges = this.interventionDataService.getInterventionDataChanges()
     if (interventionChanges) {
       const dataArr = []
-      for (const idx in Object.keys(interventionChanges)) {
-        dataArr.push(interventionChanges[idx]);
+      for (const key in interventionChanges) {
+        dataArr.push(interventionChanges[key]);
       }
 
       const interventionId = this.interventionDataService.getActiveInterventionId()
@@ -93,7 +93,7 @@ export class InterventionCostSummaryComponent implements OnInit {
         console.log(response); // patch response does not have body. msg, data etc are null
       });
 
-      this.interventionDataService.setIndustryInformationChanges(null)
+      this.interventionDataService.setInterventionDataChanges(null)
     }
 
     // navigate back to list of selected interventions

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.html
@@ -4,141 +4,143 @@
     <div class="title">
       <span> Industry Information </span>
     </div>
-    <table mat-table [dataSource]="dataSource">
-      <ng-container matColumnDef="labelText">
-        <th class="row-title" mat-header-cell *matHeaderCellDef> Intervention year </th>
-        <td class="row-title" mat-cell *matCellDef="let element">
-          {{element.labelText}} </td>
-      </ng-container>
-      <ng-container matColumnDef="year0">
-        <th class="column-title" mat-header-cell *matHeaderCellDef> 2021 </th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-          <div *ngIf="element.rowUnits === 'number'">
-            <input type="text" appDecimalInput required [value]=element.year0>
-          </div>
-          <div *ngIf="element.rowUnits === 'percent'">
-            <input type="text" appDecimalInput [value]="element.year0 * 100"
-              (input)="element.year0 = $any($event.target).value / 100">
-          </div>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="year1">
-        <th class="column-title" mat-header-cell *matHeaderCellDef> 2022 </th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-          <div *ngIf="element.rowUnits === 'number'">
-            <input type="text" appDecimalInput required [value]=element.year1>
-          </div>
-          <div *ngIf="element.rowUnits === 'percent'">
-            <input type="text" appDecimalInput [value]="element.year1 * 100"
-              (input)="element.year1 = $any($event.target).value / 100">
-          </div>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="year2">
-        <th class="column-title" mat-header-cell *matHeaderCellDef> 2023 </th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-          <div *ngIf="element.rowUnits === 'number'">
-            <input type="text" appDecimalInput required [value]=element.year2>
-          </div>
-          <div *ngIf="element.rowUnits === 'percent'">
-            <input type="text" appDecimalInput [value]="element.year2 * 100"
-              (input)="element.year2 = $any($event.target).value / 100">
-          </div>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="year3">
-        <th class="column-title" mat-header-cell *matHeaderCellDef> 2024 </th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-          <div *ngIf="element.rowUnits === 'number'">
-            <input type="text" appDecimalInput required [value]=element.year3>
-          </div>
-          <div *ngIf="element.rowUnits === 'percent'">
-            <input type="text" appDecimalInput [value]="element.year3 * 100"
-              (input)="element.year3 = $any($event.target).value / 100">
-          </div>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="year4">
-        <th class="column-title" mat-header-cell *matHeaderCellDef> 2025 </th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-          <div *ngIf="element.rowUnits === 'number'">
-            <input type="text" appDecimalInput required [value]=element.year4>
-          </div>
-          <div *ngIf="element.rowUnits === 'percent'">
-            <input type="text" appDecimalInput [value]="element.year4 * 100"
-              (input)="element.year4 = $any($event.target).value / 100">
-          </div>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="year5">
-        <th class="column-title" mat-header-cell *matHeaderCellDef> 2026 </th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-          <div *ngIf="element.rowUnits === 'number'">
-            <input type="text" appDecimalInput required [value]=element.year5>
-          </div>
-          <div *ngIf="element.rowUnits === 'percent'">
-            <input type="text" appDecimalInput [value]="element.year5 * 100"
-              (input)="element.year5 = $any($event.target).value / 100">
-          </div>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="year6">
-        <th class="column-title" mat-header-cell *matHeaderCellDef> 2027</th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-          <div *ngIf="element.rowUnits === 'number'">
-            <input type="text" appDecimalInput required [value]=element.year6>
-          </div>
-          <div *ngIf="element.rowUnits === 'percent'">
-            <input type="text" appDecimalInput [value]="element.year6 * 100"
-              (input)="element.year6 = $any($event.target).value / 100">
-          </div>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="year7">
-        <th class="column-title" mat-header-cell *matHeaderCellDef> 2028 </th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-          <div *ngIf="element.rowUnits === 'number'">
-            <input type="text" appDecimalInput required [value]=element.year7>
-          </div>
-          <div *ngIf="element.rowUnits === 'percent'">
-            <input type="text" appDecimalInput [value]="element.year7 * 100"
-              (input)="element.year7 = $any($event.target).value / 100">
-          </div>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="year8">
-        <th class="column-title" mat-header-cell *matHeaderCellDef> 2029 </th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-          <div *ngIf="element.rowUnits === 'number'">
-            <input type="text" appDecimalInput required [value]=element.year8>
-          </div>
-          <div *ngIf="element.rowUnits === 'percent'">
-            <input type="text" appDecimalInput [value]="element.year8 * 100"
-              (input)="element.year8 = $any($event.target).value / 100">
-          </div>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="year9">
-        <th class="column-title" mat-header-cell *matHeaderCellDef> 2030 </th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-          <div *ngIf="element.rowUnits === 'number'">
-            <input type="text" appDecimalInput required [value]=element.year9>
-          </div>
-          <div *ngIf="element.rowUnits === 'percent'">
-            <input type="text" appDecimalInput [value]="element.year9 * 100"
-              (input)="element.year9 = $any($event.target).value / 100">
-          </div>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="source">
-        <th class="column-title" mat-header-cell *matHeaderCellDef> Source </th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-          GFDx
-        </td>
-      </ng-container>
-      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-      <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
-    </table>
+    <form [formGroup]="form">
+      <table mat-table [dataSource]="dataSource" formArrayName="items">
+        <ng-container matColumnDef="labelText">
+          <th class="row-title" mat-header-cell *matHeaderCellDef> Intervention year </th>
+          <td class="row-title" mat-cell *matCellDef="let element">
+            {{element.labelText}} </td>
+        </ng-container>
+        <ng-container matColumnDef="year0">
+          <th class="column-title" mat-header-cell *matHeaderCellDef> 2021 </th>
+          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+            <div *ngIf="element.rowUnits === 'number'">
+              <input type="number" matInput required formControlName="year0">
+            </div>
+            <div *ngIf="element.rowUnits === 'percent'">
+              <input type="number" [value]="element.year0 * 100"
+                (input)="element.year0 = $any($event.target).value / 100">
+            </div>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="year1">
+          <th class="column-title" mat-header-cell *matHeaderCellDef> 2022 </th>
+          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+            <div *ngIf="element.rowUnits === 'number'">
+              <input type="number" matInput required [value]=element.year1 formControlName="year1">
+            </div>
+            <div *ngIf="element.rowUnits === 'percent'">
+              <input type="number" [value]="element.year1 * 100"
+                (input)="element.year1 = $any($event.target).value / 100">
+            </div>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="year2">
+          <th class="column-title" mat-header-cell *matHeaderCellDef> 2023 </th>
+          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+            <div *ngIf="element.rowUnits === 'number'">
+              <input type="number" matInput required [value]=element.year2 formControlName="year2">
+            </div>
+            <div *ngIf="element.rowUnits === 'percent'">
+              <input type="number" [value]="element.year2 * 100"
+                (input)="element.year2 = $any($event.target).value / 100">
+            </div>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="year3">
+          <th class="column-title" mat-header-cell *matHeaderCellDef> 2024 </th>
+          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+            <div *ngIf="element.rowUnits === 'number'">
+              <input type="number" matInput required [value]=element.year3 formControlName="year3">
+            </div>
+            <div *ngIf="element.rowUnits === 'percent'">
+              <input type="number" [value]="element.year3 * 100"
+                (input)="element.year3 = $any($event.target).value / 100">
+            </div>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="year4">
+          <th class="column-title" mat-header-cell *matHeaderCellDef> 2025 </th>
+          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+            <div *ngIf="element.rowUnits === 'number'">
+              <input type="number" matInput required [value]=element.year4 formControlName="year4">
+            </div>
+            <div *ngIf="element.rowUnits === 'percent'">
+              <input type="number" [value]="element.year4 * 100"
+                (input)="element.year4 = $any($event.target).value / 100">
+            </div>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="year5">
+          <th class="column-title" mat-header-cell *matHeaderCellDef> 2026 </th>
+          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+            <div *ngIf="element.rowUnits === 'number'">
+              <input type="number" matInput required [value]=element.year5 formControlName="year5">
+            </div>
+            <div *ngIf="element.rowUnits === 'percent'">
+              <input type="number" [value]="element.year5 * 100"
+                (input)="element.year5 = $any($event.target).value / 100">
+            </div>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="year6">
+          <th class="column-title" mat-header-cell *matHeaderCellDef> 2027</th>
+          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+            <div *ngIf="element.rowUnits === 'number'">
+              <input type="number" matInput required [value]=element.year6 formControlName="year6">
+            </div>
+            <div *ngIf="element.rowUnits === 'percent'">
+              <input type="number" [value]="element.year6 * 100"
+                (input)="element.year6 = $any($event.target).value / 100">
+            </div>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="year7">
+          <th class="column-title" mat-header-cell *matHeaderCellDef> 2028 </th>
+          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+            <div *ngIf="element.rowUnits === 'number'">
+              <input type="number" matInput required [value]=element.year7 formControlName="year7">
+            </div>
+            <div *ngIf="element.rowUnits === 'percent'">
+              <input type="number" [value]="element.year7 * 100"
+                (input)="element.year7 = $any($event.target).value / 100">
+            </div>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="year8">
+          <th class="column-title" mat-header-cell *matHeaderCellDef> 2029 </th>
+          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+            <div *ngIf="element.rowUnits === 'number'">
+              <input type="number" matInput required [value]=element.year8 formControlName="year8">
+            </div>
+            <div *ngIf="element.rowUnits === 'percent'">
+              <input type="number" [value]="element.year8 * 100"
+                (input)="element.year8 = $any($event.target).value / 100">
+            </div>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="year9">
+          <th class="column-title" mat-header-cell *matHeaderCellDef> 2030 </th>
+          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+            <div *ngIf="element.rowUnits === 'number'">
+              <input type="number" matInput required [value]=element.year9 formControlName="year9">
+            </div>
+            <div *ngIf="element.rowUnits === 'percent'">
+              <input type="number" [value]="element.year9 * 100"
+                (input)="element.year9 = $any($event.target).value / 100">
+            </div>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="source">
+          <th class="column-title" mat-header-cell *matHeaderCellDef> Source </th>
+          <td class="column-title" mat-cell *matCellDef="let element">
+            GFDx
+          </td>
+        </ng-container>
+        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+      </table>
+    </form>
 
     <app-intervention-step-details [resetDefaultValues]="true" [showFocusMn]="true" [showUserValues]="true"
       [showMnUnits]="true"></app-intervention-step-details>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.html
@@ -4,7 +4,7 @@
     <div class="title">
       <span> Industry Information </span>
     </div>
-    <form [formGroup]="form">
+    <form [formGroup]="form" *ngIf="form">
       <table mat-table [dataSource]="dataSource" formArrayName="items">
         <ng-container matColumnDef="labelText">
           <th class="row-title" mat-header-cell *matHeaderCellDef> Intervention year </th>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.ts
@@ -1,36 +1,24 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { MatTableDataSource } from '@angular/material/table';
 import {
-  IndustryInformation,
   InterventionIndustryInformation,
 } from 'src/app/apiAndObjects/objects/interventionIndustryInformation';
 import { AppRoutes } from 'src/app/routes/routes';
 import { InterventionDataService } from 'src/app/services/interventionData.service';
 import { InterventionSideNavContentService } from '../../components/interventionSideNavContent/interventionSideNavContent.service';
+import { FormBuilder, FormArray, FormGroup } from '@angular/forms';
+import { Unsubscriber } from 'src/app/decorators/unsubscriber.decorator';
+import { Subscription } from 'rxjs';
+import { pairwise, map } from 'rxjs/operators';
 
+@Unsubscriber('subscriptions')
 @Component({
   selector: 'app-intervention-industry-information',
   templateUrl: './interventionIndustryInformation.component.html',
   styleUrls: ['./interventionIndustryInformation.component.scss'],
 })
-export class InterventionIndustryInformationComponent implements OnInit, OnDestroy {
-  publiciIndustryInformation: IndustryInformation;
-  public testInput: number;
-
-  constructor(
-    private intSideNavService: InterventionSideNavContentService,
-    private interventionDataService: InterventionDataService,
-  ) {
-    const activeInterventionId = this.interventionDataService.getActiveInterventionId();
-    if (null != activeInterventionId) {
-      void this.interventionDataService
-        .getInterventionIndustryInformation(activeInterventionId)
-        .then((data: InterventionIndustryInformation) => {
-          this.init(data);
-        });
-    }
-  }
-  displayedColumns: string[] = [
+export class InterventionIndustryInformationComponent implements OnInit {
+  public displayedColumns: string[] = [
     'labelText',
     'year0',
     'year1',
@@ -44,21 +32,91 @@ export class InterventionIndustryInformationComponent implements OnInit, OnDestr
     'year9',
     'source',
   ];
-  public dataSource = new MatTableDataSource();
 
+  public dataSource = new MatTableDataSource();
   public ROUTES = AppRoutes;
   public pageStepperPosition = 3;
   public interventionName = 'IntName';
+  public form: FormGroup;
+  public formInitialState = [];
+  public formChanges: { [row: number]: { [col: string]: string }; } = {};
+  private subscriptions = new Array<Subscription>();
+
+  constructor(
+    private intSideNavService: InterventionSideNavContentService,
+    private interventionDataService: InterventionDataService,
+    private formBuilder: FormBuilder
+  ) {
+    const activeInterventionId = this.interventionDataService.getActiveInterventionId();
+    if (null != activeInterventionId) {
+      void this.interventionDataService
+        .getInterventionIndustryInformation(activeInterventionId)
+        .then((data: InterventionIndustryInformation) => {
+          this.dataSource = new MatTableDataSource(data.industryInformation);
+
+          const industryGroupArr = data.industryInformation.map(item => {
+            this.formInitialState.push(item)
+            return this.createIndustryGroup(item)
+          });
+          this.form = this.formBuilder.group({
+            items: this.formBuilder.array(industryGroupArr)
+          });
+
+          for (const key of Object.keys(this.industryArray)) {
+            const subscription = this.form.get('items')['controls'][key].valueChanges.pipe(pairwise(), map(([prev, next]) => {
+              const changes = {};
+              for (const idx in next) {
+                if (prev[idx] !== next[idx] && prev[idx] !== undefined) {
+                  changes[idx] = next[idx];
+                }
+              }
+              return changes;
+            })).subscribe(value => {
+              this.formChanges[key] = Object.assign({}, this.formChanges[key], {
+                [Object.keys(value).shift()]: Object.values(value).shift()
+              });
+
+              //if value is the same as initial value, remove from this.formChanges as a PUT request for the same value is not neccessary
+              Object.keys(this.formChanges).forEach((row) => {
+                Object.keys(this.formChanges[row]).forEach(col => {
+                  if (this.formInitialState[row][col] === this.formChanges[row][col]) {
+                    console.log('value is now in original state, remove value from changes object')
+                    delete this.formChanges[row][col];
+                    if (Object.keys(this.formChanges[row]).length === 0) {
+                      delete this.formChanges[row];
+                    }
+                  }
+                });
+              });
+              console.log(this.formChanges);
+              console.log(this.formInitialState);
+            });
+            this.subscriptions.push(subscription);
+          }
+        });
+    }
+  }
+
+  get industryArray() {
+    return this.form.get("items")["controls"] as FormArray;
+  }
+
+  createIndustryGroup(item) {
+    return this.formBuilder.group({
+      year0: [item.year0, []],
+      year1: [item.year1, []],
+      year2: [item.year2, []],
+      year3: [item.year3, []],
+      year4: [item.year4, []],
+      year5: [item.year5, []],
+      year6: [item.year6, []],
+      year7: [item.year7, []],
+      year8: [item.year8, []],
+      year9: [item.year9, []],
+    });
+  }
 
   public ngOnInit(): void {
     this.intSideNavService.setCurrentStepperPosition(this.pageStepperPosition);
-  }
-
-  public ngOnDestroy(): void {
-    console.debug('call');
-  }
-
-  private init(data: InterventionIndustryInformation): void {
-    this.dataSource = new MatTableDataSource(data.industryInformation);
   }
 }

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.ts
@@ -77,12 +77,14 @@ export class InterventionIndustryInformationComponent implements OnInit {
                         if (changes[rowIndex]) {
                           changes[rowIndex] = {
                             ...changes[rowIndex],
-                            [item[0]]: item[1]
+                            [item[0]]: item[1],
                           }
+                          changes[rowIndex]['rowIndex'] = rowIndex;
                         } else {
                           changes[rowIndex] = {
                             [item[0]]: item[1],
                           };
+                          changes[rowIndex]['rowIndex'] = rowIndex;
                         }
                       });
                     }

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.ts
@@ -38,8 +38,8 @@ export class InterventionIndustryInformationComponent implements OnInit {
   public pageStepperPosition = 3;
   public interventionName = 'IntName';
   public form: FormGroup;
-  public formInitialState = [];
-  public formChanges: { [row: number]: { [col: string]: string }; } = {};
+  public industryInformationInitialState = [];
+  public industryInformationFormChanges: { [row: number]: { [col: string]: string }; } = {};
   private subscriptions = new Array<Subscription>();
 
   constructor(
@@ -59,7 +59,7 @@ export class InterventionIndustryInformationComponent implements OnInit {
           this.dataSource = new MatTableDataSource(data.industryInformation);
 
           const industryGroupArr = data.industryInformation.map(item => {
-            this.formInitialState.push(item)
+            this.industryInformationInitialState.push(item)
             return this.createIndustryGroup(item)
           });
           this.form = this.formBuilder.group({
@@ -78,28 +78,17 @@ export class InterventionIndustryInformationComponent implements OnInit {
             })).subscribe(value => {
               const interventionDataRowIndex = this.form.get('items')['controls'][key]['controls'].rowIndex.value
 
-              this.formChanges[key] = {
-                ...this.formChanges[key], ...{
+              this.industryInformationFormChanges[interventionDataRowIndex] = {
+                ...this.industryInformationFormChanges[interventionDataRowIndex], ...{
                   [Object.keys(value).shift()]: Object.values(value).shift(),
                   'rowIndex': interventionDataRowIndex
                 }
               };
 
-              //if value is the same as initial value, remove from this.formChanges as a PUT request for the same value is not neccessary
-              Object.keys(this.formChanges).forEach((row) => {
-                Object.keys(this.formChanges[row]).forEach(col => {
-                  if (col !== 'rowIndex') {
-                    if (this.formInitialState[row][col] === this.formChanges[row][col]) {
-                      console.log('value is now in original state, remove value from changes object')
-                      delete this.formChanges[row][col];
-                      if (Object.keys(this.formChanges[row]).length === 0) {
-                        delete this.formChanges[row];
-                      }
-                    }
-                  }
-                });
-              });
-              this.interventionDataService.setIndustryInformationChanges(this.formChanges);
+              const newInterventionChanges = {
+                ...this.interventionDataService.getInterventionDataChanges(), ...this.industryInformationFormChanges
+              };
+              this.interventionDataService.setInterventionDataChanges(newInterventionChanges);
             });
             this.subscriptions.push(subscription);
           }

--- a/src/app/services/interventionData.service.ts
+++ b/src/app/services/interventionData.service.ts
@@ -165,4 +165,11 @@ export class InterventionDataService {
   getInterventionDataChanges(): Record<string, unknown> {
     return this.interventionDataChangesSrc.value
   }
+
+  public startReviewingIntervention(interventionID: string): void {
+    this.setActiveInterventionId(interventionID);
+    const route = this.ROUTES.INTERVENTION_REVIEW_BASELINE.getRoute();
+    const params = this.route.snapshot.queryParams;
+    void this.router.navigate(route, { queryParams: params });
+  }
 }

--- a/src/app/services/interventionData.service.ts
+++ b/src/app/services/interventionData.service.ts
@@ -153,7 +153,7 @@ export class InterventionDataService {
     const params = this.route.snapshot.queryParams;
     void this.router.navigate(route, { queryParams: params });
   }
-  
+
   public patchInterventionData(interventionId: string, data: Array<Record<string, unknown>>): Promise<InterventionData> {
     return this.apiService.endpoints.intervention.patchInterventionData.call({ interventionId, data });
   }
@@ -164,12 +164,5 @@ export class InterventionDataService {
 
   getInterventionDataChanges(): Record<string, unknown> {
     return this.interventionDataChangesSrc.value
-  }
-
-  public startReviewingIntervention(interventionID: string): void {
-    this.setActiveInterventionId(interventionID);
-    const route = this.ROUTES.INTERVENTION_REVIEW_BASELINE.getRoute();
-    const params = this.route.snapshot.queryParams;
-    void this.router.navigate(route, { queryParams: params });
   }
 }

--- a/src/app/services/interventionData.service.ts
+++ b/src/app/services/interventionData.service.ts
@@ -34,7 +34,7 @@ export class InterventionDataService {
   private readonly interventionDetailedChartPDFSrc = new BehaviorSubject<string>(null);
   public interventionDetailedChartPDFObs = this.interventionDetailedChartPDFSrc.asObservable();
 
-  private readonly interventionDataChangesSrc = new BehaviorSubject<unknown>(null);
+  private readonly interventionDataChangesSrc = new BehaviorSubject<Record<string, unknown>>(null);
   public interventionDataChangesObs = this.interventionDataChangesSrc.asObservable();
 
 
@@ -158,11 +158,11 @@ export class InterventionDataService {
     return this.apiService.endpoints.intervention.patchInterventionData.call({ interventionId, data });
   }
 
-  setIndustryInformationChanges(data: unknown): void {
+  setInterventionDataChanges(data: Record<string, unknown>): void {
     this.interventionDataChangesSrc.next(data)
   }
 
-  getIndustryInformationChanges(): unknown {
+  getInterventionDataChanges(): Record<string, unknown> {
     return this.interventionDataChangesSrc.value
   }
 }

--- a/src/app/services/interventionData.service.ts
+++ b/src/app/services/interventionData.service.ts
@@ -34,7 +34,11 @@ export class InterventionDataService {
   private readonly interventionDetailedChartPDFSrc = new BehaviorSubject<string>(null);
   public interventionDetailedChartPDFObs = this.interventionDetailedChartPDFSrc.asObservable();
 
-  constructor(private apiService: ApiService, private readonly router: Router, public route: ActivatedRoute) {}
+  private readonly interventionDataChangesSrc = new BehaviorSubject<unknown>(null);
+  public interventionDataChangesObs = this.interventionDataChangesSrc.asObservable();
+
+
+  constructor(private apiService: ApiService, private readonly router: Router, public route: ActivatedRoute) { }
 
   public getIntervention(id: string): Promise<Intervention> {
     return this.apiService.endpoints.intervention.getIntervention.call({
@@ -148,5 +152,17 @@ export class InterventionDataService {
     const route = this.ROUTES.INTERVENTION_REVIEW_BASELINE.getRoute();
     const params = this.route.snapshot.queryParams;
     void this.router.navigate(route, { queryParams: params });
+  }
+  
+  public patchInterventionData(interventionId: string, data: Array<Record<string, unknown>>): Promise<InterventionData> {
+    return this.apiService.endpoints.intervention.patchInterventionData.call({ interventionId, data });
+  }
+
+  setIndustryInformationChanges(data: unknown): void {
+    this.interventionDataChangesSrc.next(data)
+  }
+
+  getIndustryInformationChanges(): unknown {
+    return this.interventionDataChangesSrc.value
   }
 }


### PR DESCRIPTION
Branching off from @kerberpolis work, I opted, instead of creating a subscription for each input, to make use of `this.form.valueChanges` to watch for updates. This should be much more performant than creating an individual subscription for every item we want to watch. 

One small issue we noticed was that the changes were only being detected on the 2nd change of an input value. As it turns out, this was due to the use of `pairwise()` operator from RXJS, which will only fire once it has an `oldValue` and a `newValue`. The fix was to make use of `startWith(this.form.value)` to tell it to use the default form value & pick up changes from the first click. 

After that it was a fairly simple task of comparing the 2 objects representing the old row values & the new row values and only retrieving the inputs which have changed. Once we have got these numbers we can send the appropriate PATCH request to update the DB as required.
