### PR TITLE
More use of PATCH endpoint for interventions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,5 +14,24 @@
   "[json]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
-  "peacock.color": "#9b51e0"
+  "peacock.color": "#9b51e0",
+  "workbench.colorCustomizations": {
+    "activityBar.activeBackground": "#b47ce8",
+    "activityBar.activeBorder": "#f1d0ae",
+    "activityBar.background": "#b47ce8",
+    "activityBar.foreground": "#15202b",
+    "activityBar.inactiveForeground": "#15202b99",
+    "activityBarBadge.background": "#f1d0ae",
+    "activityBarBadge.foreground": "#15202b",
+    "sash.hoverBorder": "#b47ce8",
+    "statusBar.background": "#9b51e0",
+    "statusBar.foreground": "#e7e7e7",
+    "statusBarItem.hoverBackground": "#b47ce8",
+    "statusBarItem.remoteBackground": "#9b51e0",
+    "statusBarItem.remoteForeground": "#e7e7e7",
+    "titleBar.activeBackground": "#9b51e0",
+    "titleBar.activeForeground": "#e7e7e7",
+    "titleBar.inactiveBackground": "#9b51e099",
+    "titleBar.inactiveForeground": "#e7e7e799"
+  }
 }

--- a/src/app/components/dialogs/dialog.service.ts
+++ b/src/app/components/dialogs/dialog.service.ts
@@ -5,7 +5,6 @@ import { InterventionsDictionaryItem } from 'src/app/apiAndObjects/objects/dicti
 import { MicronutrientDictionaryItem } from 'src/app/apiAndObjects/objects/dictionaries/micronutrientDictionaryItem';
 import { RecurringCost, RecurringCosts } from 'src/app/apiAndObjects/objects/interventionRecurringCosts';
 import { StartUpCosts } from 'src/app/apiAndObjects/objects/interventionStartupCosts';
-import { StartUpScaleUpCostDialogSelection } from 'src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/utilities/reusableCostTable/reusableCostTable.component';
 import { BaseDialogService, DialogData } from './baseDialogService.abstract';
 import { BaselineDescriptionDialogComponent } from './baselineDescriptionDialog/baselineDescriptionDialog.component';
 import { CeCalculatedFortificationInfoDialogComponent } from './ceCalculatedFortificationInfoDialog/ceCalculatedFortificationInfoDialog.component';
@@ -122,10 +121,10 @@ export class DialogService extends BaseDialogService {
   }
 
   public openSectionStartUpCostReviewDialog(
-    costs: StartUpScaleUpCostDialogSelection,
+    costs: StartUpCosts,
     width = '80vw',
     height = '80vh',
-  ): Promise<DialogData<StartUpScaleUpCostDialogSelection>> {
+  ): Promise<DialogData<StartUpCosts>> {
     return this.openDialog('openSectionCostReviewDialog', SectionStartUpCostReviewDialogComponent, false, costs, {
       width: width,
       height: height,

--- a/src/app/components/dialogs/dialog.service.ts
+++ b/src/app/components/dialogs/dialog.service.ts
@@ -5,6 +5,7 @@ import { InterventionsDictionaryItem } from 'src/app/apiAndObjects/objects/dicti
 import { MicronutrientDictionaryItem } from 'src/app/apiAndObjects/objects/dictionaries/micronutrientDictionaryItem';
 import { RecurringCost, RecurringCosts } from 'src/app/apiAndObjects/objects/interventionRecurringCosts';
 import { StartUpCosts } from 'src/app/apiAndObjects/objects/interventionStartupCosts';
+import { StartUpScaleUpCostDialogSelection } from 'src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/utilities/reusableCostTable/reusableCostTable.component';
 import { BaseDialogService, DialogData } from './baseDialogService.abstract';
 import { BaselineDescriptionDialogComponent } from './baselineDescriptionDialog/baselineDescriptionDialog.component';
 import { CeCalculatedFortificationInfoDialogComponent } from './ceCalculatedFortificationInfoDialog/ceCalculatedFortificationInfoDialog.component';
@@ -70,7 +71,7 @@ export class DialogService extends BaseDialogService {
       CostEffectivenessSelectionDialogComponent,
       false,
       interventions,
-      { height: '600px' }
+      { height: '600px' },
     );
   }
   public openCEInfoDialog(): Promise<DialogData> {
@@ -121,10 +122,10 @@ export class DialogService extends BaseDialogService {
   }
 
   public openSectionStartUpCostReviewDialog(
-    costs: StartUpCosts,
+    costs: StartUpScaleUpCostDialogSelection,
     width = '80vw',
     height = '80vh',
-  ): Promise<DialogData<StartUpCosts>> {
+  ): Promise<DialogData<StartUpScaleUpCostDialogSelection>> {
     return this.openDialog('openSectionCostReviewDialog', SectionStartUpCostReviewDialogComponent, false, costs, {
       width: width,
       height: height,

--- a/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.html
+++ b/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.html
@@ -3,190 +3,196 @@
     <div class="title">
       <span>{{title}}</span>
     </div>
-    <table mat-table [dataSource]="dataSource" matSort class="table-full-width">
-      <ng-container matColumnDef="name">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">Years of start-up or scale-up</th>
-        <td mat-cell *matCellDef="let element"> {{element.name}} </td>
-        <td mat-footer-cell *matFooterCellDef>Total</td>
-      </ng-container>
-      <ng-container matColumnDef="year0">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2021</th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-          <div *ngIf="element.rowUnits === 'number'">
-            <input type="text" appDecimalInput required [value]=element.year0.toFixed(2)>
-          </div>
-          <div *ngIf="element.rowUnits === 'US dollars'">
-            <span>$</span><input type="text" appDecimalInput required [value]=element.year0.toFixed(2)>
-          </div>
-          <div *ngIf="element.rowUnits === 'percent'">
-            <input type="text" [value]="element.year0 * 100" (input)="element.year0 = $any($event.target).value / 100"
-              appDecimalInput>
-          </div>
-        </td>
-        <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year0') | currencyExtended}} </td>
-      </ng-container>
-      <!-- year1 -->
-      <ng-container matColumnDef="year1">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2022</th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-          <div *ngIf="element.rowUnits === 'number'">
-            <input type="text" appDecimalInput required [value]=element.year1.toFixed(2)>
-          </div>
-          <div *ngIf="element.rowUnits === 'US dollars'">
-            <span>$</span><input type="text" appDecimalInput required [value]=element.year1.toFixed(2)>
-          </div>
-          <div *ngIf="element.rowUnits === 'percent'">
-            <input type="text" [value]="element.year1 * 100" (input)="element.year1 = $any($event.target).value / 100"
-              appDecimalInput>
-          </div>
-        </td>
-        <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year1') | currencyExtended}} </td>
-      </ng-container>
-      <!-- year2 -->
-      <ng-container matColumnDef="year2">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2023</th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-          <div *ngIf="element.rowUnits === 'number'">
-            <input type="text" appDecimalInput required [value]=element.year2.toFixed(2)>
-          </div>
-          <div *ngIf="element.rowUnits === 'US dollars'">
-            <span>$</span><input type="text" appDecimalInput required [value]=element.year2.toFixed(2)>
-          </div>
-          <div *ngIf="element.rowUnits === 'percent'">
-            <input type="text" [value]="element.year2 * 100" (input)="element.year2 = $any($event.target).value / 100"
-              appDecimalInput>
-          </div>
-        </td>
-        <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year2') | currencyExtended}} </td>
-      </ng-container>
-      <!-- year3 -->
-      <ng-container matColumnDef="year3">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2024</th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-          <div *ngIf="element.rowUnits === 'number'">
-            <input type="text" appDecimalInput required [value]=element.year3.toFixed(2)>
-          </div>
-          <div *ngIf="element.rowUnits === 'US dollars'">
-            <span>$</span><input type="text" appDecimalInput required [value]=element.year3.toFixed(2)>
-          </div>
-          <div *ngIf="element.rowUnits === 'percent'">
-            <input type="text" [value]="element.year3 * 100" (input)="element.year3 = $any($event.target).value / 100"
-              appDecimalInput>
-          </div>
-        </td>
-        <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year3') | currencyExtended}} </td>
-      </ng-container>
-      <!-- year4 -->
-      <ng-container matColumnDef="year4">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2025</th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-          <div *ngIf="element.rowUnits === 'number'">
-            <input type="text" appDecimalInput required [value]=element.year4.toFixed(2)>
-          </div>
-          <div *ngIf="element.rowUnits === 'US dollars'">
-            <span>$</span><input type="text" appDecimalInput required [value]=element.year4.toFixed(2)>
-          </div>
-          <div *ngIf="element.rowUnits === 'percent'">
-            <input type="text" [value]="element.year4 * 100" (input)="element.year4 = $any($event.target).value / 100"
-              appDecimalInput>
-          </div>
-        </td>
-        <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year4') | currencyExtended}} </td>
-      </ng-container>
-      <!-- year5 -->
-      <ng-container matColumnDef="year5">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2026</th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-          <div *ngIf="element.rowUnits === 'number'">
-            <input type="text" appDecimalInput required [value]=element.year5.toFixed(2)>
-          </div>
-          <div *ngIf="element.rowUnits === 'US dollars'">
-            <span>$</span><input type="text" appDecimalInput required [value]=element.year5.toFixed(2)>
-          </div>
-          <div *ngIf="element.rowUnits === 'percent'">
-            <input type="text" [value]="element.year4 * 100" (input)="element.year5 = $any($event.target).value / 100"
-              appDecimalInput>
-          </div>
-        </td>
-        <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year5') | currencyExtended}} </td>
-      </ng-container>
-      <!-- year6 -->
-      <ng-container matColumnDef="year6">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2027</th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-          <div *ngIf="element.rowUnits === 'number'">
-            <input type="text" appDecimalInput required [value]=element.year6.toFixed(2)>
-          </div>
-          <div *ngIf="element.rowUnits === 'US dollars'">
-            <span>$</span><input type="text" appDecimalInput required [value]=element.year6.toFixed(2)>
-          </div>
-          <div *ngIf="element.rowUnits === 'percent'">
-            <input type="text" [value]="element.year6 * 100" (input)="element.year6 = $any($event.target).value / 100"
-              appDecimalInput>
-          </div>
-        </td>
-        <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year6') | currencyExtended}} </td>
-      </ng-container>
-      <!-- year7 -->
-      <ng-container matColumnDef="year7">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2028</th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-          <div *ngIf="element.rowUnits === 'number'">
-            <input type="text" appDecimalInput required [value]=element.year7.toFixed(2)>
-          </div>
-          <div *ngIf="element.rowUnits === 'US dollars'">
-            <span>$</span>
-            <input type="text" appDecimalInput required [value]=element.year7.toFixed(2)>
-          </div>
-          <div *ngIf="element.rowUnits === 'percent'">
-            <input type="text" [value]="element.year4 * 100" (input)="element.year7 = $any($event.target).value / 100"
-              appDecimalInput>
-          </div>
-        </td>
-        <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year7') | currencyExtended}} </td>
-      </ng-container>
-      <!-- year8 -->
-      <ng-container matColumnDef="year8">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2029</th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-          <div *ngIf="element.rowUnits === 'number'">
-            <input type="text" appDecimalInput required [value]=element.year8.toFixed(2)>
-          </div>
-          <div *ngIf="element.rowUnits === 'US dollars'">
-            <span>$</span><input type="text" appDecimalInput required [value]=element.year8.toFixed(2)>
-          </div>
-          <div *ngIf="element.rowUnits === 'percent'">
-            <input type="text" [value]="element.year4 * 100" (input)="element.year8 = $any($event.target).value / 100"
-              appDecimalInput>
-          </div>
-        </td>
-        <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year8') | currencyExtended}} </td>
-      </ng-container>
-      <!-- year9 -->
-      <ng-container matColumnDef="year9">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2030</th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-          <div *ngIf="element.rowUnits === 'number'">
-            <input type="text" appDecimalInput required [value]=element.year9.toFixed(2)>
-          </div>
-          <div *ngIf="element.rowUnits === 'US dollars'">
-            <span>$</span><input type="text" appDecimalInput required [value]=element.year9.toFixed(2)>
-          </div>
-          <div *ngIf="element.rowUnits === 'percent'">
-            <input type="text" [value]="element.year4 * 100" (input)="element.year9 = $any($event.target).value / 100"
-              appDecimalInput>
-          </div>
-        </td>
-        <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year9') | currencyExtended}} </td>
-      </ng-container>
-      <tr mat-header-row *matHeaderRowDef="displayHeaders;"></tr>
-      <tr mat-row *matRowDef="let row; columns: displayHeaders"></tr>
-      <tr class="mat-row" *matNoDataRow></tr>
-      <tr mat-footer-row *matFooterRowDef="displayHeaders"></tr>
-    </table>
+
+    <form [formGroup]="form" *ngIf="form">
+      <table mat-table [dataSource]="dataSource" matSort class="table-full-width" formArrayName="items">
+        <ng-container matColumnDef="name">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">Years of start-up or scale-up
+          </th>
+          <td mat-cell *matCellDef="let element"> {{element.name}} </td>
+          <td mat-footer-cell *matFooterCellDef>Total</td>
+        </ng-container>
+        <ng-container matColumnDef="year0">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2021</th>
+          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+            <div *ngIf="element.rowUnits === 'number'">
+              <input type="text" appDecimalInput required [value]=element.year0 formControlName="year0">
+            </div>
+            <div *ngIf="element.rowUnits === 'US dollars'">
+              <input type="text" appDecimalInput required [value]=element.year0 formControlName="year0">
+            </div>
+            <div *ngIf="element.rowUnits === 'percent'">
+              <input type="text" [value]="element.year0 * 100" (input)="element.year0 = $any($event.target).value / 100"
+                appDecimalInput formControlName="year0">
+            </div>
+          </td>
+          <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year0') | currencyExtended}} </td>
+        </ng-container>
+        <!-- year1 -->
+        <ng-container matColumnDef="year1">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2022</th>
+          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+            <div *ngIf="element.rowUnits === 'number'">
+              <input type="text" appDecimalInput required [value]=element.year1 formControlName="year0"
+                formControlName="year1">
+            </div>
+            <div *ngIf="element.rowUnits === 'US dollars'">
+              <input type="text" appDecimalInput required [value]=element.year1 formControlName="year0"
+                formControlName="year1">
+            </div>
+            <div *ngIf="element.rowUnits === 'percent'">
+              <input type="text" [value]="element.year1 * 100" (input)="element.year1 = $any($event.target).value / 100"
+                appDecimalInput formControlName="year1">
+            </div>
+          </td>
+          <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year1') | currencyExtended}} </td>
+        </ng-container>
+        <!-- year2 -->
+        <ng-container matColumnDef="year2">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2023</th>
+          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+            <div *ngIf="element.rowUnits === 'number'">
+              <input type="text" appDecimalInput required [value]=element.year2 formControlName="year2">
+            </div>
+            <div *ngIf="element.rowUnits === 'US dollars'">
+              <input type="text" appDecimalInput required [value]=element.year2 formControlName="year2">
+            </div>
+            <div *ngIf="element.rowUnits === 'percent'">
+              <input type="text" [value]="element.year2 * 100" (input)="element.year2 = $any($event.target).value / 100"
+                appDecimalInput formControlName="year2">
+            </div>
+          </td>
+          <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year2') | currencyExtended}} </td>
+        </ng-container>
+        <!-- year3 -->
+        <ng-container matColumnDef="year3">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2024</th>
+          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+            <div *ngIf="element.rowUnits === 'number'">
+              <input type="text" appDecimalInput required [value]=element.year3 formControlName="year3">
+            </div>
+            <div *ngIf="element.rowUnits === 'US dollars'">
+              <input type="text" appDecimalInput required [value]=element.year3 formControlName="year3">
+            </div>
+            <div *ngIf="element.rowUnits === 'percent'">
+              <input type="text" [value]="element.year3 * 100" (input)="element.year3 = $any($event.target).value / 100"
+                appDecimalInput formControlName="year3">
+            </div>
+          </td>
+          <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year3') | currencyExtended}} </td>
+        </ng-container>
+        <!-- year4 -->
+        <ng-container matColumnDef="year4">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2025</th>
+          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+            <div *ngIf="element.rowUnits === 'number'">
+              <input type="text" appDecimalInput required [value]=element.year4 formControlName="year4">
+            </div>
+            <div *ngIf="element.rowUnits === 'US dollars'">
+              <input type="text" appDecimalInput required [value]=element.year4 formControlName="year4">
+            </div>
+            <div *ngIf="element.rowUnits === 'percent'">
+              <input type="text" [value]="element.year4 * 100" (input)="element.year4 = $any($event.target).value / 100"
+                appDecimalInput formControlName="year4">
+            </div>
+          </td>
+          <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year4') | currencyExtended}} </td>
+        </ng-container>
+        <!-- year5 -->
+        <ng-container matColumnDef="year5">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2026</th>
+          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+            <div *ngIf="element.rowUnits === 'number'">
+              <input type="text" appDecimalInput required [value]=element.year5 formControlName="year5">
+            </div>
+            <div *ngIf="element.rowUnits === 'US dollars'">
+              <input type="text" appDecimalInput required [value]=element.year5 formControlName="year5">
+            </div>
+            <div *ngIf="element.rowUnits === 'percent'">
+              <input type="text" [value]="element.year4 * 100" (input)="element.year5 = $any($event.target).value / 100"
+                appDecimalInput formControlName="year5">
+            </div>
+          </td>
+          <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year5') | currencyExtended}} </td>
+        </ng-container>
+        <!-- year6 -->
+        <ng-container matColumnDef="year6">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2027</th>
+          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+            <div *ngIf="element.rowUnits === 'number'">
+              <input type="text" appDecimalInput required [value]=element.year6 formControlName="year6">
+            </div>
+            <div *ngIf="element.rowUnits === 'US dollars'">
+              <input type="text" appDecimalInput required [value]=element.year6 formControlName="year6">
+            </div>
+            <div *ngIf="element.rowUnits === 'percent'">
+              <input type="text" [value]="element.year6 * 100" (input)="element.year6 = $any($event.target).value / 100"
+                appDecimalInput formControlName="year6">
+            </div>
+          </td>
+          <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year6') | currencyExtended}} </td>
+        </ng-container>
+        <!-- year7 -->
+        <ng-container matColumnDef="year7">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2028</th>
+          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+            <div *ngIf="element.rowUnits === 'number'">
+              <input type="text" appDecimalInput required [value]=element.year7 formControlName="year7">
+            </div>
+            <div *ngIf="element.rowUnits === 'US dollars'">
+
+              <input type="text" appDecimalInput required [value]=element.year7 formControlName="year7">
+            </div>
+            <div *ngIf="element.rowUnits === 'percent'">
+              <input type="text" [value]="element.year4 * 100" (input)="element.year7 = $any($event.target).value / 100"
+                appDecimalInput formControlName="year7">
+            </div>
+          </td>
+          <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year7') | currencyExtended}} </td>
+        </ng-container>
+        <!-- year8 -->
+        <ng-container matColumnDef="year8">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2029</th>
+          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+            <div *ngIf="element.rowUnits === 'number'">
+              <input type="text" appDecimalInput required [value]=element.year8 formControlName="year8">
+            </div>
+            <div *ngIf="element.rowUnits === 'US dollars'">
+              <input type="text" appDecimalInput required [value]=element.year8 formControlName="year8">
+            </div>
+            <div *ngIf="element.rowUnits === 'percent'">
+              <input type="text" [value]="element.year4 * 100" (input)="element.year8 = $any($event.target).value / 100"
+                appDecimalInput formControlName="year8">
+            </div>
+          </td>
+          <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year8') | currencyExtended}} </td>
+        </ng-container>
+        <!-- year9 -->
+        <ng-container matColumnDef="year9">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2030</th>
+          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+            <div *ngIf="element.rowUnits === 'number'">
+              <input type="text" appDecimalInput required [value]=element.year9 formControlName="year9">
+            </div>
+            <div *ngIf="element.rowUnits === 'US dollars'">
+              <input type="text" appDecimalInput required [value]=element.year9 formControlName="year9">
+            </div>
+            <div *ngIf="element.rowUnits === 'percent'">
+              <input type="text" [value]="element.year4 * 100" (input)="element.year9 = $any($event.target).value / 100"
+                appDecimalInput formControlName="year9">
+            </div>
+          </td>
+          <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year9') | currencyExtended}} </td>
+        </ng-container>
+        <tr mat-header-row *matHeaderRowDef="displayedColumns;"></tr>
+        <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+        <tr class="mat-row" *matNoDataRow></tr>
+        <tr mat-footer-row *matFooterRowDef="displayedColumns"></tr>
+      </table>
+    </form>
     <div class="button-container">
       <button mat-stroked-button (click)="dialogData.close()">Back</button>
-      <button class="confirm" mat-stroked-button color="primary" (click)="dialogData.close()">Confirm</button>
+      <button class="confirm" mat-stroked-button color="primary" (click)="confirmChanges()">Confirm</button>
     </div>
   </div>
 </app-base-dialog>

--- a/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.scss
+++ b/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.scss
@@ -46,3 +46,9 @@ input {
   border: black 0.5px solid;
   text-align: center;
 }
+
+// user edited values
+input.ng-dirty {
+  color: $color_input_blue;
+  border-color: $color_input_blue;
+}

--- a/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.ts
+++ b/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.ts
@@ -56,7 +56,7 @@ export class SectionRecurringCostReviewDialogComponent {
     const activeInterventionId = this.interventionDataService.getActiveInterventionId();
     if (null != activeInterventionId) {
       this.dataSource = new MatTableDataSource(this.dialogData.dataIn.costBreakdown);
-      console.debug('datasource = ', this.dataSource.data);
+      // console.debug('datasource = ', this.dataSource.data);
       const reucrringGroupArr = this.dialogData.dataIn.costBreakdown.map((item) => {
         return this.createRecurringCostGroup(item);
       });

--- a/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.ts
+++ b/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.ts
@@ -3,6 +3,9 @@ import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatTableDataSource } from '@angular/material/table';
 import { RecurringCosts, RecurringCostBreakdown } from 'src/app/apiAndObjects/objects/interventionRecurringCosts';
 import { DialogData } from '../baseDialogService.abstract';
+import { pairwise, map, filter, startWith } from 'rxjs/operators';
+import { InterventionDataService, InterventionForm } from 'src/app/services/interventionData.service';
+import { FormArray, FormBuilder, FormGroup } from '@angular/forms';
 @Injectable({ providedIn: 'root' })
 @Component({
   selector: 'app-section-recurring-cost-review-dialog',
@@ -12,8 +15,10 @@ import { DialogData } from '../baseDialogService.abstract';
 export class SectionRecurringCostReviewDialogComponent {
   public dataSource = new MatTableDataSource<RecurringCostBreakdown>();
   public title = '';
+  public form: FormGroup;
+  public formChanges: InterventionForm['formChanges'] = {};
 
-  public displayHeaders = [
+  public displayedColumns: string[] = [
     'name',
     'year0',
     'year1',
@@ -30,9 +35,100 @@ export class SectionRecurringCostReviewDialogComponent {
   constructor(
     @Inject(MAT_DIALOG_DATA)
     public dialogData: DialogData<RecurringCosts>,
+    private interventionDataService: InterventionDataService,
+    private formBuilder: FormBuilder,
   ) {
-    this.dataSource = new MatTableDataSource(dialogData.dataIn.costBreakdown);
+    this.initFormWatcher();
     this.title = dialogData.dataIn.section;
+  }
+
+  /**
+   * Create a table data source from API response, then construct into a FormArray.
+   *
+   * The .valueChanges() method then tracks any updates to the form and retrieves
+   * only the values that have changed.
+   *
+   * Finally, the data is returned in the subscription
+   * at the end of the chain for processing.
+   *
+   */
+  private initFormWatcher(): void {
+    const activeInterventionId = this.interventionDataService.getActiveInterventionId();
+    if (null != activeInterventionId) {
+      this.dataSource = new MatTableDataSource(this.dialogData.dataIn.costBreakdown);
+      console.debug('datasource = ', this.dataSource.data);
+      const reucrringGroupArr = this.dialogData.dataIn.costBreakdown.map((item) => {
+        return this.createRecurringCostGroup(item);
+      });
+      this.form = this.formBuilder.group({
+        items: this.formBuilder.array(reucrringGroupArr),
+      });
+      const compareObjs = (a: Record<string, unknown>, b: Record<string, unknown>) => {
+        return Object.entries(b).filter(([key, value]) => value !== a[key]);
+      };
+      const changes = {};
+
+      this.form.valueChanges
+        .pipe(
+          startWith(this.form.value),
+          pairwise(),
+          map(([oldState, newState]) => {
+            for (const key in newState.items) {
+              const rowIndex = this.form.get('items')['controls'][key]['controls'].rowIndex.value;
+
+              if (oldState.items[key] !== newState.items[key] && oldState.items[key] !== undefined) {
+                const diff = compareObjs(oldState.items[key], newState.items[key]);
+                if (Array.isArray(diff) && diff.length > 0) {
+                  diff.forEach((item) => {
+                    if (changes[rowIndex]) {
+                      changes[rowIndex] = {
+                        ...changes[rowIndex],
+                        [item[0]]: Number(item[1]),
+                      };
+                      changes[rowIndex]['rowIndex'] = rowIndex;
+                    } else {
+                      changes[rowIndex] = {
+                        [item[0]]: Number(item[1]),
+                      };
+                      changes[rowIndex]['rowIndex'] = rowIndex;
+                    }
+                  });
+                }
+              }
+            }
+            return changes;
+          }),
+          filter((changes) => Object.keys(changes).length !== 0 && !this.form.invalid),
+        )
+        .subscribe((value) => {
+          this.formChanges = value;
+          const newInterventionChanges = {
+            ...this.interventionDataService.getInterventionDataChanges(),
+            ...this.formChanges,
+          };
+          this.interventionDataService.setInterventionDataChanges(newInterventionChanges);
+        });
+    }
+  }
+
+  get reucrringCostArray(): FormArray {
+    return this.form.get('items')['controls'] as FormArray;
+  }
+
+  private createRecurringCostGroup(item: RecurringCostBreakdown): FormGroup {
+    return this.formBuilder.group({
+      rowIndex: [item.rowIndex, []],
+      year0: [Number(item.year0), []],
+      year1: [Number(item.year1), []],
+      year2: [Number(item.year2), []],
+      year3: [Number(item.year3), []],
+      year4: [Number(item.year4), []],
+      year5: [Number(item.year5), []],
+      year6: [Number(item.year6), []],
+      year7: [Number(item.year7), []],
+      year8: [Number(item.year8), []],
+      year9: [Number(item.year9), []],
+    });
   }
 
   public getTotalCost(yearKey: string): number {
@@ -40,5 +136,16 @@ export class SectionRecurringCostReviewDialogComponent {
     // TODO: update this to factor in percentage modifiers
     const filterItemsInDollars = this.dataSource.data.filter((cost) => cost.rowUnits === 'US dollars');
     return filterItemsInDollars.map((costBreakdown) => costBreakdown[yearKey]).reduce((acc, value) => acc + value, 0);
+  }
+
+  public confirmChanges(): void {
+    if (Object.keys(this.formChanges).length !== 0) {
+      this.interventionDataService.interventionPageConfirmContinue().then(() => {
+        this.interventionDataService.interventionRecurringCostChanged(true); // trigger dialog source page to update content
+        this.dialogData.close();
+      });
+    } else {
+      this.dialogData.close();
+    }
   }
 }

--- a/src/app/components/dialogs/sectionStartUpCostReviewDialog/sectionStartUpCostReviewDialog.component.html
+++ b/src/app/components/dialogs/sectionStartUpCostReviewDialog/sectionStartUpCostReviewDialog.component.html
@@ -3,57 +3,66 @@
     <div class="title">
       <span>{{title}}</span>
     </div>
-    <table mat-table [dataSource]="dataSource" matSort class="table-full-width">
-      <ng-container matColumnDef="name">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">Years of start-up or scale-up</th>
-        <td mat-cell *matCellDef="let element"> {{element.name}} </td>
-        <td mat-footer-cell *matFooterCellDef>Total</td>
-      </ng-container>
 
-      <ng-container matColumnDef="year0">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2021</th>
-        <!-- <td mat-cell *matCellDef="let element">{{element.year0 | currencyExtended}}</td> -->
-        <td class="column-title" mat-cell *matCellDef="let element">
-          <div *ngIf="element.rowUnits === 'number'">
-            <input type="text" appDecimalInput required [value]=element.year0.toFixed(2)>
-          </div>
-          <div *ngIf="element.rowUnits === 'US dollars'">
-            <span>$</span><input type="text" appDecimalInput required [value]=element.year0.toFixed(2)>
-          </div>
-          <div *ngIf="element.rowUnits === 'percent'">
-            <input type="text" [value]="element.year0 * 100" (input)="element.year0 = $any($event.target).value / 100"
-              appDecimalInput>
-          </div>
-        </td>
-        <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year0') | currencyExtended}} </td>
-      </ng-container>
+    <form [formGroup]="form" *ngIf="form">
+      <table mat-table [dataSource]="dataSource" matSort class="table-full-width" formArrayName="items">
+        <ng-container matColumnDef="name">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">Years of start-up or scale-up
+          </th>
+          <td mat-cell *matCellDef="let element"> {{element.name}} </td>
+          <td mat-footer-cell *matFooterCellDef>Total</td>
+        </ng-container>
 
-      <ng-container matColumnDef="year1">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2022</th>
-        <!-- <td mat-cell *matCellDef="let element">{{element.year1 | currencyExtended}}</td> -->
-        <td class="column-title" mat-cell *matCellDef="let element">
-          <div *ngIf="element.rowUnits === 'number'">
-            <input type="text" appDecimalInput required [value]=element.year1.toFixed(2)>
-          </div>
-          <div *ngIf="element.rowUnits === 'US dollars'">
-            <span>$</span><input type="text" appDecimalInput required [value]=element.year1.toFixed(2)>
-          </div>
-          <div *ngIf="element.rowUnits === 'percent'">
-            <input type="text" [value]="element.year1 * 100" (input)="element.year1 = $any($event.target).value / 100"
-              appDecimalInput>
-          </div>
-        </td>
-        <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year1') | currencyExtended}} </td>
-      </ng-container>
+        <ng-container matColumnDef="year0">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2021</th>
+          <!-- <td mat-cell *matCellDef="let element">{{element.year0 | currencyExtended}}</td> -->
+          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+            <div *ngIf="element.rowUnits === 'number'">
+              <input type="text" appDecimalInput required [value]=element.year0 formControlName="year0"
+                [(ngModel)]="element.year0">
+            </div>
+            <div *ngIf="element.rowUnits === 'US dollars'">
+              <input type="text" appDecimalInput required [value]=element.year0 formControlName="year0"
+                [(ngModel)]="element.year0">
+            </div>
+            <div *ngIf="element.rowUnits === 'percent'">
+              <input type="text" [value]="element.year0 * 100" (input)="element.year0 = $any($event.target).value / 100"
+                formControlName="year0" appDecimalInput [(ngModel)]="element.year0">
+            </div>
+          </td>
+          <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year0') | currencyExtended}} </td>
+        </ng-container>
 
-      <tr mat-header-row *matHeaderRowDef="displayHeaders;"></tr>
-      <tr mat-row *matRowDef="let row; columns: displayHeaders"></tr>
-      <tr class="mat-row" *matNoDataRow></tr>
-      <tr mat-footer-row *matFooterRowDef="displayHeaders"></tr>
-    </table>
+        <ng-container matColumnDef="year1">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2022</th>
+          <!-- <td mat-cell *matCellDef="let element">{{element.year1 | currencyExtended}}</td> -->
+          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+            <div *ngIf="element.rowUnits === 'number'">
+              <input type="text" appDecimalInput required [value]=element.year1 formControlName="year1"
+                [(ngModel)]="element.year1">
+            </div>
+            <div *ngIf="element.rowUnits === 'US dollars'">
+              <input type="text" appDecimalInput required [value]=element.year1 formControlName="year1"
+                [(ngModel)]="element.year1">
+            </div>
+            <div *ngIf="element.rowUnits === 'percent'">
+              <input type="text" [value]="element.year1 * 100" (input)="element.year1 = $any($event.target).value / 100"
+                formControlName="year1" appDecimalInput [(ngModel)]="element.year1">
+            </div>
+          </td>
+          <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year1') | currencyExtended}} </td>
+        </ng-container>
+
+        <tr mat-header-row *matHeaderRowDef="displayedColumns;"></tr>
+        <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+        <tr class="mat-row" *matNoDataRow></tr>
+        <tr mat-footer-row *matFooterRowDef="displayedColumns"></tr>
+      </table>
+    </form>
+
     <div class="button-container">
       <button mat-stroked-button (click)="dialogData.close()">Back</button>
-      <button class="confirm" mat-stroked-button color="primary" (click)="dialogData.close()">Confirm</button>
+      <button class="confirm" mat-stroked-button color="primary" (click)="confirmChanges()">Confirm</button>
     </div>
   </div>
 </app-base-dialog>

--- a/src/app/components/dialogs/sectionStartUpCostReviewDialog/sectionStartUpCostReviewDialog.component.html
+++ b/src/app/components/dialogs/sectionStartUpCostReviewDialog/sectionStartUpCostReviewDialog.component.html
@@ -18,16 +18,14 @@
           <!-- <td mat-cell *matCellDef="let element">{{element.year0 | currencyExtended}}</td> -->
           <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
-              <input type="text" appDecimalInput required [value]=element.year0 formControlName="year0"
-                [(ngModel)]="element.year0">
+              <input type="text" appDecimalInput required [value]=element.year0.toFixed(2) formControlName="year0">
             </div>
             <div *ngIf="element.rowUnits === 'US dollars'">
-              <input type="text" appDecimalInput required [value]=element.year0 formControlName="year0"
-                [(ngModel)]="element.year0">
+              <input type="text" appDecimalInput required [value]=element.year0.toFixed(2) formControlName="year0">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
               <input type="text" [value]="element.year0 * 100" (input)="element.year0 = $any($event.target).value / 100"
-                formControlName="year0" appDecimalInput [(ngModel)]="element.year0">
+                formControlName="year0" appDecimalInput>
             </div>
           </td>
           <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year0') | currencyExtended}} </td>
@@ -38,16 +36,14 @@
           <!-- <td mat-cell *matCellDef="let element">{{element.year1 | currencyExtended}}</td> -->
           <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
-              <input type="text" appDecimalInput required [value]=element.year1 formControlName="year1"
-                [(ngModel)]="element.year1">
+              <input type="text" appDecimalInput required [value]=element.year1.toFixed(2) formControlName="year1">
             </div>
             <div *ngIf="element.rowUnits === 'US dollars'">
-              <input type="text" appDecimalInput required [value]=element.year1 formControlName="year1"
-                [(ngModel)]="element.year1">
+              <input type="text" appDecimalInput required [value]=element.year1.toFixed(2) formControlName="year1">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
               <input type="text" [value]="element.year1 * 100" (input)="element.year1 = $any($event.target).value / 100"
-                formControlName="year1" appDecimalInput [(ngModel)]="element.year1">
+                formControlName="year1" appDecimalInput>
             </div>
           </td>
           <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year1') | currencyExtended}} </td>

--- a/src/app/components/dialogs/sectionStartUpCostReviewDialog/sectionStartUpCostReviewDialog.component.scss
+++ b/src/app/components/dialogs/sectionStartUpCostReviewDialog/sectionStartUpCostReviewDialog.component.scss
@@ -46,3 +46,9 @@ input {
   border: black 0.5px solid;
   text-align: center;
 }
+
+// user edited values
+input.ng-dirty {
+  color: $color_input_blue;
+  border-color: $color_input_blue;
+}

--- a/src/app/components/dialogs/sectionStartUpCostReviewDialog/sectionStartUpCostReviewDialog.component.ts
+++ b/src/app/components/dialogs/sectionStartUpCostReviewDialog/sectionStartUpCostReviewDialog.component.ts
@@ -3,6 +3,10 @@ import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatTableDataSource } from '@angular/material/table';
 import { StartUpCostBreakdown, StartUpCosts } from 'src/app/apiAndObjects/objects/interventionStartupCosts';
 import { DialogData } from '../baseDialogService.abstract';
+import { FormBuilder, FormArray, FormGroup } from '@angular/forms';
+import { pairwise, map, filter, startWith } from 'rxjs/operators';
+import { InterventionDataService, InterventionForm } from 'src/app/services/interventionData.service';
+import { StartUpScaleUpCostDialogSelection } from 'src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/utilities/reusableCostTable/reusableCostTable.component';
 
 @Component({
   selector: 'app-section-start-up-cost-review',
@@ -10,17 +14,130 @@ import { DialogData } from '../baseDialogService.abstract';
   styleUrls: ['./sectionStartUpCostReviewDialog.component.scss'],
 })
 export class SectionStartUpCostReviewDialogComponent {
+  public selectedCost: StartUpCosts;
   public dataSource = new MatTableDataSource<StartUpCostBreakdown>();
   public title = '';
+  public displayedColumns: string[] = ['name', 'year0', 'year1'];
+  public form: FormGroup;
+  public formChanges: InterventionForm['formChanges'] = {};
 
-  public displayHeaders = ['name', 'year0', 'year1'];
+  constructor(
+    @Inject(MAT_DIALOG_DATA) public dialogData: DialogData<StartUpScaleUpCostDialogSelection>,
+    private interventionDataService: InterventionDataService,
+    private formBuilder: FormBuilder,
+  ) {
+    console.debug(this.dialogData);
+    this.selectedCost = this.dialogData.dataIn.costs.find(
+      (item) => item['section'] === this.dialogData.dataIn.selectedElement,
+    );
+    this.initFormWatcher();
+    this.title = this.selectedCost.section;
+  }
 
-  constructor(@Inject(MAT_DIALOG_DATA) public dialogData: DialogData<StartUpCosts>) {
-    this.dataSource = new MatTableDataSource(dialogData.dataIn.costBreakdown);
-    this.title = dialogData.dataIn.section;
+  /**
+   * Create a table data source from API response, then construct into a FormArray.
+   *
+   * The .valueChanges() method then tracks any updates to the form and retrieves
+   * only the values that have changed.
+   *
+   * Finally, the data is returned in the subscription
+   * at the end of the chain for processing.
+   *
+   */
+  private initFormWatcher(): void {
+    const activeInterventionId = this.interventionDataService.getActiveInterventionId();
+    if (null != activeInterventionId) {
+      console.debug(this.dialogData);
+      this.dataSource = new MatTableDataSource(this.selectedCost.costBreakdown);
+      console.debug('bing');
+      const startupGroupArr = this.selectedCost.costBreakdown.map((item) => {
+        return this.createStartupCostGroup(item);
+      });
+      this.form = this.formBuilder.group({
+        items: this.formBuilder.array(startupGroupArr),
+      });
+      const compareObjs = (a: Record<string, unknown>, b: Record<string, unknown>) => {
+        return Object.entries(b).filter(([key, value]) => value !== a[key]);
+      };
+      const changes = {};
+
+      this.form.valueChanges
+        .pipe(
+          startWith(this.form.value),
+          pairwise(),
+          map(([oldState, newState]) => {
+            for (const key in newState.items) {
+              const rowIndex = this.form.get('items')['controls'][key]['controls'].rowIndex.value;
+
+              if (oldState.items[key] !== newState.items[key] && oldState.items[key] !== undefined) {
+                const diff = compareObjs(oldState.items[key], newState.items[key]);
+                if (Array.isArray(diff) && diff.length > 0) {
+                  diff.forEach((item) => {
+                    if (changes[rowIndex]) {
+                      changes[rowIndex] = {
+                        ...changes[rowIndex],
+                        [item[0]]: Number(item[1]),
+                      };
+                      changes[rowIndex]['rowIndex'] = rowIndex;
+                    } else {
+                      changes[rowIndex] = {
+                        [item[0]]: Number(item[1]),
+                      };
+                      changes[rowIndex]['rowIndex'] = rowIndex;
+                    }
+                  });
+                }
+              }
+            }
+            return changes;
+          }),
+          filter((changes) => Object.keys(changes).length !== 0 && !this.form.invalid),
+        )
+        .subscribe((value) => {
+          console.debug(value);
+          this.formChanges = value;
+          const newInterventionChanges = {
+            ...this.interventionDataService.getInterventionDataChanges(),
+            ...this.formChanges,
+          };
+          this.interventionDataService.setInterventionDataChanges(newInterventionChanges);
+        });
+    }
+  }
+
+  get startupCostArray(): FormArray {
+    return this.form.get('items')['controls'] as FormArray;
+  }
+
+  private createStartupCostGroup(item: StartUpCostBreakdown): FormGroup {
+    return this.formBuilder.group({
+      rowIndex: [item.rowIndex, []],
+      year0: [Number(item.year0), []],
+      year1: [Number(item.year1), []],
+    });
   }
 
   public getTotalCost(yearKey: string): number {
     return this.dataSource.data.map((costBreakdown) => costBreakdown[yearKey]).reduce((acc, value) => acc + value, 0);
+  }
+
+  public confirmChanges(): void {
+    this.interventionDataService.interventionPageConfirmContinue(); // send PATCH updates with changes to the table
+    const newData = this.dialogData.dataIn.costs.filter(
+      (item) => item['section'] !== this.dialogData.dataIn.selectedElement,
+    );
+    console.debug(this.dataSource.data);
+    const selectedCost: StartUpCosts = {
+      section: this.selectedCost.section,
+      costBreakdown: this.dataSource.data,
+      year0Total: this.selectedCost.year0Total,
+      year1Total: this.selectedCost.year1Total,
+    };
+    newData.push(selectedCost);
+    console.debug(newData);
+    // const originalInput = this.dialogData.dataIn;
+    // const updatedInput = this.dialogData
+    // this.interventionDataService.interventionStartupCostChanged(this.dataSource.data); // trigger dialog source page to update content
+    this.dialogData.close();
   }
 }

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionBaseline/interventionBaseline.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionBaseline/interventionBaseline.component.ts
@@ -14,8 +14,9 @@ import {
 import { DialogService } from 'src/app/components/dialogs/dialog.service';
 import { QuickMapsService } from 'src/app/pages/quickMaps/quickMaps.service';
 import { AppRoutes } from 'src/app/routes/routes';
-import { InterventionDataService } from 'src/app/services/interventionData.service';
+import { InterventionDataService, InterventionForm } from 'src/app/services/interventionData.service';
 import { InterventionSideNavContentService } from '../../components/interventionSideNavContent/interventionSideNavContent.service';
+import { FormBuilder, FormArray, FormGroup } from '@angular/forms';
 
 @Component({
   selector: 'app-intervention-baseline',
@@ -40,6 +41,8 @@ export class InterventionBaselineComponent implements AfterViewInit {
 
   private subscriptions = new Array<Subscription>();
   public activeInterventionId: string;
+  public form: FormGroup;
+  public formChanges: InterventionForm['formChanges'] = {};
 
   constructor(
     public quickMapsService: QuickMapsService,
@@ -47,6 +50,7 @@ export class InterventionBaselineComponent implements AfterViewInit {
     private dialogService: DialogService,
     private intSideNavService: InterventionSideNavContentService,
     private readonly cdr: ChangeDetectorRef,
+    private formBuilder: FormBuilder,
   ) {
     this.activeInterventionId = this.interventionDataService.getActiveInterventionId();
     this.intSideNavService.setCurrentStepperPosition(this.pageStepperPosition);
@@ -55,29 +59,28 @@ export class InterventionBaselineComponent implements AfterViewInit {
   public ngAfterViewInit(): void {
     console.debug('id:', this.activeInterventionId);
     this.subscriptions.push(
-      void this.quickMapsService.micronutrient.obs
-        .subscribe((mn: MicronutrientDictionaryItem) => {
-          if (null != mn) {
-            this.interventionDataService
-              .getInterventionFoodVehicleStandards(this.activeInterventionId)
-              .then((data: InterventionFoodVehicleStandards) => {
-                if (null != data) {
-                  this.activeNutrientFVS = data.foodVehicleStandard.filter((standard: FoodVehicleStandard) => {
-                    return standard.micronutrient.includes(mn.name.toLocaleLowerCase());
+      void this.quickMapsService.micronutrient.obs.subscribe((mn: MicronutrientDictionaryItem) => {
+        if (null != mn) {
+          this.interventionDataService
+            .getInterventionFoodVehicleStandards(this.activeInterventionId)
+            .then((data: InterventionFoodVehicleStandards) => {
+              if (null != data) {
+                this.activeNutrientFVS = data.foodVehicleStandard.filter((standard: FoodVehicleStandard) => {
+                  return standard.micronutrient.includes(mn.name.toLocaleLowerCase());
+                });
+                this.createFVTableObject(this.activeNutrientFVS);
+                void this.interventionDataService
+                  .getInterventionBaselineAssumptions(this.activeInterventionId)
+                  .then((data: InterventionBaselineAssumptions) => {
+                    this.baselineAssumptions = data.baselineAssumptions as BaselineAssumptions;
+                    this.createBaselineTableObject();
+                    this.cdr.detectChanges();
                   });
-                  this.createFVTableObject(this.activeNutrientFVS);
-                  void this.interventionDataService
-                    .getInterventionBaselineAssumptions(this.activeInterventionId)
-                    .then((data: InterventionBaselineAssumptions) => {
-                      this.baselineAssumptions = data.baselineAssumptions as BaselineAssumptions;
-                      this.createBaselineTableObject();
-                      this.cdr.detectChanges();
-                    });
-                }
-              });
-          }
-          this.cdr.detectChanges();
-        })
+              }
+            });
+        }
+        this.cdr.detectChanges();
+      }),
     );
   }
 

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionBaseline/interventionBaseline.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionBaseline/interventionBaseline.component.ts
@@ -57,7 +57,7 @@ export class InterventionBaselineComponent implements AfterViewInit {
   }
 
   public ngAfterViewInit(): void {
-    console.debug('id:', this.activeInterventionId);
+    // console.debug('id:', this.activeInterventionId);
     this.subscriptions.push(
       void this.quickMapsService.micronutrient.obs.subscribe((mn: MicronutrientDictionaryItem) => {
         if (null != mn) {

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionBaseline/interventionBaseline.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionBaseline/interventionBaseline.component.ts
@@ -16,7 +16,7 @@ import { QuickMapsService } from 'src/app/pages/quickMaps/quickMaps.service';
 import { AppRoutes } from 'src/app/routes/routes';
 import { InterventionDataService, InterventionForm } from 'src/app/services/interventionData.service';
 import { InterventionSideNavContentService } from '../../components/interventionSideNavContent/interventionSideNavContent.service';
-import { FormBuilder, FormArray, FormGroup } from '@angular/forms';
+import { FormBuilder, FormGroup } from '@angular/forms';
 
 @Component({
   selector: 'app-intervention-baseline',

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCostSummary/components/detailedView/graphCosts/graphCosts.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCostSummary/components/detailedView/graphCosts/graphCosts.component.ts
@@ -41,7 +41,7 @@ export class InterventionCostSummaryDetailedCostsGraphComponent implements OnIni
   }
 
   public openSectionCostReviewDialog(costs: RecurringCosts): void {
-    console.debug(costs);
+    // console.debug(costs);
   }
 
   private initialiseGraph(): void {

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCostSummary/components/quickSummary/graphTotal/graphTotal.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCostSummary/components/quickSummary/graphTotal/graphTotal.component.ts
@@ -22,7 +22,7 @@ export class InterventionCostSummaryQuickTotalGraphComponent implements OnInit {
   }
 
   public openSectionCostReviewDialog(costs: RecurringCosts): void {
-    console.debug(costs);
+    // console.debug(costs);
   }
 
   private initialiseGraph(): void {

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.html
@@ -19,7 +19,7 @@
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
               <input type="text" appDecimalInput [value]="element.year0 * 100"
-                (input)="element.year0 = $any($event.target).value / 100">
+                (input)="element.year0 = $any($event.target).value / 100" formControlName="year0">
             </div>
           </td>
         </ng-container>
@@ -31,7 +31,7 @@
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
               <input type="text" appDecimalInput [value]="element.year1 * 100"
-                (input)="element.year1 = $any($event.target).value / 100">
+                (input)="element.year1 = $any($event.target).value / 100" formControlName="year1">
             </div>
           </td>
         </ng-container>
@@ -43,7 +43,7 @@
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
               <input type="text" appDecimalInput [value]="element.year2 * 100"
-                (input)="element.year2 = $any($event.target).value / 100">
+                (input)="element.year2 = $any($event.target).value / 100" formControlName="year2">
             </div>
           </td>
         </ng-container>
@@ -55,7 +55,7 @@
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
               <input type="text" appDecimalInput [value]="element.year3 * 100"
-                (input)="element.year3 = $any($event.target).value / 100">
+                (input)="element.year3 = $any($event.target).value / 100" formControlName="year3">
             </div>
           </td>
         </ng-container>
@@ -67,7 +67,7 @@
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
               <input type="text" appDecimalInput [value]="element.year4 * 100"
-                (input)="element.year4 = $any($event.target).value / 100">
+                (input)="element.year4 = $any($event.target).value / 100" formControlName="year4">
             </div>
           </td>
         </ng-container>
@@ -79,7 +79,7 @@
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
               <input type="text" appDecimalInput [value]="element.year5 * 100"
-                (input)="element.year5 = $any($event.target).value / 100">
+                (input)="element.year5 = $any($event.target).value / 100" formControlName="year5">
             </div>
           </td>
         </ng-container>
@@ -91,7 +91,7 @@
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
               <input type="text" appDecimalInput [value]="element.year6 * 100"
-                (input)="element.year6 = $any($event.target).value / 100">
+                (input)="element.year6 = $any($event.target).value / 100" formControlName="year6">
             </div>
           </td>
         </ng-container>
@@ -103,7 +103,7 @@
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
               <input type="text" appDecimalInput [value]="element.year7 * 100"
-                (input)="element.year7 = $any($event.target).value / 100">
+                (input)="element.year7 = $any($event.target).value / 100" formControlName="year7">
             </div>
           </td>
         </ng-container>
@@ -115,7 +115,7 @@
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
               <input type="text" appDecimalInput [value]="element.year8 * 100"
-                (input)="element.year8 = $any($event.target).value / 100">
+                (input)="element.year8 = $any($event.target).value / 100" formControlName="year8">
             </div>
           </td>
         </ng-container>
@@ -127,7 +127,7 @@
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
               <input type="text" appDecimalInput [value]="element.year9 * 100"
-                (input)="element.year9 = $any($event.target).value / 100">
+                (input)="element.year9 = $any($event.target).value / 100" formControlName="year9">
             </div>
           </td>
         </ng-container>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionMonitoringInformation/interventionMonitoringInformation.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionMonitoringInformation/interventionMonitoringInformation.component.html
@@ -19,7 +19,7 @@
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
               <input type="text" appDecimalInput [value]="element.year0 * 100"
-                (input)="element.year0 = $any($event.target).value / 100">
+                (input)="element.year0 = $any($event.target).value / 100" formControlName="year0">
             </div>
           </td>
         </ng-container>
@@ -31,7 +31,7 @@
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
               <input type="text" appDecimalInput [value]="element.year1 * 100"
-                (input)="element.year1 = $any($event.target).value / 100">
+                (input)="element.year1 = $any($event.target).value / 100" formControlName="year1">
             </div>
           </td>
         </ng-container>
@@ -43,7 +43,7 @@
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
               <input type="text" appDecimalInput [value]="element.year2 * 100"
-                (input)="element.year2 = $any($event.target).value / 100">
+                (input)="element.year2 = $any($event.target).value / 100" formControlName="year2">
             </div>
           </td>
         </ng-container>
@@ -55,7 +55,7 @@
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
               <input type="text" appDecimalInput [value]="element.year3 * 100"
-                (input)="element.year3 = $any($event.target).value / 100">
+                (input)="element.year3 = $any($event.target).value / 100" formControlName="year3">
             </div>
           </td>
         </ng-container>
@@ -67,7 +67,7 @@
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
               <input type="text" appDecimalInput [value]="element.year4 * 100"
-                (input)="element.year4 = $any($event.target).value / 100">
+                (input)="element.year4 = $any($event.target).value / 100" formControlName="year4">
             </div>
           </td>
         </ng-container>
@@ -79,7 +79,7 @@
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
               <input type="text" appDecimalInput [value]="element.year5 * 100"
-                (input)="element.year5 = $any($event.target).value / 100">
+                (input)="element.year5 = $any($event.target).value / 100" formControlName="year5">
             </div>
           </td>
         </ng-container>
@@ -91,7 +91,7 @@
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
               <input type="text" appDecimalInput [value]="element.year6 * 100"
-                (input)="element.year6 = $any($event.target).value / 100">
+                (input)="element.year6 = $any($event.target).value / 100" formControlName="year6">
             </div>
           </td>
         </ng-container>
@@ -103,7 +103,7 @@
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
               <input type="text" appDecimalInput [value]="element.year7 * 100"
-                (input)="element.year7 = $any($event.target).value / 100">
+                (input)="element.year7 = $any($event.target).value / 100" formControlName="year7">
             </div>
           </td>
         </ng-container>
@@ -115,7 +115,7 @@
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
               <input type="text" appDecimalInput [value]="element.year8 * 100"
-                (input)="element.year8 = $any($event.target).value / 100">
+                (input)="element.year8 = $any($event.target).value / 100" formControlName="year8">
             </div>
           </td>
         </ng-container>
@@ -127,7 +127,7 @@
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
               <input type="text" appDecimalInput [value]="element.year9 * 100"
-                (input)="element.year9 = $any($event.target).value / 100">
+                (input)="element.year9 = $any($event.target).value / 100" formControlName="year9">
             </div>
           </td>
         </ng-container>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionRecurringCosts/interventionRecurringCosts.component.scss
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionRecurringCosts/interventionRecurringCosts.component.scss
@@ -1,7 +1,6 @@
 @use '../interventionReviewPages.scss';
 
-
 :host {
-    display: flex;
-    flex-direction: column;
-  }
+  display: flex;
+  flex-direction: column;
+}

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionRecurringCosts/interventionRecurringCosts.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionRecurringCosts/interventionRecurringCosts.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { Subscription } from 'rxjs';
 import { InterventionRecurringCosts, RecurringCost } from 'src/app/apiAndObjects/objects/interventionRecurringCosts';
 import { AppRoutes } from 'src/app/routes/routes';
 import { InterventionDataService } from 'src/app/services/interventionData.service';
@@ -27,6 +28,8 @@ export class InterventionRecurringCostsComponent implements OnInit {
     'year9Total',
   ];
 
+  private subscriptions = new Array<Subscription>();
+
   constructor(
     private intSideNavService: InterventionSideNavContentService,
     private interventionDataService: InterventionDataService,
@@ -37,8 +40,24 @@ export class InterventionRecurringCostsComponent implements OnInit {
         .getInterventionRecurringCosts(activeInterventionId)
         .then((data: InterventionRecurringCosts) => {
           this.recurringCosts = data.recurringCosts;
+          console.debug('initial: ', this.recurringCosts);
         });
     }
+
+    this.subscriptions.push(
+      this.interventionDataService.interventionRecurringCostChangedObs.subscribe((source: boolean) => {
+        if (source === true) {
+          if (null != activeInterventionId) {
+            this.interventionDataService.interventionRecurringCostChanged(false);
+            void this.interventionDataService
+              .getInterventionRecurringCosts(activeInterventionId)
+              .then((data: InterventionRecurringCosts) => {
+                this.recurringCosts = data.recurringCosts;
+              });
+          }
+        }
+      }),
+    );
   }
   public ngOnInit(): void {
     this.intSideNavService.setCurrentStepperPosition(this.pageStepperPosition);

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionRecurringCosts/interventionRecurringCosts.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionRecurringCosts/interventionRecurringCosts.component.ts
@@ -40,7 +40,7 @@ export class InterventionRecurringCostsComponent implements OnInit {
         .getInterventionRecurringCosts(activeInterventionId)
         .then((data: InterventionRecurringCosts) => {
           this.recurringCosts = data.recurringCosts;
-          console.debug('initial: ', this.recurringCosts);
+          // console.debug('initial: ', this.recurringCosts);
         });
     }
 

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionReviewPages.scss
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionReviewPages.scss
@@ -71,3 +71,9 @@ table {
     border-bottom-color: rgba(0, 0, 0, 0);
   }
 }
+
+// user edited values
+input.ng-dirty {
+  color: $color_input_blue;
+  border-color: $color_input_blue;
+}

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionStartupScaleupCosts/interventionStartupScaleupCosts.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionStartupScaleupCosts/interventionStartupScaleupCosts.component.ts
@@ -1,9 +1,6 @@
 import { Component, OnInit } from '@angular/core';
-import {
-  InterventionStartupCosts,
-  StartUpCostBreakdown,
-  StartUpScaleUpCost,
-} from 'src/app/apiAndObjects/objects/interventionStartupCosts';
+import { Subscription } from 'rxjs';
+import { InterventionStartupCosts, StartUpScaleUpCost } from 'src/app/apiAndObjects/objects/interventionStartupCosts';
 import { AppRoutes } from 'src/app/routes/routes';
 import { InterventionDataService } from 'src/app/services/interventionData.service';
 import { InterventionSideNavContentService } from '../../components/interventionSideNavContent/interventionSideNavContent.service';
@@ -20,6 +17,8 @@ export class InterventionStartupScaleupCostsComponent implements OnInit {
   public startupCosts: Array<StartUpScaleUpCost>;
   public displayHeaders = ['section', 'year0Total', 'year1Total'];
 
+  private subscriptions = new Array<Subscription>();
+
   constructor(
     private intSideNavService: InterventionSideNavContentService,
     private interventionDataService: InterventionDataService,
@@ -32,12 +31,31 @@ export class InterventionStartupScaleupCostsComponent implements OnInit {
           this.startupCosts = data.startupScaleupCosts;
         });
     }
-    // this.interventionDataService.interventionStartupCostChangedObs.subscribe((costs: Array<StartUpCostBreakdown>) => {
-    //   console.debug('intervention was changed by dialog: ', costs);
-    // });
+
+    this.subscriptions.push(
+      this.interventionDataService.interventionStartupCostChangedObs.subscribe((source: boolean) => {
+        if (source === true) {
+          if (null != activeInterventionId) {
+            this.interventionDataService.interventionStartupCostChanged(false);
+            void this.interventionDataService
+              .getInterventionStartupCosts(activeInterventionId)
+              .then((data: InterventionStartupCosts) => {
+                // setting null then timeout prevents the chart from flickering and allows animation to work
+                this.startupCosts = null;
+                setTimeout(() => {
+                  this.startupCosts = data.startupScaleupCosts;
+                }, 0);
+              });
+          }
+        }
+      }),
+    );
   }
 
   public ngOnInit(): void {
     this.intSideNavService.setCurrentStepperPosition(this.pageStepperPosition);
+  }
+  public ngOnDestroy(): void {
+    this.subscriptions.forEach((subscription) => subscription.unsubscribe());
   }
 }

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionStartupScaleupCosts/interventionStartupScaleupCosts.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionStartupScaleupCosts/interventionStartupScaleupCosts.component.ts
@@ -1,5 +1,9 @@
 import { Component, OnInit } from '@angular/core';
-import { InterventionStartupCosts, StartUpScaleUpCost } from 'src/app/apiAndObjects/objects/interventionStartupCosts';
+import {
+  InterventionStartupCosts,
+  StartUpCostBreakdown,
+  StartUpScaleUpCost,
+} from 'src/app/apiAndObjects/objects/interventionStartupCosts';
 import { AppRoutes } from 'src/app/routes/routes';
 import { InterventionDataService } from 'src/app/services/interventionData.service';
 import { InterventionSideNavContentService } from '../../components/interventionSideNavContent/interventionSideNavContent.service';
@@ -28,6 +32,9 @@ export class InterventionStartupScaleupCostsComponent implements OnInit {
           this.startupCosts = data.startupScaleupCosts;
         });
     }
+    // this.interventionDataService.interventionStartupCostChangedObs.subscribe((costs: Array<StartUpCostBreakdown>) => {
+    //   console.debug('intervention was changed by dialog: ', costs);
+    // });
   }
 
   public ngOnInit(): void {

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/utilities/interventionStepDetails/interventionStepDetails.component.scss
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/utilities/interventionStepDetails/interventionStepDetails.component.scss
@@ -19,7 +19,7 @@ div:not(.box) {
 }
 
 .blue {
-  background-color: blue;
+  background-color: $color_input_blue;
 }
 
 .static-review-elements {
@@ -28,7 +28,7 @@ div:not(.box) {
   justify-content: space-between;
   align-items: center;
   padding: 10px;
-  height: 50px;
+  // height: 50px;
 }
 
 .item-bottom-row {

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/utilities/microNutrientsInPremixTable/premixTableRow/premixTableRow.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/utilities/microNutrientsInPremixTable/premixTableRow/premixTableRow.component.ts
@@ -30,7 +30,7 @@ export class PremixTableRowComponent {
 
   constructor(public interventionDataService: InterventionDataService) {
     this.data.subscribe((mn: FoodVehicleStandard) => {
-      console.debug('mn:', mn);
+      // console.debug('mn:', mn);
       if (null != mn) {
         this.initTable(mn);
       }

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/utilities/reusableCostTable/reusableCostTable.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/utilities/reusableCostTable/reusableCostTable.component.html
@@ -68,7 +68,7 @@
   <ng-container matColumnDef="section">
     <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">Years of start-up or scale-up</th>
     <td mat-cell *matCellDef="let element">
-      <button mat-button color="primary" (click)="openSectionStartUpCostReviewDialog(element.section)">
+      <button mat-button color="primary" (click)="openSectionStartUpCostReviewDialog(element)">
         <mat-icon>edit</mat-icon>
         {{element.section}}
       </button>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/utilities/reusableCostTable/reusableCostTable.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/utilities/reusableCostTable/reusableCostTable.component.html
@@ -68,7 +68,7 @@
   <ng-container matColumnDef="section">
     <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">Years of start-up or scale-up</th>
     <td mat-cell *matCellDef="let element">
-      <button mat-button color="primary" (click)="openSectionStartUpCostReviewDialog(element)">
+      <button mat-button color="primary" (click)="openSectionStartUpCostReviewDialog(element.section)">
         <mat-icon>edit</mat-icon>
         {{element.section}}
       </button>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/utilities/reusableCostTable/reusableCostTable.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/utilities/reusableCostTable/reusableCostTable.component.ts
@@ -31,20 +31,11 @@ export class ReusableCostTableComponent implements OnInit {
     this.dialogService.openSectionRecurringCostReviewDialog(costs);
   }
 
-  public openSectionStartUpCostReviewDialog(elementName: string): void {
-    const selectedCost: StartUpScaleUpCostDialogSelection = {
-      selectedElement: elementName,
-      costs: this.startUpScaleUpCost.costs,
-    };
-    this.dialogService.openSectionStartUpCostReviewDialog(selectedCost);
+  public openSectionStartUpCostReviewDialog(costs: StartUpCosts): void {
+    this.dialogService.openSectionStartUpCostReviewDialog(costs);
   }
 
   public getTotalCost(yearKey: string): number {
     return this.dataSource.data.map((costBreakdown) => costBreakdown[yearKey]).reduce((acc, value) => acc + value, 0);
   }
-}
-
-export interface StartUpScaleUpCostDialogSelection {
-  selectedElement: string;
-  costs: Array<StartUpCosts>;
 }

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/utilities/reusableCostTable/reusableCostTable.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/utilities/reusableCostTable/reusableCostTable.component.ts
@@ -31,11 +31,20 @@ export class ReusableCostTableComponent implements OnInit {
     this.dialogService.openSectionRecurringCostReviewDialog(costs);
   }
 
-  public openSectionStartUpCostReviewDialog(costs: StartUpCosts): void {
-    this.dialogService.openSectionStartUpCostReviewDialog(costs);
+  public openSectionStartUpCostReviewDialog(elementName: string): void {
+    const selectedCost: StartUpScaleUpCostDialogSelection = {
+      selectedElement: elementName,
+      costs: this.startUpScaleUpCost.costs,
+    };
+    this.dialogService.openSectionStartUpCostReviewDialog(selectedCost);
   }
 
   public getTotalCost(yearKey: string): number {
     return this.dataSource.data.map((costBreakdown) => costBreakdown[yearKey]).reduce((acc, value) => acc + value, 0);
   }
+}
+
+export interface StartUpScaleUpCostDialogSelection {
+  selectedElement: string;
+  costs: Array<StartUpCosts>;
 }

--- a/src/app/services/interventionData.service.ts
+++ b/src/app/services/interventionData.service.ts
@@ -13,7 +13,11 @@ import {
 import { InterventionIndustryInformation } from '../apiAndObjects/objects/interventionIndustryInformation';
 import { InterventionMonitoringInformation } from '../apiAndObjects/objects/interventionMonitoringInformation';
 import { InterventionRecurringCosts } from '../apiAndObjects/objects/interventionRecurringCosts';
-import { InterventionStartupCosts } from '../apiAndObjects/objects/interventionStartupCosts';
+import {
+  InterventionStartupCosts,
+  StartUpCostBreakdown,
+  StartUpCosts,
+} from '../apiAndObjects/objects/interventionStartupCosts';
 import { AppRoutes } from '../routes/routes';
 
 export const ACTIVE_INTERVENTION_ID = 'activeInterventionId';
@@ -36,6 +40,9 @@ export class InterventionDataService {
 
   private readonly interventionDataChangesSrc = new BehaviorSubject<Record<string, unknown>>(null);
   public interventionDataChangesObs = this.interventionDataChangesSrc.asObservable();
+
+  private readonly interventionStartupCostChangedSrc = new BehaviorSubject<StartUpCosts>(null);
+  public interventionStartupCostChangedObs = this.interventionStartupCostChangedSrc.asObservable();
 
   constructor(private apiService: ApiService, private readonly router: Router, public route: ActivatedRoute) {}
 
@@ -135,6 +142,10 @@ export class InterventionDataService {
   }
   public setInterventionDetailedChartPDF(chart: string): void {
     this.interventionDetailedChartPDFSrc.next(chart);
+  }
+
+  public interventionStartupCostChanged(costs: StartUpCosts): void {
+    this.interventionStartupCostChangedSrc.next(costs);
   }
 
   public getCachedMnInPremix(): Array<FoodVehicleStandard> {

--- a/src/app/services/interventionData.service.ts
+++ b/src/app/services/interventionData.service.ts
@@ -13,11 +13,7 @@ import {
 import { InterventionIndustryInformation } from '../apiAndObjects/objects/interventionIndustryInformation';
 import { InterventionMonitoringInformation } from '../apiAndObjects/objects/interventionMonitoringInformation';
 import { InterventionRecurringCosts } from '../apiAndObjects/objects/interventionRecurringCosts';
-import {
-  InterventionStartupCosts,
-  StartUpCostBreakdown,
-  StartUpCosts,
-} from '../apiAndObjects/objects/interventionStartupCosts';
+import { InterventionStartupCosts } from '../apiAndObjects/objects/interventionStartupCosts';
 import { AppRoutes } from '../routes/routes';
 
 export const ACTIVE_INTERVENTION_ID = 'activeInterventionId';
@@ -41,7 +37,7 @@ export class InterventionDataService {
   private readonly interventionDataChangesSrc = new BehaviorSubject<Record<string, unknown>>(null);
   public interventionDataChangesObs = this.interventionDataChangesSrc.asObservable();
 
-  private readonly interventionStartupCostChangedSrc = new BehaviorSubject<StartUpCosts>(null);
+  private readonly interventionStartupCostChangedSrc = new BehaviorSubject<boolean>(false);
   public interventionStartupCostChangedObs = this.interventionStartupCostChangedSrc.asObservable();
 
   constructor(private apiService: ApiService, private readonly router: Router, public route: ActivatedRoute) {}
@@ -144,8 +140,8 @@ export class InterventionDataService {
     this.interventionDetailedChartPDFSrc.next(chart);
   }
 
-  public interventionStartupCostChanged(costs: StartUpCosts): void {
-    this.interventionStartupCostChangedSrc.next(costs);
+  public interventionStartupCostChanged(source: boolean): void {
+    this.interventionStartupCostChangedSrc.next(source);
   }
 
   public getCachedMnInPremix(): Array<FoodVehicleStandard> {
@@ -215,12 +211,12 @@ export class InterventionDataService {
       }
 
       const interventionId = this.getActiveInterventionId();
-      this.patchInterventionData(interventionId, dataArr);
-
-      this.setInterventionDataChanges(null);
+      return this.patchInterventionData(interventionId, dataArr).then(() => {
+        this.setInterventionDataChanges(null);
+      });
+    } else {
+      return;
     }
-
-    return;
   }
 }
 

--- a/src/app/services/interventionData.service.ts
+++ b/src/app/services/interventionData.service.ts
@@ -39,6 +39,8 @@ export class InterventionDataService {
 
   private readonly interventionStartupCostChangedSrc = new BehaviorSubject<boolean>(false);
   public interventionStartupCostChangedObs = this.interventionStartupCostChangedSrc.asObservable();
+  private readonly interventionRecurringCostChangedSrc = new BehaviorSubject<boolean>(false);
+  public interventionRecurringCostChangedObs = this.interventionRecurringCostChangedSrc.asObservable();
 
   constructor(private apiService: ApiService, private readonly router: Router, public route: ActivatedRoute) {}
 
@@ -142,6 +144,10 @@ export class InterventionDataService {
 
   public interventionStartupCostChanged(source: boolean): void {
     this.interventionStartupCostChangedSrc.next(source);
+  }
+
+  public interventionRecurringCostChanged(source: boolean): void {
+    this.interventionRecurringCostChangedSrc.next(source);
   }
 
   public getCachedMnInPremix(): Array<FoodVehicleStandard> {

--- a/src/assets/scss/_angular_material_components.scss
+++ b/src/assets/scss/_angular_material_components.scss
@@ -85,6 +85,11 @@ mat-form-field.mat-form-field-appearance-fill .mat-select-arrow-wrapper {
   color: black;
 }
 
+.mat-tab-labels {
+  display: flex;
+  justify-content: center;
+}
+
 // Snackbar toasts
 .mat-snack-bar-container.maps-snackbar {
   padding: 0;

--- a/src/assets/scss/_colour.scss
+++ b/src/assets/scss/_colour.scss
@@ -72,3 +72,4 @@ $color_grey: #4f4f4f;
 $color_blue: #1d3557;
 $color_blue_form: #013171;
 $color_background_form: #f1ecf6;
+$color_input_blue: #2e80ed;


### PR DESCRIPTION
- startup costs with dialogs patching data changes
- recurring costs with dialogs patching data changes
- updated industry information to track percentage data not just number
- added blue style to inputs which are modified

## How to test
- look in the interventions pages at recurring costs and startup costs. Open the table dialogs, change values (which should show as blue when edited), confirm to close and save the changes, then reopen the dialog/refresh page and data should persist

## Note
- `.toFixed(2)` on input values are not being honoured. The appDecimal pipe ensures that user inputs are 2dp but if the original data is more than 2dp the `toFixed(2)` does not work.