### PR TITLE
Extra work done on MR 883

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,24 +14,5 @@
   "[json]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
-  "workbench.colorCustomizations": {
-    "activityBar.activeBackground": "#b47ce8",
-    "activityBar.activeBorder": "#f1d0ae",
-    "activityBar.background": "#b47ce8",
-    "activityBar.foreground": "#15202b",
-    "activityBar.inactiveForeground": "#15202b99",
-    "activityBarBadge.background": "#f1d0ae",
-    "activityBarBadge.foreground": "#15202b",
-    "sash.hoverBorder": "#b47ce8",
-    "statusBar.background": "#9b51e0",
-    "statusBar.foreground": "#e7e7e7",
-    "statusBarItem.hoverBackground": "#b47ce8",
-    "statusBarItem.remoteBackground": "#9b51e0",
-    "statusBarItem.remoteForeground": "#e7e7e7",
-    "titleBar.activeBackground": "#9b51e0",
-    "titleBar.activeForeground": "#e7e7e7",
-    "titleBar.inactiveBackground": "#9b51e099",
-    "titleBar.inactiveForeground": "#e7e7e799"
-  },
   "peacock.color": "#9b51e0"
 }

--- a/src/app/apiAndObjects/api/api.service.ts
+++ b/src/app/apiAndObjects/api/api.service.ts
@@ -38,6 +38,7 @@ import { GetInterventionStartupCosts } from './intervention/InterventionStartupC
 import { GetInterventionBaselineAssumptions } from './intervention/interventionBaselineAssumptions/getInterventionBaselineAssumptions';
 import { GetInterventionCostSummary } from './intervention/interventionCostSummary/getInterventionCostSummary';
 import { PostIntervention } from './intervention/intervention/postIntervention';
+import { PatchInterventionData } from './intervention/interventionData/patchInterventionData';
 
 @Injectable()
 export class ApiService extends BaseApi {
@@ -79,6 +80,7 @@ export class ApiService extends BaseApi {
       getInterventionBaselineAssumptions: new GetInterventionBaselineAssumptions(ApiService.USE_LIVE_API),
       getInterventionCostSummary: new GetInterventionCostSummary(ApiService.USE_LIVE_API),
       postIntervention: new PostIntervention(ApiService.USE_LIVE_API),
+      patchInterventionData: new PatchInterventionData(ApiService.USE_LIVE_API)
     },
     misc: {
       postFeedback: new postFeedback(ApiService.USE_LIVE_API),

--- a/src/app/apiAndObjects/api/intervention/interventionData/patchInterventionData.ts
+++ b/src/app/apiAndObjects/api/intervention/interventionData/patchInterventionData.ts
@@ -31,5 +31,5 @@ export class PatchInterventionData extends CacheableEndpoint<
 
 export interface PatchInterventionDataParams {
   interventionId: string;
-  data: Record<string, unknown>;
+  data: Array<Record<string, unknown>>;
 }

--- a/src/app/apiAndObjects/api/mapsHttpResponseHandler.ts
+++ b/src/app/apiAndObjects/api/mapsHttpResponseHandler.ts
@@ -52,32 +52,34 @@ export class MapsHttpResponseHandler {
     // TODO: Check response meta
     // TODO: Output to console?
     // console.debug(res);
-    const body = res.error; // .error is the body of the response?
-    let returnValue: ApiResponse;
-    let errorMessage = '';
+    if (res.error) {
+      const body = res.error; // .error is the body of the response?
+      let returnValue: ApiResponse;
+      let errorMessage = '';
 
-    switch (true) {
-      case res.ok === false:
-        errorMessage = res.message;
-        break;
-      case res.status === 404 && typeof body !== 'string':
-        returnValue = body;
-        break; // just an empty dataset
-      case typeof body !== 'string':
-        errorMessage = body.msg;
-        break;
-      default:
-        errorMessage = res.message;
-        break;
-    }
-    // console.debug('error message', errorMessage, returnValue, res);
+      switch (true) {
+        case res.ok === false:
+          errorMessage = res.message;
+          break;
+        case res.status === 404 && typeof body !== 'string':
+          returnValue = body;
+          break; // just an empty dataset
+        case typeof body !== 'string':
+          errorMessage = body.msg;
+          break;
+        default:
+          errorMessage = res.message;
+          break;
+      }
+      // console.debug('error message', errorMessage, returnValue, res);
 
-    if (errorMessage) {
-      console.error('API access error - ', errorMessage);
-      this.notificationsService.sendNegative('API Error - ', 'A call to retrieve data failed');
-      return Promise.reject(errorMessage);
-    } else {
-      return Promise.resolve(returnValue);
+      if (errorMessage) {
+        console.error('API access error - ', errorMessage);
+        this.notificationsService.sendNegative('API Error - ', 'A call to retrieve data failed');
+        return Promise.reject(errorMessage);
+      } else {
+        return Promise.resolve(returnValue);
+      }
     }
   }
 }

--- a/src/app/components/footer/footer.component.html
+++ b/src/app/components/footer/footer.component.html
@@ -1,22 +1,21 @@
 <footer>
-    <hr>
-    <div class="container">
-        <div>
-            <h3>MAPS</h3>
-            <a [routerLink]="ROUTES.MAPS_TOOL | route">MAPS Tool</a>
-            <a [routerLink]="ROUTES.EDUCATIONAL_RESOURCES | route">Educational Resources</a>
-            <a [routerLink]="ROUTES.PROJECT_OBJECTIVES | route">Project Objectives</a>
-        </div>
-        <div>
-            <h3>Help</h3>
-            <a [routerLink]="ROUTES.HELP | route">Help & Documentation</a>
-            <a>Downloads</a>
-        </div>
-        <div>
-            <h3>About</h3>
-            <a>Partners</a>
-            <a>Social media</a>
-            <a [routerLink]="ROUTES.STYLE_GUIDE | route">Style guide</a>
-        </div>
+  <hr>
+  <div class="container">
+    <div>
+      <h3>MAPS</h3>
+      <a [routerLink]="ROUTES.MAPS_TOOL | route">MAPS Tool</a>
+      <a [routerLink]="ROUTES.EDUCATIONAL_RESOURCES | route">Educational Resources</a>
+      <a [routerLink]="ROUTES.PROJECT_OBJECTIVES | route">Project Objectives</a>
     </div>
+    <div>
+      <h3>Help</h3>
+      <a [routerLink]="ROUTES.HELP | route">Help & Documentation</a>
+      <a>Downloads</a>
+    </div>
+    <div>
+      <h3>About</h3>
+      <a>Partners</a>
+      <a>Social media</a>
+    </div>
+  </div>
 </footer>

--- a/src/app/guards/featureFlagGuard.ts
+++ b/src/app/guards/featureFlagGuard.ts
@@ -7,7 +7,7 @@ export class FeatureFlagGuard implements CanActivate, CanLoad {
   constructor(private featureFlagsService: FeatureFlagsService, private router: Router) {}
 
   canActivate(route: ActivatedRouteSnapshot): boolean | UrlTree {
-    console.log(`Checking ${route.data.featureFlag} flag before activating route`);
+    // console.log(`Checking ${route.data.featureFlag} flag before activating route`);
     const flagIsEnabled = this.featureFlagsService.isEnabled(route.data.featureFlag);
     // console.log(`State: ${flagIsEnabled}`);
     if (!flagIsEnabled) {

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCostSummary/interventionCostSummary.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCostSummary/interventionCostSummary.component.html
@@ -58,7 +58,7 @@
   <footer>
     <a class="intervention-navigation" mat-stroked-button
       [routerLink]="ROUTES.INTERVENTION_REVIEW_RECURRING_COSTS | route" queryParamsHandling="preserve">Back</a>
-    <a class="intervention-navigation-confirm" mat-stroked-button
-      [routerLink]="ROUTES.QUICK_MAPS_COST_EFFECTIVENESS | route" queryParamsHandling="preserve">Confirm costs</a>
+    <a class="intervention-navigation-confirm" mat-stroked-button (click)="onSubmit()"
+      queryParamsHandling="preserve">Confirm costs</a>
   </footer>
 </div>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCostSummary/interventionCostSummary.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCostSummary/interventionCostSummary.component.ts
@@ -9,7 +9,6 @@ import { InterventionDataService } from 'src/app/services/interventionData.servi
 import { InterventionSideNavContentService } from '../../components/interventionSideNavContent/interventionSideNavContent.service';
 import { Router, ActivatedRoute } from '@angular/router';
 
-
 @Component({
   selector: 'app-intervention-cost-summary',
   templateUrl: './interventionCostSummary.component.html',
@@ -35,8 +34,9 @@ export class InterventionCostSummaryComponent implements OnInit {
     private interventionDataService: InterventionDataService,
     private cdRef: ChangeDetectorRef,
     private router: Router,
-    private route: ActivatedRoute
-  ) { }
+    private route: ActivatedRoute,
+  ) {}
+
   public ngOnInit(): void {
     this.intSideNavService.setCurrentStepperPosition(this.pageStepperPosition);
     const activeInterventionId = this.interventionDataService.getActiveInterventionId();
@@ -80,23 +80,25 @@ export class InterventionCostSummaryComponent implements OnInit {
     }
   }
 
-  onSubmit(): void {
-    const interventionChanges = this.interventionDataService.getInterventionDataChanges()
+  public onSubmit(): void {
+    const interventionChanges = this.interventionDataService.getInterventionDataChanges();
     if (interventionChanges) {
-      const dataArr = []
+      const dataArr = [];
       for (const key in interventionChanges) {
         dataArr.push(interventionChanges[key]);
       }
 
-      const interventionId = this.interventionDataService.getActiveInterventionId()
-      this.interventionDataService.patchInterventionData(interventionId, dataArr).then(response => {
+      const interventionId = this.interventionDataService.getActiveInterventionId();
+      this.interventionDataService.patchInterventionData(interventionId, dataArr).then((response) => {
         console.log(response); // patch response does not have body. msg, data etc are null
       });
 
-      this.interventionDataService.setInterventionDataChanges(null)
+      this.interventionDataService.setInterventionDataChanges(null);
     }
 
     // navigate back to list of selected interventions
-    this.router.navigate(this.ROUTES.QUICK_MAPS_COST_EFFECTIVENESS.getRoute(), { queryParams: this.route.snapshot.queryParams });
+    this.router.navigate(this.ROUTES.QUICK_MAPS_COST_EFFECTIVENESS.getRoute(), {
+      queryParams: this.route.snapshot.queryParams,
+    });
   }
 }

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCostSummary/interventionCostSummary.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCostSummary/interventionCostSummary.component.ts
@@ -7,6 +7,8 @@ import { InterventionStartupCosts, StartUpScaleUpCost } from 'src/app/apiAndObje
 import { AppRoutes } from 'src/app/routes/routes';
 import { InterventionDataService } from 'src/app/services/interventionData.service';
 import { InterventionSideNavContentService } from '../../components/interventionSideNavContent/interventionSideNavContent.service';
+import { Router, ActivatedRoute } from '@angular/router';
+
 
 @Component({
   selector: 'app-intervention-cost-summary',
@@ -32,7 +34,9 @@ export class InterventionCostSummaryComponent implements OnInit {
     private intSideNavService: InterventionSideNavContentService,
     private interventionDataService: InterventionDataService,
     private cdRef: ChangeDetectorRef,
-  ) {}
+    private router: Router,
+    private route: ActivatedRoute
+  ) { }
   public ngOnInit(): void {
     this.intSideNavService.setCurrentStepperPosition(this.pageStepperPosition);
     const activeInterventionId = this.interventionDataService.getActiveInterventionId();
@@ -74,5 +78,25 @@ export class InterventionCostSummaryComponent implements OnInit {
         }),
       );
     }
+  }
+
+  onSubmit(): void {
+    const interventionChanges = this.interventionDataService.getIndustryInformationChanges()
+    if (interventionChanges) {
+      const dataArr = []
+      for (const idx in Object.keys(interventionChanges)) {
+        dataArr.push(interventionChanges[idx]);
+      }
+
+      const interventionId = this.interventionDataService.getActiveInterventionId()
+      this.interventionDataService.patchInterventionData(interventionId, dataArr).then(response => {
+        console.log(response); // patch response does not have body. msg, data etc are null
+      });
+
+      this.interventionDataService.setIndustryInformationChanges(null)
+    }
+
+    // navigate back to list of selected interventions
+    this.router.navigate(this.ROUTES.QUICK_MAPS_COST_EFFECTIVENESS.getRoute(), { queryParams: this.route.snapshot.queryParams });
   }
 }

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCostSummary/interventionCostSummary.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCostSummary/interventionCostSummary.component.ts
@@ -81,11 +81,11 @@ export class InterventionCostSummaryComponent implements OnInit {
   }
 
   onSubmit(): void {
-    const interventionChanges = this.interventionDataService.getIndustryInformationChanges()
+    const interventionChanges = this.interventionDataService.getInterventionDataChanges()
     if (interventionChanges) {
       const dataArr = []
-      for (const idx in Object.keys(interventionChanges)) {
-        dataArr.push(interventionChanges[idx]);
+      for (const key in interventionChanges) {
+        dataArr.push(interventionChanges[key]);
       }
 
       const interventionId = this.interventionDataService.getActiveInterventionId()
@@ -93,7 +93,7 @@ export class InterventionCostSummaryComponent implements OnInit {
         console.log(response); // patch response does not have body. msg, data etc are null
       });
 
-      this.interventionDataService.setIndustryInformationChanges(null)
+      this.interventionDataService.setInterventionDataChanges(null)
     }
 
     // navigate back to list of selected interventions

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCostSummary/interventionCostSummary.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCostSummary/interventionCostSummary.component.ts
@@ -81,21 +81,6 @@ export class InterventionCostSummaryComponent implements OnInit {
   }
 
   public onSubmit(): void {
-    const interventionChanges = this.interventionDataService.getInterventionDataChanges();
-    if (interventionChanges) {
-      const dataArr = [];
-      for (const key in interventionChanges) {
-        dataArr.push(interventionChanges[key]);
-      }
-
-      const interventionId = this.interventionDataService.getActiveInterventionId();
-      this.interventionDataService.patchInterventionData(interventionId, dataArr).then((response) => {
-        console.log(response); // patch response does not have body. msg, data etc are null
-      });
-
-      this.interventionDataService.setInterventionDataChanges(null);
-    }
-
     // navigate back to list of selected interventions
     this.router.navigate(this.ROUTES.QUICK_MAPS_COST_EFFECTIVENESS.getRoute(), {
       queryParams: this.route.snapshot.queryParams,

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.html
@@ -151,7 +151,8 @@
     <a class="intervention-navigation" mat-stroked-button [routerLink]="ROUTES.QUICK_MAPS_COST_EFFECTIVENESS | route"
       queryParamsHandling="preserve">Save and close</a>
     <a class="intervention-navigation-confirm" mat-stroked-button
-      [routerLink]="ROUTES.INTERVENTION_REVIEW_MONITORING_INFORMATION | route" queryParamsHandling="preserve">Confirm
+      [routerLink]="ROUTES.INTERVENTION_REVIEW_MONITORING_INFORMATION | route" queryParamsHandling="preserve"
+      (click)="confirmAndContinue()">Confirm
       and
       continue</a>
   </footer>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.html
@@ -15,10 +15,10 @@
           <th class="column-title" mat-header-cell *matHeaderCellDef> 2021 </th>
           <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
-              <input type="number" matInput required formControlName="year0">
+              <input type="text" appDecimalInput required [value]=element.year0 formControlName="year0">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input type="number" [value]="element.year0 * 100"
+              <input type="text" appDecimalInput [value]="element.year0 * 100"
                 (input)="element.year0 = $any($event.target).value / 100">
             </div>
           </td>
@@ -27,10 +27,10 @@
           <th class="column-title" mat-header-cell *matHeaderCellDef> 2022 </th>
           <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
-              <input type="number" matInput required [value]=element.year1 formControlName="year1">
+              <input type="text" appDecimalInput required [value]=element.year1 formControlName="year1">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input type="number" [value]="element.year1 * 100"
+              <input type="text" appDecimalInput [value]="element.year1 * 100"
                 (input)="element.year1 = $any($event.target).value / 100">
             </div>
           </td>
@@ -39,10 +39,10 @@
           <th class="column-title" mat-header-cell *matHeaderCellDef> 2023 </th>
           <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
-              <input type="number" matInput required [value]=element.year2 formControlName="year2">
+              <input type="text" appDecimalInput required [value]=element.year2 formControlName="year2">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input type="number" [value]="element.year2 * 100"
+              <input type="text" appDecimalInput [value]="element.year2 * 100"
                 (input)="element.year2 = $any($event.target).value / 100">
             </div>
           </td>
@@ -51,10 +51,10 @@
           <th class="column-title" mat-header-cell *matHeaderCellDef> 2024 </th>
           <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
-              <input type="number" matInput required [value]=element.year3 formControlName="year3">
+              <input type="text" appDecimalInput required [value]=element.year3 formControlName="year3">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input type="number" [value]="element.year3 * 100"
+              <input type="text" appDecimalInput [value]="element.year3 * 100"
                 (input)="element.year3 = $any($event.target).value / 100">
             </div>
           </td>
@@ -63,10 +63,10 @@
           <th class="column-title" mat-header-cell *matHeaderCellDef> 2025 </th>
           <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
-              <input type="number" matInput required [value]=element.year4 formControlName="year4">
+              <input type="text" appDecimalInput required [value]=element.year4 formControlName="year4">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input type="number" [value]="element.year4 * 100"
+              <input type="text" appDecimalInput [value]="element.year4 * 100"
                 (input)="element.year4 = $any($event.target).value / 100">
             </div>
           </td>
@@ -75,10 +75,10 @@
           <th class="column-title" mat-header-cell *matHeaderCellDef> 2026 </th>
           <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
-              <input type="number" matInput required [value]=element.year5 formControlName="year5">
+              <input type="text" appDecimalInput required [value]=element.year5 formControlName="year5">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input type="number" [value]="element.year5 * 100"
+              <input type="text" appDecimalInput [value]="element.year5 * 100"
                 (input)="element.year5 = $any($event.target).value / 100">
             </div>
           </td>
@@ -87,10 +87,10 @@
           <th class="column-title" mat-header-cell *matHeaderCellDef> 2027</th>
           <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
-              <input type="number" matInput required [value]=element.year6 formControlName="year6">
+              <input type="text" appDecimalInput required [value]=element.year6 formControlName="year6">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input type="number" [value]="element.year6 * 100"
+              <input type="text" appDecimalInput [value]="element.year6 * 100"
                 (input)="element.year6 = $any($event.target).value / 100">
             </div>
           </td>
@@ -99,10 +99,10 @@
           <th class="column-title" mat-header-cell *matHeaderCellDef> 2028 </th>
           <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
-              <input type="number" matInput required [value]=element.year7 formControlName="year7">
+              <input type="text" appDecimalInput required [value]=element.year7 formControlName="year7">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input type="number" [value]="element.year7 * 100"
+              <input type="text" appDecimalInput [value]="element.year7 * 100"
                 (input)="element.year7 = $any($event.target).value / 100">
             </div>
           </td>
@@ -111,10 +111,10 @@
           <th class="column-title" mat-header-cell *matHeaderCellDef> 2029 </th>
           <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
-              <input type="number" matInput required [value]=element.year8 formControlName="year8">
+              <input type="text" appDecimalInput required [value]=element.year8 formControlName="year8">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input type="number" [value]="element.year8 * 100"
+              <input type="text" appDecimalInput [value]="element.year8 * 100"
                 (input)="element.year8 = $any($event.target).value / 100">
             </div>
           </td>
@@ -123,10 +123,10 @@
           <th class="column-title" mat-header-cell *matHeaderCellDef> 2030 </th>
           <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
-              <input type="number" matInput required [value]=element.year9 formControlName="year9">
+              <input type="text" appDecimalInput required [value]=element.year9 formControlName="year9">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input type="number" [value]="element.year9 * 100"
+              <input type="text" appDecimalInput [value]="element.year9 * 100"
                 (input)="element.year9 = $any($event.target).value / 100">
             </div>
           </td>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.html
@@ -4,141 +4,143 @@
     <div class="title">
       <span> Industry Information </span>
     </div>
-    <table mat-table [dataSource]="dataSource">
-      <ng-container matColumnDef="labelText">
-        <th class="row-title" mat-header-cell *matHeaderCellDef> Intervention year </th>
-        <td class="row-title" mat-cell *matCellDef="let element">
-          {{element.labelText}} </td>
-      </ng-container>
-      <ng-container matColumnDef="year0">
-        <th class="column-title" mat-header-cell *matHeaderCellDef> 2021 </th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-          <div *ngIf="element.rowUnits === 'number'">
-            <input type="text" appDecimalInput required [value]=element.year0>
-          </div>
-          <div *ngIf="element.rowUnits === 'percent'">
-            <input type="text" appDecimalInput [value]="element.year0 * 100"
-              (input)="element.year0 = $any($event.target).value / 100">
-          </div>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="year1">
-        <th class="column-title" mat-header-cell *matHeaderCellDef> 2022 </th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-          <div *ngIf="element.rowUnits === 'number'">
-            <input type="text" appDecimalInput required [value]=element.year1>
-          </div>
-          <div *ngIf="element.rowUnits === 'percent'">
-            <input type="text" appDecimalInput [value]="element.year1 * 100"
-              (input)="element.year1 = $any($event.target).value / 100">
-          </div>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="year2">
-        <th class="column-title" mat-header-cell *matHeaderCellDef> 2023 </th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-          <div *ngIf="element.rowUnits === 'number'">
-            <input type="text" appDecimalInput required [value]=element.year2>
-          </div>
-          <div *ngIf="element.rowUnits === 'percent'">
-            <input type="text" appDecimalInput [value]="element.year2 * 100"
-              (input)="element.year2 = $any($event.target).value / 100">
-          </div>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="year3">
-        <th class="column-title" mat-header-cell *matHeaderCellDef> 2024 </th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-          <div *ngIf="element.rowUnits === 'number'">
-            <input type="text" appDecimalInput required [value]=element.year3>
-          </div>
-          <div *ngIf="element.rowUnits === 'percent'">
-            <input type="text" appDecimalInput [value]="element.year3 * 100"
-              (input)="element.year3 = $any($event.target).value / 100">
-          </div>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="year4">
-        <th class="column-title" mat-header-cell *matHeaderCellDef> 2025 </th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-          <div *ngIf="element.rowUnits === 'number'">
-            <input type="text" appDecimalInput required [value]=element.year4>
-          </div>
-          <div *ngIf="element.rowUnits === 'percent'">
-            <input type="text" appDecimalInput [value]="element.year4 * 100"
-              (input)="element.year4 = $any($event.target).value / 100">
-          </div>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="year5">
-        <th class="column-title" mat-header-cell *matHeaderCellDef> 2026 </th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-          <div *ngIf="element.rowUnits === 'number'">
-            <input type="text" appDecimalInput required [value]=element.year5>
-          </div>
-          <div *ngIf="element.rowUnits === 'percent'">
-            <input type="text" appDecimalInput [value]="element.year5 * 100"
-              (input)="element.year5 = $any($event.target).value / 100">
-          </div>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="year6">
-        <th class="column-title" mat-header-cell *matHeaderCellDef> 2027</th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-          <div *ngIf="element.rowUnits === 'number'">
-            <input type="text" appDecimalInput required [value]=element.year6>
-          </div>
-          <div *ngIf="element.rowUnits === 'percent'">
-            <input type="text" appDecimalInput [value]="element.year6 * 100"
-              (input)="element.year6 = $any($event.target).value / 100">
-          </div>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="year7">
-        <th class="column-title" mat-header-cell *matHeaderCellDef> 2028 </th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-          <div *ngIf="element.rowUnits === 'number'">
-            <input type="text" appDecimalInput required [value]=element.year7>
-          </div>
-          <div *ngIf="element.rowUnits === 'percent'">
-            <input type="text" appDecimalInput [value]="element.year7 * 100"
-              (input)="element.year7 = $any($event.target).value / 100">
-          </div>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="year8">
-        <th class="column-title" mat-header-cell *matHeaderCellDef> 2029 </th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-          <div *ngIf="element.rowUnits === 'number'">
-            <input type="text" appDecimalInput required [value]=element.year8>
-          </div>
-          <div *ngIf="element.rowUnits === 'percent'">
-            <input type="text" appDecimalInput [value]="element.year8 * 100"
-              (input)="element.year8 = $any($event.target).value / 100">
-          </div>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="year9">
-        <th class="column-title" mat-header-cell *matHeaderCellDef> 2030 </th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-          <div *ngIf="element.rowUnits === 'number'">
-            <input type="text" appDecimalInput required [value]=element.year9>
-          </div>
-          <div *ngIf="element.rowUnits === 'percent'">
-            <input type="text" appDecimalInput [value]="element.year9 * 100"
-              (input)="element.year9 = $any($event.target).value / 100">
-          </div>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="source">
-        <th class="column-title" mat-header-cell *matHeaderCellDef> Source </th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-          GFDx
-        </td>
-      </ng-container>
-      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-      <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
-    </table>
+    <form [formGroup]="form">
+      <table mat-table [dataSource]="dataSource" formArrayName="items">
+        <ng-container matColumnDef="labelText">
+          <th class="row-title" mat-header-cell *matHeaderCellDef> Intervention year </th>
+          <td class="row-title" mat-cell *matCellDef="let element">
+            {{element.labelText}} </td>
+        </ng-container>
+        <ng-container matColumnDef="year0">
+          <th class="column-title" mat-header-cell *matHeaderCellDef> 2021 </th>
+          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+            <div *ngIf="element.rowUnits === 'number'">
+              <input type="number" matInput required formControlName="year0">
+            </div>
+            <div *ngIf="element.rowUnits === 'percent'">
+              <input type="number" [value]="element.year0 * 100"
+                (input)="element.year0 = $any($event.target).value / 100">
+            </div>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="year1">
+          <th class="column-title" mat-header-cell *matHeaderCellDef> 2022 </th>
+          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+            <div *ngIf="element.rowUnits === 'number'">
+              <input type="number" matInput required [value]=element.year1 formControlName="year1">
+            </div>
+            <div *ngIf="element.rowUnits === 'percent'">
+              <input type="number" [value]="element.year1 * 100"
+                (input)="element.year1 = $any($event.target).value / 100">
+            </div>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="year2">
+          <th class="column-title" mat-header-cell *matHeaderCellDef> 2023 </th>
+          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+            <div *ngIf="element.rowUnits === 'number'">
+              <input type="number" matInput required [value]=element.year2 formControlName="year2">
+            </div>
+            <div *ngIf="element.rowUnits === 'percent'">
+              <input type="number" [value]="element.year2 * 100"
+                (input)="element.year2 = $any($event.target).value / 100">
+            </div>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="year3">
+          <th class="column-title" mat-header-cell *matHeaderCellDef> 2024 </th>
+          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+            <div *ngIf="element.rowUnits === 'number'">
+              <input type="number" matInput required [value]=element.year3 formControlName="year3">
+            </div>
+            <div *ngIf="element.rowUnits === 'percent'">
+              <input type="number" [value]="element.year3 * 100"
+                (input)="element.year3 = $any($event.target).value / 100">
+            </div>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="year4">
+          <th class="column-title" mat-header-cell *matHeaderCellDef> 2025 </th>
+          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+            <div *ngIf="element.rowUnits === 'number'">
+              <input type="number" matInput required [value]=element.year4 formControlName="year4">
+            </div>
+            <div *ngIf="element.rowUnits === 'percent'">
+              <input type="number" [value]="element.year4 * 100"
+                (input)="element.year4 = $any($event.target).value / 100">
+            </div>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="year5">
+          <th class="column-title" mat-header-cell *matHeaderCellDef> 2026 </th>
+          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+            <div *ngIf="element.rowUnits === 'number'">
+              <input type="number" matInput required [value]=element.year5 formControlName="year5">
+            </div>
+            <div *ngIf="element.rowUnits === 'percent'">
+              <input type="number" [value]="element.year5 * 100"
+                (input)="element.year5 = $any($event.target).value / 100">
+            </div>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="year6">
+          <th class="column-title" mat-header-cell *matHeaderCellDef> 2027</th>
+          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+            <div *ngIf="element.rowUnits === 'number'">
+              <input type="number" matInput required [value]=element.year6 formControlName="year6">
+            </div>
+            <div *ngIf="element.rowUnits === 'percent'">
+              <input type="number" [value]="element.year6 * 100"
+                (input)="element.year6 = $any($event.target).value / 100">
+            </div>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="year7">
+          <th class="column-title" mat-header-cell *matHeaderCellDef> 2028 </th>
+          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+            <div *ngIf="element.rowUnits === 'number'">
+              <input type="number" matInput required [value]=element.year7 formControlName="year7">
+            </div>
+            <div *ngIf="element.rowUnits === 'percent'">
+              <input type="number" [value]="element.year7 * 100"
+                (input)="element.year7 = $any($event.target).value / 100">
+            </div>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="year8">
+          <th class="column-title" mat-header-cell *matHeaderCellDef> 2029 </th>
+          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+            <div *ngIf="element.rowUnits === 'number'">
+              <input type="number" matInput required [value]=element.year8 formControlName="year8">
+            </div>
+            <div *ngIf="element.rowUnits === 'percent'">
+              <input type="number" [value]="element.year8 * 100"
+                (input)="element.year8 = $any($event.target).value / 100">
+            </div>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="year9">
+          <th class="column-title" mat-header-cell *matHeaderCellDef> 2030 </th>
+          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+            <div *ngIf="element.rowUnits === 'number'">
+              <input type="number" matInput required [value]=element.year9 formControlName="year9">
+            </div>
+            <div *ngIf="element.rowUnits === 'percent'">
+              <input type="number" [value]="element.year9 * 100"
+                (input)="element.year9 = $any($event.target).value / 100">
+            </div>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="source">
+          <th class="column-title" mat-header-cell *matHeaderCellDef> Source </th>
+          <td class="column-title" mat-cell *matCellDef="let element">
+            GFDx
+          </td>
+        </ng-container>
+        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+      </table>
+    </form>
 
     <app-intervention-step-details [resetDefaultValues]="true" [showFocusMn]="true" [showUserValues]="true"
       [showMnUnits]="true"></app-intervention-step-details>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.html
@@ -4,7 +4,7 @@
     <div class="title">
       <span> Industry Information </span>
     </div>
-    <form [formGroup]="form">
+    <form [formGroup]="form" *ngIf="form">
       <table mat-table [dataSource]="dataSource" formArrayName="items">
         <ng-container matColumnDef="labelText">
           <th class="row-title" mat-header-cell *matHeaderCellDef> Intervention year </th>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.ts
@@ -5,19 +5,10 @@ import {
   InterventionIndustryInformation,
 } from 'src/app/apiAndObjects/objects/interventionIndustryInformation';
 import { AppRoutes } from 'src/app/routes/routes';
-import { InterventionDataService } from 'src/app/services/interventionData.service';
+import { InterventionDataService, InterventionForm } from 'src/app/services/interventionData.service';
 import { InterventionSideNavContentService } from '../../components/interventionSideNavContent/interventionSideNavContent.service';
 import { FormBuilder, FormArray, FormGroup } from '@angular/forms';
 import { pairwise, map, filter, startWith } from 'rxjs/operators';
-import { Router } from '@angular/router';
-
-interface IForm {
-  formChanges: {
-    [row: number]: {
-      [col: string]: string;
-    };
-  };
-}
 
 @Component({
   selector: 'app-intervention-industry-information',
@@ -45,13 +36,12 @@ export class InterventionIndustryInformationComponent implements OnInit {
   public pageStepperPosition = 3;
   public interventionName = 'IntName';
   public form: FormGroup;
-  public formChanges: IForm['formChanges'] = {};
+  public formChanges: InterventionForm['formChanges'] = {};
 
   constructor(
     private intSideNavService: InterventionSideNavContentService,
     private interventionDataService: InterventionDataService,
     private formBuilder: FormBuilder,
-    private router: Router,
   ) {}
 
   /**
@@ -97,12 +87,12 @@ export class InterventionIndustryInformationComponent implements OnInit {
                         if (changes[rowIndex]) {
                           changes[rowIndex] = {
                             ...changes[rowIndex],
-                            [item[0]]: item[1],
+                            [item[0]]: Number(item[1]),
                           };
                           changes[rowIndex]['rowIndex'] = rowIndex;
                         } else {
                           changes[rowIndex] = {
-                            [item[0]]: item[1],
+                            [item[0]]: Number(item[1]),
                           };
                           changes[rowIndex]['rowIndex'] = rowIndex;
                         }
@@ -115,7 +105,6 @@ export class InterventionIndustryInformationComponent implements OnInit {
               filter((changes) => Object.keys(changes).length !== 0 && !this.form.invalid),
             )
             .subscribe((value) => {
-              console.log(value);
               this.formChanges = value;
               const newInterventionChanges = {
                 ...this.interventionDataService.getInterventionDataChanges(),
@@ -134,16 +123,16 @@ export class InterventionIndustryInformationComponent implements OnInit {
   private createIndustryGroup(item: IndustryInformation): FormGroup {
     return this.formBuilder.group({
       rowIndex: [item.rowIndex, []],
-      year0: [item.year0, []],
-      year1: [item.year1, []],
-      year2: [item.year2, []],
-      year3: [item.year3, []],
-      year4: [item.year4, []],
-      year5: [item.year5, []],
-      year6: [item.year6, []],
-      year7: [item.year7, []],
-      year8: [item.year8, []],
-      year9: [item.year9, []],
+      year0: [Number(item.year0), []],
+      year1: [Number(item.year1), []],
+      year2: [Number(item.year2), []],
+      year3: [Number(item.year3), []],
+      year4: [Number(item.year4), []],
+      year5: [Number(item.year5), []],
+      year6: [Number(item.year6), []],
+      year7: [Number(item.year7), []],
+      year8: [Number(item.year8), []],
+      year9: [Number(item.year9), []],
     });
   }
 

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.ts
@@ -9,13 +9,14 @@ import { InterventionDataService } from 'src/app/services/interventionData.servi
 import { InterventionSideNavContentService } from '../../components/interventionSideNavContent/interventionSideNavContent.service';
 import { FormBuilder, FormArray, FormGroup } from '@angular/forms';
 import { pairwise, map, filter, startWith } from 'rxjs/operators';
+import { Router } from '@angular/router';
 
 interface IForm {
   formChanges: {
     [row: number]: {
       [col: string]: string;
-    }
-  }
+    };
+  };
 }
 
 @Component({
@@ -50,6 +51,7 @@ export class InterventionIndustryInformationComponent implements OnInit {
     private intSideNavService: InterventionSideNavContentService,
     private interventionDataService: InterventionDataService,
     private formBuilder: FormBuilder,
+    private router: Router,
   ) {}
 
   /**
@@ -69,7 +71,6 @@ export class InterventionIndustryInformationComponent implements OnInit {
         .getInterventionIndustryInformation(activeInterventionId)
         .then((data: InterventionIndustryInformation) => {
           this.dataSource = new MatTableDataSource(data.industryInformation);
-
           const industryGroupArr = data.industryInformation.map((item) => {
             return this.createIndustryGroup(item);
           });
@@ -149,5 +150,9 @@ export class InterventionIndustryInformationComponent implements OnInit {
   public ngOnInit(): void {
     this.intSideNavService.setCurrentStepperPosition(this.pageStepperPosition);
     this.initFormWatcher();
+  }
+
+  public confirmAndContinue(): void {
+    this.interventionDataService.interventionPageConfirmContinue();
   }
 }

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.ts
@@ -1,36 +1,24 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { MatTableDataSource } from '@angular/material/table';
 import {
-  IndustryInformation,
   InterventionIndustryInformation,
 } from 'src/app/apiAndObjects/objects/interventionIndustryInformation';
 import { AppRoutes } from 'src/app/routes/routes';
 import { InterventionDataService } from 'src/app/services/interventionData.service';
 import { InterventionSideNavContentService } from '../../components/interventionSideNavContent/interventionSideNavContent.service';
+import { FormBuilder, FormArray, FormGroup } from '@angular/forms';
+import { Unsubscriber } from 'src/app/decorators/unsubscriber.decorator';
+import { Subscription } from 'rxjs';
+import { pairwise, map } from 'rxjs/operators';
 
+@Unsubscriber('subscriptions')
 @Component({
   selector: 'app-intervention-industry-information',
   templateUrl: './interventionIndustryInformation.component.html',
   styleUrls: ['./interventionIndustryInformation.component.scss'],
 })
-export class InterventionIndustryInformationComponent implements OnInit, OnDestroy {
-  publiciIndustryInformation: IndustryInformation;
-  public testInput: number;
-
-  constructor(
-    private intSideNavService: InterventionSideNavContentService,
-    private interventionDataService: InterventionDataService,
-  ) {
-    const activeInterventionId = this.interventionDataService.getActiveInterventionId();
-    if (null != activeInterventionId) {
-      void this.interventionDataService
-        .getInterventionIndustryInformation(activeInterventionId)
-        .then((data: InterventionIndustryInformation) => {
-          this.init(data);
-        });
-    }
-  }
-  displayedColumns: string[] = [
+export class InterventionIndustryInformationComponent implements OnInit {
+  public displayedColumns: string[] = [
     'labelText',
     'year0',
     'year1',
@@ -44,21 +32,91 @@ export class InterventionIndustryInformationComponent implements OnInit, OnDestr
     'year9',
     'source',
   ];
-  public dataSource = new MatTableDataSource();
 
+  public dataSource = new MatTableDataSource();
   public ROUTES = AppRoutes;
   public pageStepperPosition = 3;
   public interventionName = 'IntName';
+  public form: FormGroup;
+  public formInitialState = [];
+  public formChanges: { [row: number]: { [col: string]: string }; } = {};
+  private subscriptions = new Array<Subscription>();
+
+  constructor(
+    private intSideNavService: InterventionSideNavContentService,
+    private interventionDataService: InterventionDataService,
+    private formBuilder: FormBuilder
+  ) {
+    const activeInterventionId = this.interventionDataService.getActiveInterventionId();
+    if (null != activeInterventionId) {
+      void this.interventionDataService
+        .getInterventionIndustryInformation(activeInterventionId)
+        .then((data: InterventionIndustryInformation) => {
+          this.dataSource = new MatTableDataSource(data.industryInformation);
+
+          const industryGroupArr = data.industryInformation.map(item => {
+            this.formInitialState.push(item)
+            return this.createIndustryGroup(item)
+          });
+          this.form = this.formBuilder.group({
+            items: this.formBuilder.array(industryGroupArr)
+          });
+
+          for (const key of Object.keys(this.industryArray)) {
+            const subscription = this.form.get('items')['controls'][key].valueChanges.pipe(pairwise(), map(([prev, next]) => {
+              const changes = {};
+              for (const idx in next) {
+                if (prev[idx] !== next[idx] && prev[idx] !== undefined) {
+                  changes[idx] = next[idx];
+                }
+              }
+              return changes;
+            })).subscribe(value => {
+              this.formChanges[key] = Object.assign({}, this.formChanges[key], {
+                [Object.keys(value).shift()]: Object.values(value).shift()
+              });
+
+              //if value is the same as initial value, remove from this.formChanges as a PUT request for the same value is not neccessary
+              Object.keys(this.formChanges).forEach((row) => {
+                Object.keys(this.formChanges[row]).forEach(col => {
+                  if (this.formInitialState[row][col] === this.formChanges[row][col]) {
+                    console.log('value is now in original state, remove value from changes object')
+                    delete this.formChanges[row][col];
+                    if (Object.keys(this.formChanges[row]).length === 0) {
+                      delete this.formChanges[row];
+                    }
+                  }
+                });
+              });
+              console.log(this.formChanges);
+              console.log(this.formInitialState);
+            });
+            this.subscriptions.push(subscription);
+          }
+        });
+    }
+  }
+
+  get industryArray() {
+    return this.form.get("items")["controls"] as FormArray;
+  }
+
+  createIndustryGroup(item) {
+    return this.formBuilder.group({
+      year0: [item.year0, []],
+      year1: [item.year1, []],
+      year2: [item.year2, []],
+      year3: [item.year3, []],
+      year4: [item.year4, []],
+      year5: [item.year5, []],
+      year6: [item.year6, []],
+      year7: [item.year7, []],
+      year8: [item.year8, []],
+      year9: [item.year9, []],
+    });
+  }
 
   public ngOnInit(): void {
     this.intSideNavService.setCurrentStepperPosition(this.pageStepperPosition);
-  }
-
-  public ngOnDestroy(): void {
-    console.debug('call');
-  }
-
-  private init(data: InterventionIndustryInformation): void {
-    this.dataSource = new MatTableDataSource(data.industryInformation);
   }
 }

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.ts
@@ -77,12 +77,14 @@ export class InterventionIndustryInformationComponent implements OnInit {
                         if (changes[rowIndex]) {
                           changes[rowIndex] = {
                             ...changes[rowIndex],
-                            [item[0]]: item[1]
+                            [item[0]]: item[1],
                           }
+                          changes[rowIndex]['rowIndex'] = rowIndex;
                         } else {
                           changes[rowIndex] = {
                             [item[0]]: item[1],
                           };
+                          changes[rowIndex]['rowIndex'] = rowIndex;
                         }
                       });
                     }

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.ts
@@ -38,8 +38,8 @@ export class InterventionIndustryInformationComponent implements OnInit {
   public pageStepperPosition = 3;
   public interventionName = 'IntName';
   public form: FormGroup;
-  public formInitialState = [];
-  public formChanges: { [row: number]: { [col: string]: string }; } = {};
+  public industryInformationInitialState = [];
+  public industryInformationFormChanges: { [row: number]: { [col: string]: string }; } = {};
   private subscriptions = new Array<Subscription>();
 
   constructor(
@@ -59,7 +59,7 @@ export class InterventionIndustryInformationComponent implements OnInit {
           this.dataSource = new MatTableDataSource(data.industryInformation);
 
           const industryGroupArr = data.industryInformation.map(item => {
-            this.formInitialState.push(item)
+            this.industryInformationInitialState.push(item)
             return this.createIndustryGroup(item)
           });
           this.form = this.formBuilder.group({
@@ -78,28 +78,17 @@ export class InterventionIndustryInformationComponent implements OnInit {
             })).subscribe(value => {
               const interventionDataRowIndex = this.form.get('items')['controls'][key]['controls'].rowIndex.value
 
-              this.formChanges[key] = {
-                ...this.formChanges[key], ...{
+              this.industryInformationFormChanges[interventionDataRowIndex] = {
+                ...this.industryInformationFormChanges[interventionDataRowIndex], ...{
                   [Object.keys(value).shift()]: Object.values(value).shift(),
                   'rowIndex': interventionDataRowIndex
                 }
               };
 
-              //if value is the same as initial value, remove from this.formChanges as a PUT request for the same value is not neccessary
-              Object.keys(this.formChanges).forEach((row) => {
-                Object.keys(this.formChanges[row]).forEach(col => {
-                  if (col !== 'rowIndex') {
-                    if (this.formInitialState[row][col] === this.formChanges[row][col]) {
-                      console.log('value is now in original state, remove value from changes object')
-                      delete this.formChanges[row][col];
-                      if (Object.keys(this.formChanges[row]).length === 0) {
-                        delete this.formChanges[row];
-                      }
-                    }
-                  }
-                });
-              });
-              this.interventionDataService.setIndustryInformationChanges(this.formChanges);
+              const newInterventionChanges = {
+                ...this.interventionDataService.getInterventionDataChanges(), ...this.industryInformationFormChanges
+              };
+              this.interventionDataService.setInterventionDataChanges(newInterventionChanges);
             });
             this.subscriptions.push(subscription);
           }

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionMonitoringInformation/interventionMonitoringInformation.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionMonitoringInformation/interventionMonitoringInformation.component.html
@@ -4,143 +4,144 @@
     <div class="title">
       <span>Program Monitoring Information</span>
     </div>
-    <table mat-table [dataSource]="dataSource">
-      <ng-container matColumnDef="labelText">
-        <th class="row-title" mat-header-cell *matHeaderCellDef> Intervention year </th>
-        <td class="row-title" mat-cell *matCellDef="let element">
-          {{element.labelText}} </td>
-      </ng-container>
-      <ng-container matColumnDef="year0">
-        <th class="column-title" mat-header-cell *matHeaderCellDef> 2021 </th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-          <div *ngIf="element.rowUnits === 'number'">
-            <input type="text" appDecimalInput required [value]=element.year0>
-          </div>
-          <div *ngIf="element.rowUnits === 'percent'">
-            <input type="text" appDecimalInput [value]="element.year0 * 100"
-              (input)="element.year0 = $any($event.target).value / 100">
-          </div>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="year1">
-        <th class="column-title" mat-header-cell *matHeaderCellDef> 2022 </th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-          <div *ngIf="element.rowUnits === 'number'">
-            <input type="text" appDecimalInput required [value]=element.year1>
-          </div>
-          <div *ngIf="element.rowUnits === 'percent'">
-            <input type="text" appDecimalInput [value]="element.year1 * 100"
-              (input)="element.year1 = $any($event.target).value / 100">
-          </div>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="year2">
-        <th class="column-title" mat-header-cell *matHeaderCellDef> 2023 </th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-          <div *ngIf="element.rowUnits === 'number'">
-            <input type="text" appDecimalInput required [value]=element.year2>
-          </div>
-          <div *ngIf="element.rowUnits === 'percent'">
-            <input type="text" appDecimalInput [value]="element.year2 * 100"
-              (input)="element.year2 = $any($event.target).value / 100">
-          </div>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="year3">
-        <th class="column-title" mat-header-cell *matHeaderCellDef> 2024 </th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-          <div *ngIf="element.rowUnits === 'number'">
-            <input type="text" appDecimalInput required [value]=element.year3>
-          </div>
-          <div *ngIf="element.rowUnits === 'percent'">
-            <input type="text" appDecimalInput [value]="element.year3 * 100"
-              (input)="element.year3 = $any($event.target).value / 100">
-          </div>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="year4">
-        <th class="column-title" mat-header-cell *matHeaderCellDef> 2025 </th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-          <div *ngIf="element.rowUnits === 'number'">
-            <input type="text" appDecimalInput required [value]=element.year4>
-          </div>
-          <div *ngIf="element.rowUnits === 'percent'">
-            <input type="text" appDecimalInput [value]="element.year4 * 100"
-              (input)="element.year4 = $any($event.target).value / 100">
-          </div>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="year5">
-        <th class="column-title" mat-header-cell *matHeaderCellDef> 2026 </th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-          <div *ngIf="element.rowUnits === 'number'">
-            <input type="text" appDecimalInput required [value]=element.year5>
-          </div>
-          <div *ngIf="element.rowUnits === 'percent'">
-            <input type="text" appDecimalInput [value]="element.year5 * 100"
-              (input)="element.year5 = $any($event.target).value / 100">
-          </div>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="year6">
-        <th class="column-title" mat-header-cell *matHeaderCellDef> 2027</th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-          <div *ngIf="element.rowUnits === 'number'">
-            <input type="text" appDecimalInput required [value]=element.year6>
-          </div>
-          <div *ngIf="element.rowUnits === 'percent'">
-            <input type="text" appDecimalInput [value]="element.year6 * 100"
-              (input)="element.year6 = $any($event.target).value / 100">
-          </div>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="year7">
-        <th class="column-title" mat-header-cell *matHeaderCellDef> 2028 </th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-          <div *ngIf="element.rowUnits === 'number'">
-            <input type="text" appDecimalInput required [value]=element.year7>
-          </div>
-          <div *ngIf="element.rowUnits === 'percent'">
-            <input type="text" appDecimalInput [value]="element.year7 * 100"
-              (input)="element.year7 = $any($event.target).value / 100">
-          </div>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="year8">
-        <th class="column-title" mat-header-cell *matHeaderCellDef> 2029 </th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-          <div *ngIf="element.rowUnits === 'number'">
-            <input type="text" appDecimalInput required [value]=element.year8>
-          </div>
-          <div *ngIf="element.rowUnits === 'percent'">
-            <input type="text" appDecimalInput [value]="element.year8 * 100"
-              (input)="element.year8 = $any($event.target).value / 100">
-          </div>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="year9">
-        <th class="column-title" mat-header-cell *matHeaderCellDef> 2030 </th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-          <div *ngIf="element.rowUnits === 'number'">
-            <input type="text" appDecimalInput required [value]=element.year9>
-          </div>
-          <div *ngIf="element.rowUnits === 'percent'">
-            <input type="text" appDecimalInput [value]="element.year9 * 100"
-              (input)="element.year9 = $any($event.target).value / 100">
-          </div>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="source">
-        <th class="column-title" mat-header-cell *matHeaderCellDef> Source </th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-          GFDx
-        </td>
-      </ng-container>
+    <form [formGroup]="form" *ngIf="form">
+      <table mat-table [dataSource]="dataSource" formArrayName="items">
+        <ng-container matColumnDef="labelText">
+          <th class="row-title" mat-header-cell *matHeaderCellDef> Intervention year </th>
+          <td class="row-title" mat-cell *matCellDef="let element">
+            {{element.labelText}} </td>
+        </ng-container>
+        <ng-container matColumnDef="year0">
+          <th class="column-title" mat-header-cell *matHeaderCellDef> 2021 </th>
+          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+            <div *ngIf="element.rowUnits === 'number'">
+              <input type="text" appDecimalInput required [value]=element.year0 formControlName="year0">
+            </div>
+            <div *ngIf="element.rowUnits === 'percent'">
+              <input type="text" appDecimalInput [value]="element.year0 * 100"
+                (input)="element.year0 = $any($event.target).value / 100">
+            </div>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="year1">
+          <th class="column-title" mat-header-cell *matHeaderCellDef> 2022 </th>
+          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+            <div *ngIf="element.rowUnits === 'number'">
+              <input type="text" appDecimalInput required [value]=element.year1 formControlName="year1">
+            </div>
+            <div *ngIf="element.rowUnits === 'percent'">
+              <input type="text" appDecimalInput [value]="element.year1 * 100"
+                (input)="element.year1 = $any($event.target).value / 100">
+            </div>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="year2">
+          <th class="column-title" mat-header-cell *matHeaderCellDef> 2023 </th>
+          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+            <div *ngIf="element.rowUnits === 'number'">
+              <input type="text" appDecimalInput required [value]=element.year2 formControlName="year2">
+            </div>
+            <div *ngIf="element.rowUnits === 'percent'">
+              <input type="text" appDecimalInput [value]="element.year2 * 100"
+                (input)="element.year2 = $any($event.target).value / 100">
+            </div>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="year3">
+          <th class="column-title" mat-header-cell *matHeaderCellDef> 2024 </th>
+          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+            <div *ngIf="element.rowUnits === 'number'">
+              <input type="text" appDecimalInput required [value]=element.year3 formControlName="year3">
+            </div>
+            <div *ngIf="element.rowUnits === 'percent'">
+              <input type="text" appDecimalInput [value]="element.year3 * 100"
+                (input)="element.year3 = $any($event.target).value / 100">
+            </div>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="year4">
+          <th class="column-title" mat-header-cell *matHeaderCellDef> 2025 </th>
+          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+            <div *ngIf="element.rowUnits === 'number'">
+              <input type="text" appDecimalInput required [value]=element.year4 formControlName="year4">
+            </div>
+            <div *ngIf="element.rowUnits === 'percent'">
+              <input type="text" appDecimalInput [value]="element.year4 * 100"
+                (input)="element.year4 = $any($event.target).value / 100">
+            </div>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="year5">
+          <th class="column-title" mat-header-cell *matHeaderCellDef> 2026 </th>
+          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+            <div *ngIf="element.rowUnits === 'number'">
+              <input type="text" appDecimalInput required [value]=element.year5 formControlName="year5">
+            </div>
+            <div *ngIf="element.rowUnits === 'percent'">
+              <input type="text" appDecimalInput [value]="element.year5 * 100"
+                (input)="element.year5 = $any($event.target).value / 100">
+            </div>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="year6">
+          <th class="column-title" mat-header-cell *matHeaderCellDef> 2027</th>
+          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+            <div *ngIf="element.rowUnits === 'number'">
+              <input type="text" appDecimalInput required [value]=element.year6 formControlName="year6">
+            </div>
+            <div *ngIf="element.rowUnits === 'percent'">
+              <input type="text" appDecimalInput [value]="element.year6 * 100"
+                (input)="element.year6 = $any($event.target).value / 100">
+            </div>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="year7">
+          <th class="column-title" mat-header-cell *matHeaderCellDef> 2028 </th>
+          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+            <div *ngIf="element.rowUnits === 'number'">
+              <input type="text" appDecimalInput required [value]=element.year7 formControlName="year7">
+            </div>
+            <div *ngIf="element.rowUnits === 'percent'">
+              <input type="text" appDecimalInput [value]="element.year7 * 100"
+                (input)="element.year7 = $any($event.target).value / 100">
+            </div>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="year8">
+          <th class="column-title" mat-header-cell *matHeaderCellDef> 2029 </th>
+          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+            <div *ngIf="element.rowUnits === 'number'">
+              <input type="text" appDecimalInput required [value]=element.year8 formControlName="year8">
+            </div>
+            <div *ngIf="element.rowUnits === 'percent'">
+              <input type="text" appDecimalInput [value]="element.year8 * 100"
+                (input)="element.year8 = $any($event.target).value / 100">
+            </div>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="year9">
+          <th class="column-title" mat-header-cell *matHeaderCellDef> 2030 </th>
+          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+            <div *ngIf="element.rowUnits === 'number'">
+              <input type="text" appDecimalInput required [value]=element.year9 formControlName="year9">
+            </div>
+            <div *ngIf="element.rowUnits === 'percent'">
+              <input type="text" appDecimalInput [value]="element.year9 * 100"
+                (input)="element.year9 = $any($event.target).value / 100">
+            </div>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="source">
+          <th class="column-title" mat-header-cell *matHeaderCellDef> Source </th>
+          <td class="column-title" mat-cell *matCellDef="let element">
+            GFDx
+          </td>
+        </ng-container>
 
-      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-      <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
-    </table>
-
+        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+      </table>
+    </form>
     <app-intervention-step-details [resetDefaultValues]="true" [showFocusMn]="true" [showUserValues]="true"
       [showMnUnits]="true"></app-intervention-step-details>
 
@@ -151,7 +152,8 @@
     <a class="intervention-navigation" mat-stroked-button [routerLink]="ROUTES.QUICK_MAPS_COST_EFFECTIVENESS | route"
       queryParamsHandling="preserve">Save and close</a>
     <a class="intervention-navigation-confirm" mat-stroked-button
-      [routerLink]="ROUTES.INTERVENTION_REVIEW_STARTUP_SCALEUP_COSTS | route" queryParamsHandling="preserve">Confirm and
+      [routerLink]="ROUTES.INTERVENTION_REVIEW_STARTUP_SCALEUP_COSTS | route" queryParamsHandling="preserve"
+      (click)="confirmAndContinue()">Confirm and
       continue</a>
   </footer>
 </div>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionMonitoringInformation/interventionMonitoringInformation.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionMonitoringInformation/interventionMonitoringInformation.component.ts
@@ -1,32 +1,21 @@
 import { Component, OnInit } from '@angular/core';
+import { FormGroup, FormBuilder, FormArray } from '@angular/forms';
 import { MatTableDataSource } from '@angular/material/table';
-import { InterventionMonitoringInformation } from 'src/app/apiAndObjects/objects/interventionMonitoringInformation';
+import {
+  InterventionMonitoringInformation,
+  MonitoringInformation,
+} from 'src/app/apiAndObjects/objects/interventionMonitoringInformation';
 import { QuickMapsService } from 'src/app/pages/quickMaps/quickMaps.service';
 import { AppRoutes } from 'src/app/routes/routes';
-import { InterventionDataService } from 'src/app/services/interventionData.service';
+import { InterventionDataService, InterventionForm } from 'src/app/services/interventionData.service';
 import { InterventionSideNavContentService } from '../../components/interventionSideNavContent/interventionSideNavContent.service';
+import { pairwise, map, filter, startWith } from 'rxjs/operators';
 @Component({
   selector: 'app-intervention-monitoring-information',
   templateUrl: './interventionMonitoringInformation.component.html',
   styleUrls: ['./interventionMonitoringInformation.component.scss'],
 })
 export class InterventionMonitoringInformationComponent implements OnInit {
-  constructor(
-    public quickMapsService: QuickMapsService,
-
-    private intSideNavService: InterventionSideNavContentService,
-    private interventionDataService: InterventionDataService,
-  ) {
-    const activeInterventionId = this.interventionDataService.getActiveInterventionId();
-    if (null != activeInterventionId) {
-      this.interventionDataService
-        .getInterventionMonitoringInformation(activeInterventionId)
-        .then((data: InterventionMonitoringInformation) => {
-          this.init(data);
-        });
-    }
-  }
-
   displayedColumns: string[] = [
     'labelText',
     'year0',
@@ -45,13 +34,114 @@ export class InterventionMonitoringInformationComponent implements OnInit {
   public ROUTES = AppRoutes;
   public pageStepperPosition = 4;
   public interventionName = 'IntName';
+  public form: FormGroup;
+  public formChanges: InterventionForm['formChanges'] = {};
+
+  constructor(
+    public quickMapsService: QuickMapsService,
+    private intSideNavService: InterventionSideNavContentService,
+    private interventionDataService: InterventionDataService,
+    private formBuilder: FormBuilder,
+  ) {}
+
+  /**
+   * Create a table data source from API response, then construct into a FormArray.
+   *
+   * The .valueChanges() method then tracks any updates to the form and retrieves
+   * only the values that have changed.
+   *
+   * Finally, the data is returned in the subscription
+   * at the end of the chain for processing.
+   *
+   */
+  private initFormWatcher(): void {
+    const activeInterventionId = this.interventionDataService.getActiveInterventionId();
+    if (null != activeInterventionId) {
+      void this.interventionDataService
+        .getInterventionMonitoringInformation(activeInterventionId)
+        .then((data: InterventionMonitoringInformation) => {
+          this.dataSource = new MatTableDataSource(data.monitoringInformation);
+          const monitoringGroupArr = data.monitoringInformation.map((item) => {
+            return this.createMonitoringGroup(item);
+          });
+          this.form = this.formBuilder.group({
+            items: this.formBuilder.array(monitoringGroupArr),
+          });
+          const compareObjs = (a: Record<string, unknown>, b: Record<string, unknown>) => {
+            return Object.entries(b).filter(([key, value]) => value !== a[key]);
+          };
+          const changes = {};
+
+          this.form.valueChanges
+            .pipe(
+              startWith(this.form.value),
+              pairwise(),
+              map(([oldState, newState]) => {
+                for (const key in newState.items) {
+                  const rowIndex = this.form.get('items')['controls'][key]['controls'].rowIndex.value;
+
+                  if (oldState.items[key] !== newState.items[key] && oldState.items[key] !== undefined) {
+                    const diff = compareObjs(oldState.items[key], newState.items[key]);
+                    if (Array.isArray(diff) && diff.length > 0) {
+                      diff.forEach((item) => {
+                        if (changes[rowIndex]) {
+                          changes[rowIndex] = {
+                            ...changes[rowIndex],
+                            [item[0]]: Number(item[1]),
+                          };
+                          changes[rowIndex]['rowIndex'] = rowIndex;
+                        } else {
+                          changes[rowIndex] = {
+                            [item[0]]: Number(item[1]),
+                          };
+                          changes[rowIndex]['rowIndex'] = rowIndex;
+                        }
+                      });
+                    }
+                  }
+                }
+                return changes;
+              }),
+              filter((changes) => Object.keys(changes).length !== 0 && !this.form.invalid),
+            )
+            .subscribe((value) => {
+              this.formChanges = value;
+              const newInterventionChanges = {
+                ...this.interventionDataService.getInterventionDataChanges(),
+                ...this.formChanges,
+              };
+              this.interventionDataService.setInterventionDataChanges(newInterventionChanges);
+            });
+        });
+    }
+  }
+
+  get monitoringArray(): FormArray {
+    return this.form.get('items')['controls'] as FormArray;
+  }
+
+  private createMonitoringGroup(item: MonitoringInformation): FormGroup {
+    return this.formBuilder.group({
+      rowIndex: [item.rowIndex, []],
+      year0: [Number(item.year0), []],
+      year1: [Number(item.year1), []],
+      year2: [Number(item.year2), []],
+      year3: [Number(item.year3), []],
+      year4: [Number(item.year4), []],
+      year5: [Number(item.year5), []],
+      year6: [Number(item.year6), []],
+      year7: [Number(item.year7), []],
+      year8: [Number(item.year8), []],
+      year9: [Number(item.year9), []],
+    });
+  }
 
   public ngOnInit(): void {
     this.intSideNavService.setCurrentStepperPosition(this.pageStepperPosition);
+    this.initFormWatcher();
   }
-  private init(data: InterventionMonitoringInformation): void {
-    // console.debug(data);
-    this.dataSource = new MatTableDataSource(data.monitoringInformation);
-    console.log(data.monitoringInformation);
+
+  public confirmAndContinue(): void {
+    this.interventionDataService.interventionPageConfirmContinue();
   }
 }

--- a/src/app/services/featureFlags.service.ts
+++ b/src/app/services/featureFlags.service.ts
@@ -21,7 +21,7 @@ export class FeatureFlagsService {
   }
 
   public isEnabled(flag: string): boolean {
-    console.log(`Checking ${flag}. State=${this.unleashClient.isEnabled(flag)}`);
+    // console.log(`Checking ${flag}. State=${this.unleashClient.isEnabled(flag)}`);
     return this.unleashClient.isEnabled(flag);
   }
 

--- a/src/app/services/interventionData.service.ts
+++ b/src/app/services/interventionData.service.ts
@@ -165,4 +165,11 @@ export class InterventionDataService {
   getInterventionDataChanges(): Record<string, unknown> {
     return this.interventionDataChangesSrc.value
   }
+
+  public startReviewingIntervention(interventionID: string): void {
+    this.setActiveInterventionId(interventionID);
+    const route = this.ROUTES.INTERVENTION_REVIEW_BASELINE.getRoute();
+    const params = this.route.snapshot.queryParams;
+    void this.router.navigate(route, { queryParams: params });
+  }
 }

--- a/src/app/services/interventionData.service.ts
+++ b/src/app/services/interventionData.service.ts
@@ -153,7 +153,7 @@ export class InterventionDataService {
     const params = this.route.snapshot.queryParams;
     void this.router.navigate(route, { queryParams: params });
   }
-  
+
   public patchInterventionData(interventionId: string, data: Array<Record<string, unknown>>): Promise<InterventionData> {
     return this.apiService.endpoints.intervention.patchInterventionData.call({ interventionId, data });
   }
@@ -164,12 +164,5 @@ export class InterventionDataService {
 
   getInterventionDataChanges(): Record<string, unknown> {
     return this.interventionDataChangesSrc.value
-  }
-
-  public startReviewingIntervention(interventionID: string): void {
-    this.setActiveInterventionId(interventionID);
-    const route = this.ROUTES.INTERVENTION_REVIEW_BASELINE.getRoute();
-    const params = this.route.snapshot.queryParams;
-    void this.router.navigate(route, { queryParams: params });
   }
 }

--- a/src/app/services/interventionData.service.ts
+++ b/src/app/services/interventionData.service.ts
@@ -34,7 +34,7 @@ export class InterventionDataService {
   private readonly interventionDetailedChartPDFSrc = new BehaviorSubject<string>(null);
   public interventionDetailedChartPDFObs = this.interventionDetailedChartPDFSrc.asObservable();
 
-  private readonly interventionDataChangesSrc = new BehaviorSubject<unknown>(null);
+  private readonly interventionDataChangesSrc = new BehaviorSubject<Record<string, unknown>>(null);
   public interventionDataChangesObs = this.interventionDataChangesSrc.asObservable();
 
 
@@ -158,11 +158,11 @@ export class InterventionDataService {
     return this.apiService.endpoints.intervention.patchInterventionData.call({ interventionId, data });
   }
 
-  setIndustryInformationChanges(data: unknown): void {
+  setInterventionDataChanges(data: Record<string, unknown>): void {
     this.interventionDataChangesSrc.next(data)
   }
 
-  getIndustryInformationChanges(): unknown {
+  getInterventionDataChanges(): Record<string, unknown> {
     return this.interventionDataChangesSrc.value
   }
 }

--- a/src/app/services/interventionData.service.ts
+++ b/src/app/services/interventionData.service.ts
@@ -64,9 +64,12 @@ export class InterventionDataService {
     );
   }
   public getInterventionMonitoringInformation(id: string): Promise<InterventionMonitoringInformation> {
-    return this.apiService.endpoints.intervention.getInterventionMonitoringInformation.call({
-      id,
-    });
+    return this.apiService.endpoints.intervention.getInterventionMonitoringInformation.call(
+      {
+        id,
+      },
+      false,
+    );
   }
   public getInterventionIndustryInformation(id: string): Promise<InterventionIndustryInformation> {
     return this.apiService.endpoints.intervention.getInterventionIndustryInformation.call(
@@ -160,7 +163,7 @@ export class InterventionDataService {
 
   public getActiveInterventionId(): string {
     const activeId = localStorage.getItem(ACTIVE_INTERVENTION_ID);
-    console.debug('aactiveId from service', activeId);
+    // console.debug('aactiveId from service', activeId);
     if (null == activeId) {
       const route = this.ROUTES.QUICK_MAPS_COST_EFFECTIVENESS.getRoute();
       const params = this.route.snapshot.queryParams;
@@ -208,4 +211,12 @@ export class InterventionDataService {
 
     return;
   }
+}
+
+export interface InterventionForm {
+  formChanges: {
+    [row: number]: {
+      [col: string]: string;
+    };
+  };
 }

--- a/src/app/services/interventionData.service.ts
+++ b/src/app/services/interventionData.service.ts
@@ -34,7 +34,11 @@ export class InterventionDataService {
   private readonly interventionDetailedChartPDFSrc = new BehaviorSubject<string>(null);
   public interventionDetailedChartPDFObs = this.interventionDetailedChartPDFSrc.asObservable();
 
-  constructor(private apiService: ApiService, private readonly router: Router, public route: ActivatedRoute) {}
+  private readonly interventionDataChangesSrc = new BehaviorSubject<unknown>(null);
+  public interventionDataChangesObs = this.interventionDataChangesSrc.asObservable();
+
+
+  constructor(private apiService: ApiService, private readonly router: Router, public route: ActivatedRoute) { }
 
   public getIntervention(id: string): Promise<Intervention> {
     return this.apiService.endpoints.intervention.getIntervention.call({
@@ -148,5 +152,17 @@ export class InterventionDataService {
     const route = this.ROUTES.INTERVENTION_REVIEW_BASELINE.getRoute();
     const params = this.route.snapshot.queryParams;
     void this.router.navigate(route, { queryParams: params });
+  }
+  
+  public patchInterventionData(interventionId: string, data: Array<Record<string, unknown>>): Promise<InterventionData> {
+    return this.apiService.endpoints.intervention.patchInterventionData.call({ interventionId, data });
+  }
+
+  setIndustryInformationChanges(data: unknown): void {
+    this.interventionDataChangesSrc.next(data)
+  }
+
+  getIndustryInformationChanges(): unknown {
+    return this.interventionDataChangesSrc.value
   }
 }

--- a/src/app/services/interventionData.service.ts
+++ b/src/app/services/interventionData.service.ts
@@ -37,23 +37,31 @@ export class InterventionDataService {
   private readonly interventionDataChangesSrc = new BehaviorSubject<Record<string, unknown>>(null);
   public interventionDataChangesObs = this.interventionDataChangesSrc.asObservable();
 
-
-  constructor(private apiService: ApiService, private readonly router: Router, public route: ActivatedRoute) { }
+  constructor(private apiService: ApiService, private readonly router: Router, public route: ActivatedRoute) {}
 
   public getIntervention(id: string): Promise<Intervention> {
-    return this.apiService.endpoints.intervention.getIntervention.call({
-      id,
-    });
+    return this.apiService.endpoints.intervention.getIntervention.call(
+      {
+        id,
+      },
+      false,
+    );
   }
   public getInterventionData(id: string): Promise<InterventionData> {
-    return this.apiService.endpoints.intervention.getInterventionData.call({
-      id,
-    });
+    return this.apiService.endpoints.intervention.getInterventionData.call(
+      {
+        id,
+      },
+      false,
+    );
   }
   public getInterventionFoodVehicleStandards(id: string): Promise<InterventionFoodVehicleStandards> {
-    return this.apiService.endpoints.intervention.getInterventionFoodVehicleStandards.call({
-      id,
-    });
+    return this.apiService.endpoints.intervention.getInterventionFoodVehicleStandards.call(
+      {
+        id,
+      },
+      false,
+    );
   }
   public getInterventionMonitoringInformation(id: string): Promise<InterventionMonitoringInformation> {
     return this.apiService.endpoints.intervention.getInterventionMonitoringInformation.call({
@@ -61,29 +69,44 @@ export class InterventionDataService {
     });
   }
   public getInterventionIndustryInformation(id: string): Promise<InterventionIndustryInformation> {
-    return this.apiService.endpoints.intervention.getInterventionIndustryInformation.call({
-      id,
-    });
+    return this.apiService.endpoints.intervention.getInterventionIndustryInformation.call(
+      {
+        id,
+      },
+      false,
+    );
   }
   public getInterventionRecurringCosts(id: string): Promise<InterventionRecurringCosts> {
-    return this.apiService.endpoints.intervention.getInterventionRecurringCosts.call({
-      id,
-    });
+    return this.apiService.endpoints.intervention.getInterventionRecurringCosts.call(
+      {
+        id,
+      },
+      false,
+    );
   }
   public getInterventionStartupCosts(id: string): Promise<InterventionStartupCosts> {
-    return this.apiService.endpoints.intervention.getInterventionStartupCosts.call({
-      id,
-    });
+    return this.apiService.endpoints.intervention.getInterventionStartupCosts.call(
+      {
+        id,
+      },
+      false,
+    );
   }
   public getInterventionBaselineAssumptions(id: string): Promise<InterventionBaselineAssumptions> {
-    return this.apiService.endpoints.intervention.getInterventionBaselineAssumptions.call({
-      id,
-    });
+    return this.apiService.endpoints.intervention.getInterventionBaselineAssumptions.call(
+      {
+        id,
+      },
+      false,
+    );
   }
   public getInterventionCostSummary(id: string): Promise<InterventionCostSummary> {
-    return this.apiService.endpoints.intervention.getInterventionCostSummary.call({
-      id,
-    });
+    return this.apiService.endpoints.intervention.getInterventionCostSummary.call(
+      {
+        id,
+      },
+      false,
+    );
   }
   public setIntervention(
     parentInterventionId: number,
@@ -154,15 +177,35 @@ export class InterventionDataService {
     void this.router.navigate(route, { queryParams: params });
   }
 
-  public patchInterventionData(interventionId: string, data: Array<Record<string, unknown>>): Promise<InterventionData> {
+  public patchInterventionData(
+    interventionId: string,
+    data: Array<Record<string, unknown>>,
+  ): Promise<InterventionData> {
     return this.apiService.endpoints.intervention.patchInterventionData.call({ interventionId, data });
   }
 
-  setInterventionDataChanges(data: Record<string, unknown>): void {
-    this.interventionDataChangesSrc.next(data)
+  public setInterventionDataChanges(data: Record<string, unknown>): void {
+    this.interventionDataChangesSrc.next(data);
   }
 
-  getInterventionDataChanges(): Record<string, unknown> {
-    return this.interventionDataChangesSrc.value
+  public getInterventionDataChanges(): Record<string, unknown> {
+    return this.interventionDataChangesSrc.value;
+  }
+
+  public interventionPageConfirmContinue(): Promise<void> {
+    const interventionChanges = this.getInterventionDataChanges();
+    if (interventionChanges) {
+      const dataArr = [];
+      for (const key in interventionChanges) {
+        dataArr.push(interventionChanges[key]);
+      }
+
+      const interventionId = this.getActiveInterventionId();
+      this.patchInterventionData(interventionId, dataArr);
+
+      this.setInterventionDataChanges(null);
+    }
+
+    return;
   }
 }


### PR DESCRIPTION
Addition to #883 

- each intervention GET is using the live API instead of cached data. This means that when moving between intervention pages it pulls the latest info each time, which includes any changes made in other pages.
- moved the store and send PATCH to intervention service which is called when confirming page, instead of when at cost summary page
- update industry intervention page to use string inputs instead of numbers, to enable 2 decimal place pipe to work
- ...which meant that needed to ensure that inputs were changes to numbers when building the PATCH request