### PR TITLE
refactor: remove .toPromise() from code and replace with lastValueFrom()

### DIFF
--- a/src/app/apiAndObjects/_lib_code/api/apiCaller.ts
+++ b/src/app/apiAndObjects/_lib_code/api/apiCaller.ts
@@ -1,4 +1,4 @@
-import { Observable } from 'rxjs';
+import { lastValueFrom, Observable } from 'rxjs';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { HttpResponseHandler } from './httpResponseHandler.interface';
 import { RequestMethod } from './requestMethod.enum';
@@ -56,8 +56,7 @@ export class ApiCaller {
         break;
     }
     if (response != null) {
-      return response
-        .toPromise()
+      return lastValueFrom(response)
         .then((responseJson: unknown) =>
           fullResponse
             ? this.httpCallErrorHandler.handleSuccess(responseJson, true)

--- a/src/app/apiAndObjects/api/biomarker/getBiomarkerDataSources.ts
+++ b/src/app/apiAndObjects/api/biomarker/getBiomarkerDataSources.ts
@@ -5,6 +5,7 @@ import { MicronutrientDictionaryItem } from '../../objects/dictionaries/micronut
 import { AgeGenderDictionaryItem } from '../../objects/dictionaries/ageGenderDictionaryItem';
 import { BiomarkerDataSource } from '../../objects/biomarkerDataSource';
 import { HttpClient } from '@angular/common/http';
+import { lastValueFrom } from 'rxjs';
 
 export class GetBiomarkerDataSources extends CacheableEndpoint<
   Array<BiomarkerDataSource>,
@@ -33,7 +34,7 @@ export class GetBiomarkerDataSources extends CacheableEndpoint<
       // response after delay
       new Promise((resolve) => {
         setTimeout(() => {
-          resolve(httpClient.get('/assets/exampleData/biomarker_datasources.json').toPromise());
+          resolve(lastValueFrom(httpClient.get('/assets/exampleData/biomarker_datasources.json')));
         }, 1500);
       }),
     );

--- a/src/app/apiAndObjects/api/diet/getDietDataSources.ts
+++ b/src/app/apiAndObjects/api/diet/getDietDataSources.ts
@@ -4,6 +4,7 @@ import { RequestMethod } from '../../_lib_code/api/requestMethod.enum';
 import { MicronutrientDictionaryItem } from '../../objects/dictionaries/micronutrientDictionaryItem';
 import { DietDataSource } from '../../objects/dietDataSource';
 import { HttpClient } from '@angular/common/http';
+import { lastValueFrom } from 'rxjs';
 
 export class GetDietDataSources extends CacheableEndpoint<
   Array<DietDataSource>,
@@ -31,7 +32,7 @@ export class GetDietDataSources extends CacheableEndpoint<
       // response after delay
       new Promise((resolve) => {
         setTimeout(() => {
-          resolve(httpClient.get('/assets/exampleData/diet_datasources.json').toPromise());
+          resolve(lastValueFrom(httpClient.get('/assets/exampleData/diet_datasources.json')));
         }, 1500);
       }),
     );

--- a/src/app/apiAndObjects/api/diet/getMatchedTotals.ts
+++ b/src/app/apiAndObjects/api/diet/getMatchedTotals.ts
@@ -1,5 +1,6 @@
 /* tslint:disable: no-string-literal */
 import { HttpClient } from '@angular/common/http';
+import { lastValueFrom } from 'rxjs';
 import { MicronutrientDictionaryItem } from '../../objects/dictionaries/micronutrientDictionaryItem';
 import { DietDataSource } from '../../objects/dietDataSource';
 import { MatchedTotals } from '../../objects/matchedTotals';
@@ -34,7 +35,7 @@ export class GetMatchedTotals extends CacheableEndpoint<Array<MatchedTotals>, Ge
       // response after delay
       new Promise((resolve) => {
         setTimeout(() => {
-          resolve(httpClient.get('/assets/exampleData/mn_availability.json').toPromise());
+          resolve(lastValueFrom(httpClient.get('/assets/exampleData/mn_availability.json')));
         }, 1500);
       }),
     );

--- a/src/app/apiAndObjects/api/diet/getMicronutrientAvailability.ts
+++ b/src/app/apiAndObjects/api/diet/getMicronutrientAvailability.ts
@@ -1,5 +1,6 @@
 /* tslint:disable: no-string-literal */
 import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { lastValueFrom } from 'rxjs';
 import { CountryDictionaryItem } from '../../objects/dictionaries/countryDictionaryItem';
 import { MicronutrientDictionaryItem } from '../../objects/dictionaries/micronutrientDictionaryItem';
 import { DietDataSource } from '../../objects/dietDataSource';
@@ -50,7 +51,11 @@ export class GetMicronutrientAvailability extends CacheableEndpoint<
       // response after delay
       new Promise((resolve) => {
         setTimeout(() => {
-          resolve(httpClient.get('/assets/exampleData/mn_availability.json').toPromise());
+          resolve(
+            lastValueFrom(httpClient.get('/assets/exampleData/mn_availability.json')) as Promise<
+              ExtendedRespose<MN_AVAILABILITY_TYPE>
+            >,
+          );
         }, 1500);
       }),
     ).then((d) => ({

--- a/src/app/apiAndObjects/api/diet/getMonthlyFoodGroups.ts
+++ b/src/app/apiAndObjects/api/diet/getMonthlyFoodGroups.ts
@@ -1,5 +1,6 @@
 /* tslint:disable: no-string-literal */
 import { HttpClient } from '@angular/common/http';
+import { lastValueFrom } from 'rxjs';
 import { CountryDictionaryItem } from '../../objects/dictionaries/countryDictionaryItem';
 import { MicronutrientDictionaryItem } from '../../objects/dictionaries/micronutrientDictionaryItem';
 import { DietDataSource } from '../../objects/dietDataSource';
@@ -33,7 +34,11 @@ export class GetMonthlyFoodGroups extends CacheableEndpoint<
       // response after delay
       new Promise((resolve) => {
         setTimeout(() => {
-          resolve(httpClient.get('/assets/exampleData/monthly-food-groups.json').toPromise());
+          resolve(
+            lastValueFrom(httpClient.get('/assets/exampleData/monthly-food-groups.json')) as Promise<
+              Array<MonthlyFoodGroup>
+            >,
+          );
         }, 1500);
       }).then((data: Record<string, unknown>) => {
         if (null != data) {

--- a/src/app/apiAndObjects/api/diet/getNationalSummary.ts
+++ b/src/app/apiAndObjects/api/diet/getNationalSummary.ts
@@ -1,5 +1,6 @@
 /* tslint:disable: no-string-literal */
 import { HttpClient } from '@angular/common/http';
+import { lastValueFrom } from 'rxjs';
 import { CountryDictionaryItem } from '../../objects/dictionaries/countryDictionaryItem';
 import { MicronutrientDictionaryItem } from '../../objects/dictionaries/micronutrientDictionaryItem';
 import { DietaryHouseholdSummary } from '../../objects/dietaryHouseholdSummary';
@@ -33,7 +34,11 @@ export class GetNationalSummary extends CacheableEndpoint<
       // response after delay
       new Promise((resolve) => {
         setTimeout(() => {
-          resolve(httpClient.get('/assets/exampleData/national_summary.json').toPromise());
+          resolve(
+            lastValueFrom(httpClient.get('/assets/exampleData/national_summary.json')) as Promise<
+              Array<DietaryHouseholdSummary>
+            >,
+          );
         }, 1500);
       }).then((data: Array<Record<string, unknown>>) => {
         if (null != data) {

--- a/src/app/apiAndObjects/api/diet/getTopFoods.ts
+++ b/src/app/apiAndObjects/api/diet/getTopFoods.ts
@@ -1,4 +1,5 @@
 import { HttpClient } from '@angular/common/http';
+import { lastValueFrom } from 'rxjs';
 import { MicronutrientDictionaryItem } from '../../objects/dictionaries/micronutrientDictionaryItem';
 import { DietDataSource } from '../../objects/dietDataSource';
 import { DataLevel } from '../../objects/enums/dataLevel.enum';
@@ -33,16 +34,15 @@ export class GetTopFood extends CacheableEndpoint<Array<TopFoodSource>, TopFoodP
       new Promise((resolve) => {
         setTimeout(() => {
           resolve(
-            httpClient
-              .get('/assets/exampleData/top-foods.json')
-              .toPromise()
-              .then((objects: Array<Record<string, unknown>>) => {
+            lastValueFrom(httpClient.get('/assets/exampleData/top-foods.json')).then(
+              (objects: Array<Record<string, unknown>>) => {
                 if (null != objects[0]) {
                   // change something so that the display changes a little (multiply by 0.8 to 0.9)
                   (objects[0][TopFoodSource.KEYS.DAILY_MN_CONTRIBUTION] as number) *= Math.random() * 0.1 + 0.8;
                 }
                 return objects;
-              }),
+              },
+            ),
           );
         }, 1500);
       }),

--- a/src/app/apiAndObjects/api/projections/getMicronutrientProjectionSources.ts
+++ b/src/app/apiAndObjects/api/projections/getMicronutrientProjectionSources.ts
@@ -8,6 +8,7 @@ import { MicronutrientProjectionCommodity } from '../../objects/micronutrientPro
 import { MicronutrientProjectionFoodGroup } from '../../objects/micronutrientProjectionFoodGroup';
 import { FoodSourceGroup } from '../../objects/enums/foodSourceGroup.enum';
 import { ImpactScenarioDictionaryItem } from '../../objects/dictionaries/impactScenarioDictionaryItem';
+import { lastValueFrom } from 'rxjs';
 
 export class GetMicronutrientProjectionSources extends CacheableEndpoint<
   Array<MicronutrientProjectionSource>,
@@ -44,7 +45,11 @@ export class GetMicronutrientProjectionSources extends CacheableEndpoint<
       // response after delay
       new Promise((resolve) => {
         setTimeout(() => {
-          resolve(httpClient.get('/assets/exampleData/projection_commodities.json').toPromise());
+          resolve(
+            lastValueFrom(httpClient.get('/assets/exampleData/projection_commodities.json')) as Promise<
+              Array<MicronutrientProjectionSource>
+            >,
+          );
         }, 1500);
       }).then((data: Array<Record<string, unknown>>) =>
         data.map((item) => {

--- a/src/app/apiAndObjects/api/projections/getProjectionSummaries.ts
+++ b/src/app/apiAndObjects/api/projections/getProjectionSummaries.ts
@@ -1,4 +1,5 @@
 import { HttpClient } from '@angular/common/http';
+import { lastValueFrom } from 'rxjs';
 import { CountryDictionaryItem } from '../../objects/dictionaries/countryDictionaryItem';
 import { ImpactScenarioDictionaryItem } from '../../objects/dictionaries/impactScenarioDictionaryItem';
 import { MicronutrientDictionaryItem } from '../../objects/dictionaries/micronutrientDictionaryItem';
@@ -30,7 +31,9 @@ export class GetProjectionSummaries extends CacheableEndpoint<ProjectionsSummary
       // response after delay
       new Promise((resolve) => {
         setTimeout(() => {
-          resolve(httpClient.get('/assets/exampleData/projection-summary.json').toPromise());
+          resolve(
+            lastValueFrom(httpClient.get('/assets/exampleData/projection-summary.json')) as Promise<ProjectionsSummary>,
+          );
         }, 1500);
       }),
     );

--- a/src/app/apiAndObjects/api/projections/getProjectionTotals.ts
+++ b/src/app/apiAndObjects/api/projections/getProjectionTotals.ts
@@ -5,6 +5,7 @@ import { Endpoint } from '../../_lib_code/api/endpoint.abstract';
 import { CountryDictionaryItem } from '../../objects/dictionaries/countryDictionaryItem';
 import { MicronutrientDictionaryItem } from '../../objects/dictionaries/micronutrientDictionaryItem';
 import { ImpactScenarioDictionaryItem } from '../../objects/dictionaries/impactScenarioDictionaryItem';
+import { lastValueFrom } from 'rxjs';
 
 export class GetProjectionTotals extends Endpoint<
   Array<ProjectedAvailability>,
@@ -32,7 +33,11 @@ export class GetProjectionTotals extends Endpoint<
       // response after delay
       new Promise((resolve) => {
         setTimeout(() => {
-          resolve(httpClient.get('/assets/exampleData/projection-total.json').toPromise());
+          resolve(
+            lastValueFrom(httpClient.get('/assets/exampleData/projection-total.json')) as Promise<
+              Array<ProjectedAvailability>
+            >,
+          );
         }, 1500);
       }).then((data: Array<Record<string, unknown>>) =>
         data.map((item) => {

--- a/src/app/apiAndObjects/api/scenario/getCurrentComposition.ts
+++ b/src/app/apiAndObjects/api/scenario/getCurrentComposition.ts
@@ -5,6 +5,7 @@ import { Endpoint } from '../../_lib_code/api/endpoint.abstract';
 import { DietDataSource } from '../../objects/dietDataSource';
 import { MicronutrientDictionaryItem } from '../../objects/dictionaries/micronutrientDictionaryItem';
 import { HttpClient } from '@angular/common/http';
+import { lastValueFrom } from 'rxjs';
 
 export class GetCurrentComposition extends Endpoint<CurrentComposition, GetCurrentCompositionParams> {
   protected callLive(params: GetCurrentCompositionParams): Promise<CurrentComposition> {
@@ -24,7 +25,9 @@ export class GetCurrentComposition extends Endpoint<CurrentComposition, GetCurre
       // response after delay
       new Promise((resolve) => {
         setTimeout(() => {
-          resolve(httpClient.get('/assets/exampleData/food_composition.json').toPromise());
+          resolve(
+            lastValueFrom(httpClient.get('/assets/exampleData/food_composition.json')) as Promise<CurrentComposition>,
+          );
         }, 1500);
       }),
     );

--- a/src/app/apiAndObjects/api/scenario/getCurrentConsumption.ts
+++ b/src/app/apiAndObjects/api/scenario/getCurrentConsumption.ts
@@ -4,6 +4,7 @@ import { CurrentConsumption } from '../../objects/currentConsumption';
 import { Endpoint } from '../../_lib_code/api/endpoint.abstract';
 import { DietDataSource } from '../../objects/dietDataSource';
 import { HttpClient } from '@angular/common/http';
+import { lastValueFrom } from 'rxjs';
 
 export class GetCurrentConsumption extends Endpoint<CurrentConsumption, GetCurrentConsumptionParams> {
   protected callLive(params: GetCurrentConsumptionParams): Promise<CurrentConsumption> {
@@ -22,7 +23,9 @@ export class GetCurrentConsumption extends Endpoint<CurrentConsumption, GetCurre
       // response after delay
       new Promise((resolve) => {
         setTimeout(() => {
-          resolve(httpClient.get('/assets/exampleData/food_consumption.json').toPromise());
+          resolve(
+            lastValueFrom(httpClient.get('/assets/exampleData/food_consumption.json')) as Promise<CurrentConsumption>,
+          );
         }, 1500);
       }),
     );

--- a/src/app/apiAndObjects/api/scenario/getDietChangeComposition.ts
+++ b/src/app/apiAndObjects/api/scenario/getDietChangeComposition.ts
@@ -6,6 +6,7 @@ import { RequestMethod } from '../../_lib_code/api/requestMethod.enum';
 import { MicronutrientDictionaryItem } from '../../objects/dictionaries/micronutrientDictionaryItem';
 import { MnAvailabilityEndpointHelper, MN_AVAILABILITY_TYPE } from '../diet/mnAvailabilityEndpointHelper';
 import { MnAvailibiltyItem } from '../../objects/mnAvailibilityItem.abstract';
+import { lastValueFrom } from 'rxjs';
 
 export class GetDietChangeComposition extends Endpoint<
   Array<MN_AVAILABILITY_TYPE>,
@@ -41,17 +42,16 @@ export class GetDietChangeComposition extends Endpoint<
       new Promise((resolve) => {
         setTimeout(() => {
           resolve(
-            httpClient
-              .get('/assets/exampleData/mn_availability.json')
-              .toPromise()
-              .then((objects: Array<Record<string, unknown>>) => {
+            lastValueFrom(httpClient.get('/assets/exampleData/mn_availability.json')).then(
+              (objects: Array<Record<string, unknown>>) => {
                 objects.forEach((obj) => {
                   // change something so that the display changes a little (multiply by 0.8 to 0.9)
                   (obj[MnAvailibiltyItem.KEYS.DEFICIENT_VALUE] as number) *= Math.random() * 0.1 + 0.8;
                   (obj[MnAvailibiltyItem.KEYS.DEFICIENT_PERC] as number) *= Math.random() * 0.1 + 0.8;
                 });
                 return objects;
-              }),
+              },
+            ),
           );
         }, 1500);
       }),

--- a/src/app/apiAndObjects/api/scenario/getDietChangeConsumption.ts
+++ b/src/app/apiAndObjects/api/scenario/getDietChangeConsumption.ts
@@ -6,6 +6,7 @@ import { RequestMethod } from '../../_lib_code/api/requestMethod.enum';
 import { MnAvailibiltyItem } from '../../objects/mnAvailibilityItem.abstract';
 import { MnAvailabilityEndpointHelper, MN_AVAILABILITY_TYPE } from '../diet/mnAvailabilityEndpointHelper';
 import { NumberChangeItem } from '../../objects/dietaryChangeItem';
+import { lastValueFrom } from 'rxjs';
 
 export class GetDietChangeConsumption extends Endpoint<
   Array<MN_AVAILABILITY_TYPE>,
@@ -41,17 +42,16 @@ export class GetDietChangeConsumption extends Endpoint<
       new Promise((resolve) => {
         setTimeout(() => {
           resolve(
-            httpClient
-              .get('/assets/exampleData/mn_availability.json')
-              .toPromise()
-              .then((objects: Array<Record<string, unknown>>) => {
+            lastValueFrom(httpClient.get('/assets/exampleData/mn_availability.json')).then(
+              (objects: Array<Record<string, unknown>>) => {
                 objects.forEach((obj) => {
                   // change something so that the display changes a little (multiply by 0.8 to 0.9)
                   (obj[MnAvailibiltyItem.KEYS.DEFICIENT_VALUE] as number) *= Math.random() * 0.1 + 0.8;
                   (obj[MnAvailibiltyItem.KEYS.DEFICIENT_PERC] as number) *= Math.random() * 0.1 + 0.8;
                 });
                 return objects;
-              }),
+              },
+            ),
           );
         }, 1500);
       }),

--- a/src/app/apiAndObjects/api/scenario/getDietChangeFoodItem.ts
+++ b/src/app/apiAndObjects/api/scenario/getDietChangeFoodItem.ts
@@ -6,6 +6,7 @@ import { MicronutrientDictionaryItem } from '../../objects/dictionaries/micronut
 import { MnAvailibiltyItem } from '../../objects/mnAvailibilityItem.abstract';
 import { RequestMethod } from '../../_lib_code/api/requestMethod.enum';
 import { FoodItemChangeItem } from '../../objects/dietaryChangeItem';
+import { lastValueFrom } from 'rxjs';
 
 export class GetDietChangeFoodItem extends Endpoint<
   Array<MN_AVAILABILITY_TYPE>,
@@ -41,17 +42,16 @@ export class GetDietChangeFoodItem extends Endpoint<
       new Promise((resolve) => {
         setTimeout(() => {
           resolve(
-            httpClient
-              .get('/assets/exampleData/mn_availability.json')
-              .toPromise()
-              .then((objects: Array<Record<string, unknown>>) => {
+            lastValueFrom(httpClient.get('/assets/exampleData/mn_availability.json')).then(
+              (objects: Array<Record<string, unknown>>) => {
                 objects.forEach((obj) => {
                   // change something so that the display changes a little (multiply by 0.8 to 0.9)
                   (obj[MnAvailibiltyItem.KEYS.DEFICIENT_VALUE] as number) *= Math.random() * 0.1 + 0.8;
                   (obj[MnAvailibiltyItem.KEYS.DEFICIENT_PERC] as number) *= Math.random() * 0.1 + 0.8;
                 });
                 return objects;
-              }),
+              },
+            ),
           );
         }, 1500);
       }),

--- a/src/app/apiAndObjects/objects/dictionaries/ageGenderDictionaryItem.ts
+++ b/src/app/apiAndObjects/objects/dictionaries/ageGenderDictionaryItem.ts
@@ -1,5 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { Injector } from '@angular/core';
+import { lastValueFrom } from 'rxjs';
 import { MapsDictionaryItem } from './mapsBaseDictionaryItem';
 
 export class AgeGenderDictionaryItem extends MapsDictionaryItem {
@@ -24,7 +25,7 @@ export class AgeGenderDictionaryItem extends MapsDictionaryItem {
   public static getMockItems(injector: Injector): Promise<Array<Record<string, unknown>>> {
     const httpClient = injector.get<HttpClient>(HttpClient);
     // return a single random element when specified
-    return httpClient.get('/assets/exampleData/age-gender-groups.json').toPromise() as Promise<
+    return lastValueFrom(httpClient.get('/assets/exampleData/age-gender-groups.json')) as Promise<
       Array<Record<string, unknown>>
     >;
   }

--- a/src/app/apiAndObjects/objects/dictionaries/countryDictionaryItem.ts
+++ b/src/app/apiAndObjects/objects/dictionaries/countryDictionaryItem.ts
@@ -1,6 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Injector } from '@angular/core';
 import * as GeoJSON from 'geojson';
+import { lastValueFrom } from 'rxjs';
 import { MapsDictionaryItem } from './mapsBaseDictionaryItem';
 
 export class CountryDictionaryItem extends MapsDictionaryItem {
@@ -28,7 +29,7 @@ export class CountryDictionaryItem extends MapsDictionaryItem {
   public static getMockItems(injector: Injector): Promise<Array<Record<string, unknown>>> {
     const httpClient = injector.get<HttpClient>(HttpClient);
     // return a single random element when specified
-    return httpClient.get('/assets/exampleData/country_select.json').toPromise() as Promise<
+    return lastValueFrom(httpClient.get('/assets/exampleData/country_select.json')) as Promise<
       Array<Record<string, unknown>>
     >;
   }

--- a/src/app/apiAndObjects/objects/dictionaries/foodGroupDictionaryItem.ts
+++ b/src/app/apiAndObjects/objects/dictionaries/foodGroupDictionaryItem.ts
@@ -1,5 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { Injector } from '@angular/core';
+import { lastValueFrom } from 'rxjs';
 import { Dictionary } from '../../_lib_code/objects/dictionary';
 import { ObjectAccessor } from '../../_lib_code/objects/objectAccessor';
 import { ObjectBuilder } from '../../_lib_code/objects/objectBuilder';
@@ -45,7 +46,7 @@ export class FoodGroupDictionaryItem extends MapsDictionaryItem {
   public static getMockItems(injector: Injector): Promise<Array<Record<string, unknown>>> {
     const httpClient = injector.get<HttpClient>(HttpClient);
     // return a single random element when specified
-    return httpClient.get('/assets/exampleData/food_groups.json').toPromise() as Promise<
+    return lastValueFrom(httpClient.get('/assets/exampleData/food_groups.json')) as Promise<
       Array<Record<string, unknown>>
     >;
   }

--- a/src/app/apiAndObjects/objects/dictionaries/impactScenarioDictionaryItem.ts
+++ b/src/app/apiAndObjects/objects/dictionaries/impactScenarioDictionaryItem.ts
@@ -1,5 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { Injector } from '@angular/core';
+import { lastValueFrom } from 'rxjs';
 import { MapsDictionaryItem } from './mapsBaseDictionaryItem';
 
 export class ImpactScenarioDictionaryItem extends MapsDictionaryItem {
@@ -21,7 +22,7 @@ export class ImpactScenarioDictionaryItem extends MapsDictionaryItem {
   public static getMockItems(injector: Injector): Promise<Array<Record<string, unknown>>> {
     const httpClient = injector.get<HttpClient>(HttpClient);
     // return a single random element when specified
-    return httpClient.get('/assets/exampleData/impact_scenarios.json').toPromise() as Promise<
+    return lastValueFrom(httpClient.get('/assets/exampleData/impact_scenarios.json')) as Promise<
       Array<Record<string, unknown>>
     >;
   }

--- a/src/app/apiAndObjects/objects/dictionaries/micronutrientDictionaryItem.ts
+++ b/src/app/apiAndObjects/objects/dictionaries/micronutrientDictionaryItem.ts
@@ -1,5 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { Injector } from '@angular/core';
+import { lastValueFrom } from 'rxjs';
 import { MicronutrientMeasureType } from '../enums/micronutrientMeasureType.enum';
 import { MicronutrientType } from '../enums/micronutrientType.enum';
 import { MapsDictionaryItem } from './mapsBaseDictionaryItem';
@@ -20,12 +21,7 @@ export class MicronutrientDictionaryItem extends MapsDictionaryItem {
   public readonly isDiet: boolean;
   public readonly measures = Array<MicronutrientMeasureType>();
 
-  protected constructor(
-    sourceObject: Record<string, unknown>,
-    id: string,
-    name: string,
-    description: string,
-  ) {
+  protected constructor(sourceObject: Record<string, unknown>, id: string, name: string, description: string) {
     super(sourceObject, id, name, description);
 
     this.type = this._getEnum(MicronutrientDictionaryItem.KEYS.TYPE, MicronutrientType);
@@ -46,6 +42,8 @@ export class MicronutrientDictionaryItem extends MapsDictionaryItem {
   public static getMockItems(injector: Injector): Promise<Array<Record<string, unknown>>> {
     const httpClient = injector.get<HttpClient>(HttpClient);
     // return a single random element when specified
-    return httpClient.get('/assets/exampleData/mineral-vitamin-select.json').toPromise() as Promise<Array<Record<string, unknown>>>;
+    return lastValueFrom(httpClient.get('/assets/exampleData/mineral-vitamin-select.json')) as Promise<
+      Array<Record<string, unknown>>
+    >;
   }
 }

--- a/src/app/components/dialogs/baseDialogService.abstract.ts
+++ b/src/app/components/dialogs/baseDialogService.abstract.ts
@@ -1,5 +1,6 @@
 import { ComponentType } from '@angular/cdk/portal';
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
+import { lastValueFrom } from 'rxjs';
 
 export abstract class BaseDialogService {
   private customBackdropCounts = new Map<HTMLElement, number>();
@@ -62,18 +63,12 @@ export abstract class BaseDialogService {
       this.addCustomBackdrop(parentElement);
       dialogRef = this.dialog.open(contentComponent, config);
 
-      void dialogRef
-        .afterClosed()
-        .toPromise()
-        .then(() => {
-          if (null != parentElement) {
-            this.tryRemoveCustomBackdrop(parentElement);
-          }
-        });
-      return dialogRef
-        .afterClosed()
-        .toPromise()
-        .then(() => dialogData);
+      void lastValueFrom(dialogRef.afterClosed()).then(() => {
+        if (null != parentElement) {
+          this.tryRemoveCustomBackdrop(parentElement);
+        }
+      });
+      return lastValueFrom(dialogRef.afterClosed()).then(() => dialogData);
     }
   }
 

--- a/src/app/pages/quickMaps/pages/biomarkers/biomarkerInfo/biomarkerInfo.component.ts
+++ b/src/app/pages/quickMaps/pages/biomarkers/biomarkerInfo/biomarkerInfo.component.ts
@@ -8,7 +8,7 @@ import { DialogService } from 'src/app/components/dialogs/dialog.service';
 import { ChangeDetectorRef } from '@angular/core';
 import { DialogData } from 'src/app/components/dialogs/baseDialogService.abstract';
 import { MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { BehaviorSubject, Subscription } from 'rxjs';
+import { BehaviorSubject, lastValueFrom, Subscription } from 'rxjs';
 import { HttpClient } from '@angular/common/http';
 import { Papa } from 'ngx-papaparse';
 import { QuickMapsService } from '../../../quickMaps.service';
@@ -138,11 +138,8 @@ export class BiomarkerInfoComponent implements AfterViewInit {
       }
     }
 
-    void this.http
-      .get('./assets/dummyData/FakeBiomarkerDataForDev.csv', { responseType: 'text' })
-      .toPromise()
+    void lastValueFrom(this.http.get('./assets/dummyData/FakeBiomarkerDataForDev.csv', { responseType: 'text' }))
       .then((data: string) => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         const blob = this.papa.parse(data, { header: true }).data;
         const dataArray = new Array<AdditionalInformationData>();
 

--- a/src/app/pages/quickMaps/pages/biomarkers/biomarkerStatus/biomarkerStatus.component.ts
+++ b/src/app/pages/quickMaps/pages/biomarkers/biomarkerStatus/biomarkerStatus.component.ts
@@ -16,7 +16,7 @@ import { QuickMapsService } from 'src/app/pages/quickMaps/quickMaps.service';
 import { DialogService } from 'src/app/components/dialogs/dialog.service';
 import { DialogData } from 'src/app/components/dialogs/baseDialogService.abstract';
 import { MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { BehaviorSubject, Subscription } from 'rxjs';
+import { BehaviorSubject, lastValueFrom, Subscription } from 'rxjs';
 import { HttpClient } from '@angular/common/http';
 import { Papa } from 'ngx-papaparse';
 import { MatMenu } from '@angular/material/menu';
@@ -209,10 +209,8 @@ export class BiomarkerStatusComponent implements AfterViewInit {
     if (null != this.card) {
       this.card.title = this.title;
     }
-    void this.http
-      .get('./assets/dummyData/FakeBiomarkerDataForDev.csv', { responseType: 'text' })
-      .toPromise()
-      .then((data: string) => {
+    void lastValueFrom(this.http.get('./assets/dummyData/FakeBiomarkerDataForDev.csv', { responseType: 'text' })).then(
+      (data: string) => {
         const blob = this.papa.parse(data, { header: true }).data;
         const dataArray = new Array<BiomarkerStatusData>();
         blob.forEach((simpleData: simpleDataObject) => {
@@ -230,7 +228,8 @@ export class BiomarkerStatusComponent implements AfterViewInit {
         );
 
         this.mineralData = filterByParamatersArray;
-      });
+      },
+    );
   }
 
   private openDialog(): void {


### PR DESCRIPTION
In the latest version of Angular(14) toPromise () has been deprecated. 
- removed .toPromise() from code and replaced with lastValueFrom()
#### Information regarding the changes: 
https://indepth.dev/posts/1287/rxjs-heads-up-topromise-is-being-deprecated

https://stackoverflow.com/questions/69629634/are-lastvaluefrom-and-firstvaluefrom-equivalent-in-angular-http#:~:text=Since%20this%20a%20synchronous%20call,once%20complete()%20gets%20called.
