### PR TITLE
chore: tweak docker/npm config

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: npm install and npm run build
         run: |
-          npm i
+          npm i --verbose
           npm run build:staging-branch
 
       - name: add robots.txt to stop spidering

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-registry=https://registry.npmjs.org

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apk update && apk upgrade && \
 WORKDIR /micronutrient-support-tool
 COPY package*.json ./
 
-RUN npm i
+RUN npm i --verbose
 COPY . .
 
 RUN npm run build:prod


### PR DESCRIPTION
Removed .npmrc file to allow alternative registries to be picked up.

Github Actions defaults to npm registry correctly and builds and deploys.

Cypress borked, but unrelated to this (API issue)