### PR TITLE
fix: table styling

### DIFF
--- a/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.html
+++ b/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.html
@@ -1,19 +1,15 @@
-<app-base-dialog [data]="dialogData">
+<app-base-dialog [data]="dialogData" [title]="title">
   <div class="bmgf-maps-nice-scrollbar">
-    <div class="title">
-      <span>{{title}}</span>
-    </div>
-
     <form [formGroup]="form" *ngIf="form">
       <table mat-table [dataSource]="dataSource" matSort class="table-full-width" formArrayName="items">
         <ng-container matColumnDef="name">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">Years of start-up or scale-up
+          <th class="row-title-left" mat-header-cell *matHeaderCellDef>Years of start-up or scale-up
           </th>
-          <td mat-cell *matCellDef="let element"> {{element.name}} </td>
-          <td mat-footer-cell *matFooterCellDef>Total</td>
+          <td class="row-title-left" mat-cell *matCellDef="let element"> {{element.name}} </td>
+          <td class="row-title-left" mat-footer-cell *matFooterCellDef>Total</td>
         </ng-container>
         <ng-container matColumnDef="year0">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2021</th>
+          <th mat-header-cell *matHeaderCellDef>2021</th>
           <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
               <input type="text" appDecimalInput required [value]=element.year0 formControlName="year0">
@@ -30,7 +26,7 @@
         </ng-container>
         <!-- year1 -->
         <ng-container matColumnDef="year1">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2022</th>
+          <th mat-header-cell *matHeaderCellDef>2022</th>
           <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
               <input type="text" appDecimalInput required [value]=element.year1 formControlName="year1">
@@ -47,7 +43,7 @@
         </ng-container>
         <!-- year2 -->
         <ng-container matColumnDef="year2">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2023</th>
+          <th mat-header-cell *matHeaderCellDef>2023</th>
           <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
               <input type="text" appDecimalInput required [value]=element.year2 formControlName="year2">
@@ -64,7 +60,7 @@
         </ng-container>
         <!-- year3 -->
         <ng-container matColumnDef="year3">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2024</th>
+          <th mat-header-cell *matHeaderCellDef>2024</th>
           <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
               <input type="text" appDecimalInput required [value]=element.year3 formControlName="year3">
@@ -81,7 +77,7 @@
         </ng-container>
         <!-- year4 -->
         <ng-container matColumnDef="year4">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2025</th>
+          <th mat-header-cell *matHeaderCellDef>2025</th>
           <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
               <input type="text" appDecimalInput required [value]=element.year4 formControlName="year4">
@@ -98,7 +94,7 @@
         </ng-container>
         <!-- year5 -->
         <ng-container matColumnDef="year5">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2026</th>
+          <th mat-header-cell *matHeaderCellDef>2026</th>
           <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
               <input type="text" appDecimalInput required [value]=element.year5 formControlName="year5">
@@ -115,7 +111,7 @@
         </ng-container>
         <!-- year6 -->
         <ng-container matColumnDef="year6">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2027</th>
+          <th mat-header-cell *matHeaderCellDef>2027</th>
           <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
               <input type="text" appDecimalInput required [value]=element.year6 formControlName="year6">
@@ -132,7 +128,7 @@
         </ng-container>
         <!-- year7 -->
         <ng-container matColumnDef="year7">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2028</th>
+          <th mat-header-cell *matHeaderCellDef>2028</th>
           <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
               <input type="text" appDecimalInput required [value]=element.year7 formControlName="year7">
@@ -150,7 +146,7 @@
         </ng-container>
         <!-- year8 -->
         <ng-container matColumnDef="year8">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2029</th>
+          <th mat-header-cell *matHeaderCellDef>2029</th>
           <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
               <input type="text" appDecimalInput required [value]=element.year8 formControlName="year8">
@@ -167,7 +163,7 @@
         </ng-container>
         <!-- year9 -->
         <ng-container matColumnDef="year9">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2030</th>
+          <th mat-header-cell *matHeaderCellDef>2030</th>
           <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
               <input type="text" appDecimalInput required [value]=element.year9 formControlName="year9">

--- a/src/app/components/dialogs/sectionStartUpCostReviewDialog/sectionStartUpCostReviewDialog.component.html
+++ b/src/app/components/dialogs/sectionStartUpCostReviewDialog/sectionStartUpCostReviewDialog.component.html
@@ -1,20 +1,16 @@
-<app-base-dialog [data]="dialogData">
+<app-base-dialog [data]="dialogData" [title]="title">
   <div class="bmgf-maps-nice-scrollbar">
-    <div class="title">
-      <span>{{title}}</span>
-    </div>
-
     <form [formGroup]="form" *ngIf="form">
       <table mat-table [dataSource]="dataSource" matSort class="table-full-width" formArrayName="items">
         <ng-container matColumnDef="name">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">Years of start-up or scale-up
+          <th class="row-title-left" mat-header-cell *matHeaderCellDef>Years of start-up or scale-up
           </th>
-          <td mat-cell *matCellDef="let element"> {{element.name}} </td>
-          <td mat-footer-cell *matFooterCellDef>Total</td>
+          <td class="row-title-left" mat-cell *matCellDef="let element"> {{element.name}} </td>
+          <td class="row-title-left" mat-footer-cell *matFooterCellDef>Total</td>
         </ng-container>
 
         <ng-container matColumnDef="year0">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2021</th>
+          <th mat-header-cell *matHeaderCellDef>2021</th>
           <!-- <td mat-cell *matCellDef="let element">{{element.year0 | currencyExtended}}</td> -->
           <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
@@ -32,7 +28,7 @@
         </ng-container>
 
         <ng-container matColumnDef="year1">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2022</th>
+          <th mat-header-cell *matHeaderCellDef>2022</th>
           <!-- <td mat-cell *matCellDef="let element">{{element.year1 | currencyExtended}}</td> -->
           <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">

--- a/src/app/components/dialogs/sectionSummaryRecurringCostReviewDialog/sectionSummaryRecurringCostReviewDialog.component.html
+++ b/src/app/components/dialogs/sectionSummaryRecurringCostReviewDialog/sectionSummaryRecurringCostReviewDialog.component.html
@@ -1,61 +1,58 @@
-<app-base-dialog [data]="dialogData">
+<app-base-dialog [data]="dialogData" [title]="title">
   <div class="bmgf-maps-nice-scrollbar">
-    <div class="title">
-      <span>{{title}}</span>
-    </div>
     <table mat-table [dataSource]="dataSource" matSort class="table-full-width">
       <ng-container matColumnDef="section">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">Years of start-up or scale-up</th>
-        <td mat-cell *matCellDef="let element"> {{element.section}} </td>
-        <td mat-footer-cell *matFooterCellDef>Total</td>
+        <th class="row-title-left" mat-header-cell *matHeaderCellDef>Years of start-up or scale-up</th>
+        <td class="row-title-left" mat-cell *matCellDef="let element"> {{element.section}} </td>
+        <td class="row-title-left" mat-footer-cell *matFooterCellDef>Total</td>
       </ng-container>
       <ng-container matColumnDef="year0Total">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2021</th>
+        <th mat-header-cell *matHeaderCellDef>2021</th>
         <td mat-cell *matCellDef="let element">{{element.year0Total | currencyExtended}}</td>
         <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year0Total') | currencyExtended}} </td>
       </ng-container>
       <ng-container matColumnDef="year1Total">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2022</th>
+        <th mat-header-cell *matHeaderCellDef>2022</th>
         <td mat-cell *matCellDef="let element">{{element.year1Total | currencyExtended}}</td>
         <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year1Total') | currencyExtended}} </td>
       </ng-container>
       <ng-container matColumnDef="year2Total">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2023</th>
+        <th mat-header-cell *matHeaderCellDef>2023</th>
         <td mat-cell *matCellDef="let element">{{element.year2Total | currencyExtended}}</td>
         <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year2Total') | currencyExtended}} </td>
       </ng-container>
       <ng-container matColumnDef="year3Total">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2024</th>
+        <th mat-header-cell *matHeaderCellDef>2024</th>
         <td mat-cell *matCellDef="let element">{{element.year3Total | currencyExtended}}</td>
         <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year3Total') | currencyExtended}} </td>
       </ng-container>
       <ng-container matColumnDef="year4Total">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2025</th>
+        <th mat-header-cell *matHeaderCellDef>2025</th>
         <td mat-cell *matCellDef="let element">{{element.year4Total | currencyExtended}}</td>
         <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year4Total') | currencyExtended}} </td>
       </ng-container>
       <ng-container matColumnDef="year5Total">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2026</th>
+        <th mat-header-cell *matHeaderCellDef>2026</th>
         <td mat-cell *matCellDef="let element">{{element.year5Total | currencyExtended}}</td>
         <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year5Total') | currencyExtended}} </td>
       </ng-container>
       <ng-container matColumnDef="year6Total">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2027</th>
+        <th mat-header-cell *matHeaderCellDef>2027</th>
         <td mat-cell *matCellDef="let element">{{element.year6Total | currencyExtended}}</td>
         <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year6Total') | currencyExtended}} </td>
       </ng-container>
       <ng-container matColumnDef="year7Total">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2028</th>
+        <th mat-header-cell *matHeaderCellDef>2028</th>
         <td mat-cell *matCellDef="let element">{{element.year7Total | currencyExtended}}</td>
         <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year7Total') | currencyExtended}} </td>
       </ng-container>
       <ng-container matColumnDef="year8Total">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2029</th>
+        <th mat-header-cell *matHeaderCellDef>2029</th>
         <td mat-cell *matCellDef="let element">{{element.year8Total | currencyExtended}}</td>
         <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year8Total') | currencyExtended}} </td>
       </ng-container>
       <ng-container matColumnDef="year9Total">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2030</th>
+        <th mat-header-cell *matHeaderCellDef>2030</th>
         <td mat-cell *matCellDef="let element">{{element.year9Total | currencyExtended}}</td>
         <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year9Total') | currencyExtended}} </td>
       </ng-container>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionAssumptionsReview/interventionAssumptionsReview.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionAssumptionsReview/interventionAssumptionsReview.component.html
@@ -4,53 +4,53 @@
     <div class="title">
       <span>Review of program assumptions</span>
     </div>
-    <table class="no-margin" mat-table [dataSource]="dataSource" matSort>
+    <table class="no-margin" mat-table [dataSource]="dataSource" matSort class="table-full-width">
       <ng-container matColumnDef="title">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">Intervention year</th>
-        <td mat-cell *matCellDef="let element">{{element.title}}</td>
+        <th class="row-title-left" mat-header-cell *matHeaderCellDef>Intervention year</th>
+        <td class="row-title-left" mat-cell *matCellDef="let element">{{element.title}}</td>
       </ng-container>
       <ng-container matColumnDef="standard">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">Standard</th>
+        <th mat-header-cell *matHeaderCellDef>Standard</th>
         <td mat-cell *matCellDef="let element"></td>
       </ng-container>
       <ng-container matColumnDef="year0">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2021</th>
+        <th mat-header-cell *matHeaderCellDef>2021</th>
         <td mat-cell *matCellDef="let element">{{element.year0 | percent}}</td>
       </ng-container>
       <ng-container matColumnDef="year1">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2022</th>
+        <th mat-header-cell *matHeaderCellDef>2022</th>
         <td mat-cell *matCellDef="let element">{{element.year1 | percent}}</td>
       </ng-container>
       <ng-container matColumnDef="year2">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2023</th>
+        <th mat-header-cell *matHeaderCellDef>2023</th>
         <td mat-cell *matCellDef="let element">{{element.year2 | percent}}</td>
       </ng-container>
       <ng-container matColumnDef="year3">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2024</th>
+        <th mat-header-cell *matHeaderCellDef>2024</th>
         <td mat-cell *matCellDef="let element">{{element.year3 | percent}}</td>
       </ng-container>
       <ng-container matColumnDef="year4">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2025</th>
+        <th mat-header-cell *matHeaderCellDef>2025</th>
         <td mat-cell *matCellDef="let element">{{element.year4 | percent}}</td>
       </ng-container>
       <ng-container matColumnDef="year5">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2026</th>
+        <th mat-header-cell *matHeaderCellDef>2026</th>
         <td mat-cell *matCellDef="let element">{{element.year5 | percent}}</td>
       </ng-container>
       <ng-container matColumnDef="year6">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2027</th>
+        <th mat-header-cell *matHeaderCellDef>2027</th>
         <td mat-cell *matCellDef="let element">{{element.year6 | percent}}</td>
       </ng-container>
       <ng-container matColumnDef="year7">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2028</th>
+        <th mat-header-cell *matHeaderCellDef>2028</th>
         <td mat-cell *matCellDef="let element">{{element.year7 | percent}}</td>
       </ng-container>
       <ng-container matColumnDef="year8">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2029</th>
+        <th mat-header-cell *matHeaderCellDef>2029</th>
         <td mat-cell *matCellDef="let element">{{element.year8 | percent}}</td>
       </ng-container>
       <ng-container matColumnDef="year9">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2030</th>
+        <th mat-header-cell *matHeaderCellDef>2030</th>
         <td mat-cell *matCellDef="let element">{{element.year9 | percent}}</td>
       </ng-container>
       <tr mat-header-row *matHeaderRowDef="assumptionsDisplayedColumns;"></tr>
@@ -68,63 +68,63 @@
       </div>
       <table mat-table [dataSource]="newDataSource" matSort>
         <ng-container matColumnDef="standard">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">Standard</th>
+          <th mat-header-cell *matHeaderCellDef>Standard</th>
           <td mat-cell *matCellDef="let element">{{element.standard}}</td>
         </ng-container>
         <ng-container matColumnDef="year0">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2021</th>
+          <th mat-header-cell *matHeaderCellDef>2021</th>
           <td mat-cell *matCellDef="let element">{{element.year0}}</td>
         </ng-container>
         <ng-container matColumnDef="year1">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2022</th>
+          <th mat-header-cell *matHeaderCellDef>2022</th>
           <td mat-cell *matCellDef="let element">
             {{element.year1 | number:'1.1-2'}}
           </td>
         </ng-container>
         <ng-container matColumnDef="year2">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2023</th>
+          <th mat-header-cell *matHeaderCellDef>2023</th>
           <td mat-cell *matCellDef="let element">
             {{element.year2 | number:'1.1-2'}}
           </td>
         </ng-container>
         <ng-container matColumnDef="year3">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2024</th>
+          <th mat-header-cell *matHeaderCellDef>2024</th>
           <td mat-cell *matCellDef="let element">
             {{element.year3 | number:'1.1-2'}}
           </td>
         </ng-container>
         <ng-container matColumnDef="year4">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2025</th>
+          <th mat-header-cell *matHeaderCellDef>2025</th>
           <td mat-cell *matCellDef="let element">
             {{element.year4 | number:'1.1-2'}}
           </td>
         </ng-container>
         <ng-container matColumnDef="year5">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2026</th>
+          <th mat-header-cell *matHeaderCellDef>2026</th>
           <td mat-cell *matCellDef="let element">
             {{element.year5 | number:'1.1-2'}}
           </td>
         </ng-container>
         <ng-container matColumnDef="year6">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2027</th>
+          <th mat-header-cell *matHeaderCellDef>2027</th>
           <td mat-cell *matCellDef="let element">
             {{element.year6 | number:'1.1-2'}}
           </td>
         </ng-container>
         <ng-container matColumnDef="year7">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2028</th>
+          <th mat-header-cell *matHeaderCellDef>2028</th>
           <td mat-cell *matCellDef="let element">
             {{element.year7 | number:'1.1-2'}}
           </td>
         </ng-container>
         <ng-container matColumnDef="year8">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2029</th>
+          <th mat-header-cell *matHeaderCellDef>2029</th>
           <td mat-cell *matCellDef="let element">
             {{element.year8 | number:'1.1-2'}}
           </td>
         </ng-container>
         <ng-container matColumnDef="year9">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2030</th>
+          <th mat-header-cell *matHeaderCellDef>2030</th>
           <td mat-cell *matCellDef="let element">
             {{element.year9 | number:'1.1-2'}}
           </td>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionBaseline/interventionBaseline.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionBaseline/interventionBaseline.component.html
@@ -5,9 +5,9 @@
       <span>Baseline Assumptions</span>
     </div>
 
-    <table mat-table [dataSource]="dataSource">
+    <table mat-table [dataSource]="dataSource" class="table-full-width">
       <ng-container matColumnDef="title">
-        <td mat-cell *matCellDef="let element">
+        <td class="row-title-left" mat-cell *matCellDef="let element">
           {{ element.title }}
         </td>
       </ng-container>
@@ -51,7 +51,7 @@
     </div>
 
     <div class="lower-table-wrapper">
-      <table mat-table [dataSource]="FVdataSource">
+      <table mat-table [dataSource]="FVdataSource" class="table-full-width">
         <ng-container matColumnDef="micronutrient">
           <th class="row-title focus" mat-header-cell *matHeaderCellDef>
             Micronutrient

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionBaseline/interventionBaseline.component.scss
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionBaseline/interventionBaseline.component.scss
@@ -70,12 +70,12 @@ table {
     }
   }
 
-  th {
-    &.mat-mdc-header-cell {
-      border-bottom: none;
-      text-align: left !important;
-    }
-  }
+  // th {
+  //   &.mat-mdc-header-cell {
+  //     border-bottom: none;
+  //     text-align: left !important;
+  //   }
+  // }
 }
 
 .intervention-baseline-panel {

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCompliance/interventionCompliance.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCompliance/interventionCompliance.component.html
@@ -6,67 +6,69 @@
     </div>
     <table mat-table [dataSource]="dataSource" matSort class="table-full-width">
       <ng-container matColumnDef="title">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">Intervention year</th>
-        <td mat-cell *matCellDef="let element">{{element.title}}</td>
+        <th class="row-title-left" mat-header-cell *matHeaderCellDef>Intervention
+          year
+        </th>
+        <td class="row-title-left" mat-cell *matCellDef="let element">{{element.title}}</td>
       </ng-container>
       <ng-container matColumnDef="standard">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">Standard</th>
+        <th mat-header-cell *matHeaderCellDef>Standard</th>
         <td mat-cell *matCellDef="let element"></td>
       </ng-container>
       <ng-container matColumnDef="year0">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2021</th>
+        <th mat-header-cell *matHeaderCellDef>2021</th>
         <td mat-cell *matCellDef="let element">{{element.year0 | percent}}</td>
       </ng-container>
       <ng-container matColumnDef="year1">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2022</th>
+        <th mat-header-cell *matHeaderCellDef>2022</th>
         <td mat-cell *matCellDef="let element">
           <input appDecimalInput type="text" [ngModel]="formatNumberForDisplay(element.year0)">
         </td>
       </ng-container>
       <ng-container matColumnDef="year2">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2023</th>
+        <th mat-header-cell *matHeaderCellDef>2023</th>
         <td mat-cell *matCellDef="let element">
           <input matInput appDecimalInput type="text" [ngModel]="formatNumberForDisplay(element.year2)">
         </td>
       </ng-container>
       <ng-container matColumnDef="year3">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2024</th>
+        <th mat-header-cell *matHeaderCellDef>2024</th>
         <td mat-cell *matCellDef="let element">
           <input appDecimalInput type="text" [ngModel]="formatNumberForDisplay(element.year3)">
         </td>
       </ng-container>
       <ng-container matColumnDef="year4">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2025</th>
+        <th mat-header-cell *matHeaderCellDef>2025</th>
         <td mat-cell *matCellDef="let element">
           <input appDecimalInput type="text" [ngModel]="formatNumberForDisplay(element.year4)">
         </td>
       </ng-container>
       <ng-container matColumnDef="year5">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2026</th>
+        <th mat-header-cell *matHeaderCellDef>2026</th>
         <td mat-cell *matCellDef="let element">
           <input appDecimalInput type="text" [ngModel]="formatNumberForDisplay(element.year5)">
         </td>
       </ng-container>
       <ng-container matColumnDef="year6">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2027</th>
+        <th mat-header-cell *matHeaderCellDef>2027</th>
         <td mat-cell *matCellDef="let element">
           <input appDecimalInput type="text" [ngModel]="formatNumberForDisplay(element.year6)">
         </td>
       </ng-container>
       <ng-container matColumnDef="year7">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2028</th>
+        <th mat-header-cell *matHeaderCellDef>2028</th>
         <td mat-cell *matCellDef="let element">
           <input appDecimalInput type="text" [ngModel]="formatNumberForDisplay(element.year7)">
         </td>
       </ng-container>
       <ng-container matColumnDef="year8">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2029</th>
+        <th mat-header-cell *matHeaderCellDef>2029</th>
         <td mat-cell *matCellDef="let element">
           <input appDecimalInput type="text" [ngModel]="formatNumberForDisplay(element.year8)">
         </td>
       </ng-container>
       <ng-container matColumnDef="year9">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2030</th>
+        <th mat-header-cell *matHeaderCellDef>2030</th>
         <td mat-cell *matCellDef="let element">
           <input appDecimalInput type="text" [ngModel]="formatNumberForDisplay(element.year9)">
         </td>
@@ -86,63 +88,63 @@
       </div>
       <table mat-table [dataSource]="newDataSource" matSort class="table-full-width">
         <ng-container matColumnDef="standard">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">Standard</th>
+          <th mat-header-cell *matHeaderCellDef>Standard</th>
           <td mat-cell *matCellDef="let element">{{element.standard}}</td>
         </ng-container>
         <ng-container matColumnDef="year0">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2021</th>
+          <th mat-header-cell *matHeaderCellDef>2021</th>
           <td mat-cell *matCellDef="let element">{{element.year0}}</td>
         </ng-container>
         <ng-container matColumnDef="year1">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2022</th>
+          <th mat-header-cell *matHeaderCellDef>2022</th>
           <td mat-cell *matCellDef="let element">
             {{element.year1 | number:'1.1-2'}}
           </td>
         </ng-container>
         <ng-container matColumnDef="year2">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2023</th>
+          <th mat-header-cell *matHeaderCellDef>2023</th>
           <td mat-cell *matCellDef="let element">
             {{element.year2 | number:'1.1-2'}}
           </td>
         </ng-container>
         <ng-container matColumnDef="year3">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2024</th>
+          <th mat-header-cell *matHeaderCellDef>2024</th>
           <td mat-cell *matCellDef="let element">
             {{element.year3 | number:'1.1-2'}}
           </td>
         </ng-container>
         <ng-container matColumnDef="year4">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2025</th>
+          <th mat-header-cell *matHeaderCellDef>2025</th>
           <td mat-cell *matCellDef="let element">
             {{element.year4 | number:'1.1-2'}}
           </td>
         </ng-container>
         <ng-container matColumnDef="year5">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2026</th>
+          <th mat-header-cell *matHeaderCellDef>2026</th>
           <td mat-cell *matCellDef="let element">
             {{element.year5 | number:'1.1-2'}}
           </td>
         </ng-container>
         <ng-container matColumnDef="year6">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2027</th>
+          <th mat-header-cell *matHeaderCellDef>2027</th>
           <td mat-cell *matCellDef="let element">
             {{element.year6 | number:'1.1-2'}}
           </td>
         </ng-container>
         <ng-container matColumnDef="year7">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2028</th>
+          <th mat-header-cell *matHeaderCellDef>2028</th>
           <td mat-cell *matCellDef="let element">
             {{element.year7 | number:'1.1-2'}}
           </td>
         </ng-container>
         <ng-container matColumnDef="year8">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2029</th>
+          <th mat-header-cell *matHeaderCellDef>2029</th>
           <td mat-cell *matCellDef="let element">
             {{element.year8 | number:'1.1-2'}}
           </td>
         </ng-container>
         <ng-container matColumnDef="year9">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2030</th>
+          <th mat-header-cell *matHeaderCellDef>2030</th>
           <td mat-cell *matCellDef="let element">
             {{element.year9 | number:'1.1-2'}}
           </td>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCompliance/interventionCompliance.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCompliance/interventionCompliance.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { UntypedFormGroup } from '@angular/forms';
 import { MatTableDataSource } from '@angular/material/table';
 import { Subscription } from 'rxjs';
 import { MicronutrientDictionaryItem } from 'src/app/apiAndObjects/objects/dictionaries/micronutrientDictionaryItem';
@@ -9,7 +10,7 @@ import {
 import { FoodVehicleStandard } from 'src/app/apiAndObjects/objects/interventionFoodVehicleStandards';
 import { QuickMapsService } from 'src/app/pages/quickMaps/quickMaps.service';
 import { AppRoutes } from 'src/app/routes/routes';
-import { InterventionDataService } from 'src/app/services/interventionData.service';
+import { InterventionDataService, InterventionForm } from 'src/app/services/interventionData.service';
 import { InterventionSideNavContentService } from '../../components/interventionSideNavContent/interventionSideNavContent.service';
 @Component({
   selector: 'app-intervention-compliance',
@@ -52,6 +53,8 @@ export class InterventionComplianceComponent implements OnInit {
   public dataSource = new MatTableDataSource();
   public newDataSource = new MatTableDataSource<AverageNutrientLevelTableObject>();
   private subscriptions = new Array<Subscription>();
+  public form: UntypedFormGroup;
+  public formChanges: InterventionForm['formChanges'] = {};
 
   constructor(
     public quickMapsService: QuickMapsService,

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCostSummary/components/detailedView/tableRecurringCosts/tableRecurringCosts.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCostSummary/components/detailedView/tableRecurringCosts/tableRecurringCosts.component.html
@@ -8,61 +8,62 @@
 
         <table mat-table [dataSource]="dataSource" matSort class="table-full-width">
           <ng-container matColumnDef="section">
-            <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">Years</th>
-            <td mat-cell *matCellDef="let element" class="truncate-cell">
-              <button mat-button color="primary" (click)="openSectionRecurringCostReviewDialog(element.category)">
+            <th class="row-title-left" mat-header-cell *matHeaderCellDef>Years</th>
+            <td class="row-title-left" mat-cell *matCellDef="let element" class="truncate-cell">
+              <button class="table-edit-button" mat-button color="primary"
+                (click)="openSectionRecurringCostReviewDialog(element.category)">
                 <mat-icon>edit</mat-icon>{{element.category}}
               </button>
             </td>
-            <td mat-footer-cell *matFooterCellDef> Total </td>
+            <td class="row-title-left" mat-footer-cell *matFooterCellDef> Total </td>
           </ng-container>
           <ng-container matColumnDef="year0Total">
-            <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2021</th>
+            <th mat-header-cell *matHeaderCellDef>2021</th>
             <td mat-cell *matCellDef="let element">{{element.year0CombinedTotal | currencyExtended}}</td>
             <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year0CombinedTotal') | currencyExtended}} </td>
           </ng-container>
           <ng-container matColumnDef="year1Total">
-            <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2022</th>
+            <th mat-header-cell *matHeaderCellDef>2022</th>
             <td mat-cell *matCellDef="let element">{{element.year1CombinedTotal | currencyExtended}}</td>
             <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year1CombinedTotal') | currencyExtended}} </td>
           </ng-container>
           <ng-container matColumnDef="year2Total">
-            <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2023</th>
+            <th mat-header-cell *matHeaderCellDef>2023</th>
             <td mat-cell *matCellDef="let element">{{element.year2CombinedTotal | currencyExtended}}</td>
             <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year2CombinedTotal') | currencyExtended}} </td>
           </ng-container>
           <ng-container matColumnDef="year3Total">
-            <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2024</th>
+            <th mat-header-cell *matHeaderCellDef>2024</th>
             <td mat-cell *matCellDef="let element">{{element.year3CombinedTotal | currencyExtended}}</td>
             <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year3CombinedTotal') | currencyExtended}} </td>
           </ng-container>
           <ng-container matColumnDef="year4Total">
-            <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2025</th>
+            <th mat-header-cell *matHeaderCellDef>2025</th>
             <td mat-cell *matCellDef="let element">{{element.year4CombinedTotal | currencyExtended}}</td>
             <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year4CombinedTotal') | currencyExtended}} </td>
           </ng-container>
           <ng-container matColumnDef="year5Total">
-            <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2026</th>
+            <th mat-header-cell *matHeaderCellDef>2026</th>
             <td mat-cell *matCellDef="let element">{{element.year5CombinedTotal | currencyExtended}}</td>
             <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year5CombinedTotal') | currencyExtended}} </td>
           </ng-container>
           <ng-container matColumnDef="year6Total">
-            <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2027</th>
+            <th mat-header-cell *matHeaderCellDef>2027</th>
             <td mat-cell *matCellDef="let element">{{element.year6CombinedTotal | currencyExtended}}</td>
             <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year6CombinedTotal') | currencyExtended}} </td>
           </ng-container>
           <ng-container matColumnDef="year7Total">
-            <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2028</th>
+            <th mat-header-cell *matHeaderCellDef>2028</th>
             <td mat-cell *matCellDef="let element">{{element.year7CombinedTotal | currencyExtended}}</td>
             <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year7CombinedTotal') | currencyExtended}} </td>
           </ng-container>
           <ng-container matColumnDef="year8Total">
-            <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2029</th>
+            <th mat-header-cell *matHeaderCellDef>2029</th>
             <td mat-cell *matCellDef="let element">{{element.year8CombinedTotal | currencyExtended}}</td>
             <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year8CombinedTotal') | currencyExtended}} </td>
           </ng-container>
           <ng-container matColumnDef="year9Total">
-            <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2030</th>
+            <th mat-header-cell *matHeaderCellDef>2030</th>
             <td mat-cell *matCellDef="let element">{{element.year9CombinedTotal | currencyExtended}}</td>
             <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year9CombinedTotal') | currencyExtended}} </td>
           </ng-container>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCostSummary/components/detailedView/tableStartupCosts/tableStartupCosts.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCostSummary/components/detailedView/tableStartupCosts/tableStartupCosts.component.html
@@ -8,19 +8,19 @@
 
         <table mat-table [dataSource]="dataSource" matSort class="table-full-width">
           <ng-container matColumnDef="section">
-            <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">Years</th>
-            <td mat-cell *matCellDef="let element">
+            <th class="row-title-left" mat-header-cell *matHeaderCellDef>Years</th>
+            <td class="row-title-left" mat-cell *matCellDef="let element">
               {{element.category}}
             </td>
-            <td mat-footer-cell *matFooterCellDef> Total </td>
+            <td class="row-title-left" mat-footer-cell *matFooterCellDef> Total </td>
           </ng-container>
           <ng-container matColumnDef="year0Total">
-            <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2021</th>
+            <th mat-header-cell *matHeaderCellDef>2021</th>
             <td mat-cell *matCellDef="let element">{{element.year0CombinedTotal | currencyExtended}}</td>
             <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year1CombinedTotal') | currencyExtended}} </td>
           </ng-container>
           <ng-container matColumnDef="year1Total">
-            <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2022</th>
+            <th mat-header-cell *matHeaderCellDef>2022</th>
             <td mat-cell *matCellDef="let element">{{element.year1CombinedTotal | currencyExtended}}</td>
             <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year1CombinedTotal') | currencyExtended}} </td>
           </ng-container>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCostSummary/components/quickSummary/tableTotalDiscounted/tableTotalDiscounted.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCostSummary/components/quickSummary/tableTotalDiscounted/tableTotalDiscounted.component.html
@@ -3,48 +3,48 @@
 
   <table mat-table [dataSource]="dataSource" matSort class="table-full-width">
     <ng-container matColumnDef="year">
-      <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">Intervention year</th>
-      <td mat-cell *matCellDef="let element"></td>
+      <th class="row-title-left" mat-header-cell *matHeaderCellDef>Intervention year</th>
+      <td class="row-title-left" mat-cell *matCellDef="let element"></td>
     </ng-container>
 
     <ng-container matColumnDef="year0">
-      <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2021</th>
+      <th mat-header-cell *matHeaderCellDef>2021</th>
       <td mat-cell *matCellDef="let element">{{element.year0 | currencyExtended}}</td>
     </ng-container>
     <ng-container matColumnDef="year1">
-      <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2022</th>
+      <th mat-header-cell *matHeaderCellDef>2022</th>
       <td mat-cell *matCellDef="let element">{{element.year1 | currencyExtended}}</td>
     </ng-container>
     <ng-container matColumnDef="year2">
-      <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2023</th>
+      <th mat-header-cell *matHeaderCellDef>2023</th>
       <td mat-cell *matCellDef="let element">{{element.year2 | currencyExtended}}</td>
     </ng-container>
     <ng-container matColumnDef="year3">
-      <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2024</th>
+      <th mat-header-cell *matHeaderCellDef>2024</th>
       <td mat-cell *matCellDef="let element">{{element.year3 | currencyExtended}}</td>
     </ng-container>
     <ng-container matColumnDef="year4">
-      <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2025</th>
+      <th mat-header-cell *matHeaderCellDef>2025</th>
       <td mat-cell *matCellDef="let element">{{element.year4 | currencyExtended}}</td>
     </ng-container>
     <ng-container matColumnDef="year5">
-      <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2026</th>
+      <th mat-header-cell *matHeaderCellDef>2026</th>
       <td mat-cell *matCellDef="let element">{{element.year5 | currencyExtended}}</td>
     </ng-container>
     <ng-container matColumnDef="year6">
-      <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2027</th>
+      <th mat-header-cell *matHeaderCellDef>2027</th>
       <td mat-cell *matCellDef="let element">{{element.year6 | currencyExtended}}</td>
     </ng-container>
     <ng-container matColumnDef="year7">
-      <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2028</th>
+      <th mat-header-cell *matHeaderCellDef>2028</th>
       <td mat-cell *matCellDef="let element">{{element.year7 | currencyExtended}}</td>
     </ng-container>
     <ng-container matColumnDef="year8">
-      <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2029</th>
+      <th mat-header-cell *matHeaderCellDef>2029</th>
       <td mat-cell *matCellDef="let element">{{element.year8 | currencyExtended}}</td>
     </ng-container>
     <ng-container matColumnDef="year9">
-      <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2030</th>
+      <th mat-header-cell *matHeaderCellDef>2030</th>
       <td mat-cell *matCellDef="let element">{{element.year9 | currencyExtended}}</td>
     </ng-container>
     <tr mat-header-row *matHeaderRowDef="displayHeaders;"></tr>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCostSummary/components/quickSummary/tableTotalUndiscounted/tableTotalUndiscounted.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCostSummary/components/quickSummary/tableTotalUndiscounted/tableTotalUndiscounted.component.html
@@ -1,51 +1,51 @@
 <div class="tab-content">
   <h2>Total (startup + recurring) by year, 2021 USD undiscounted</h2>
 
-  <table mat-table [dataSource]="dataSource" matSort class="data-table table-full-width">
+  <table mat-table [dataSource]="dataSource" matSort class="table-full-width">
     <ng-container matColumnDef="year">
-      <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before" arrowPosition="before">Intervention
+      <th class="row-title-left" mat-header-cell *matHeaderCellDef>Intervention
         year</th>
-      <td mat-cell *matCellDef="let element"></td>
+      <td class="row-title-left" mat-cell *matCellDef="let element"></td>
     </ng-container>
 
     <ng-container matColumnDef="year0">
-      <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before" arrowPosition="before">2021</th>
+      <th mat-header-cell *matHeaderCellDef>2021</th>
       <td mat-cell *matCellDef="let element">{{element.year0 | currencyExtended}}</td>
     </ng-container>
     <ng-container matColumnDef="year1">
-      <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before" arrowPosition="before">2022</th>
+      <th mat-header-cell *matHeaderCellDef>2022</th>
       <td mat-cell *matCellDef="let element">{{element.year1 | currencyExtended}}</td>
     </ng-container>
     <ng-container matColumnDef="year2">
-      <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before" arrowPosition="before">2023</th>
+      <th mat-header-cell *matHeaderCellDef>2023</th>
       <td mat-cell *matCellDef="let element">{{element.year2 | currencyExtended}}</td>
     </ng-container>
     <ng-container matColumnDef="year3">
-      <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before" arrowPosition="before">2024</th>
+      <th mat-header-cell *matHeaderCellDef>2024</th>
       <td mat-cell *matCellDef="let element">{{element.year3 | currencyExtended}}</td>
     </ng-container>
     <ng-container matColumnDef="year4">
-      <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before" arrowPosition="before">2025</th>
+      <th mat-header-cell *matHeaderCellDef>2025</th>
       <td mat-cell *matCellDef="let element">{{element.year4 | currencyExtended}}</td>
     </ng-container>
     <ng-container matColumnDef="year5">
-      <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before" arrowPosition="before">2026</th>
+      <th mat-header-cell *matHeaderCellDef>2026</th>
       <td mat-cell *matCellDef="let element">{{element.year5 | currencyExtended}}</td>
     </ng-container>
     <ng-container matColumnDef="year6">
-      <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before" arrowPosition="before">2027</th>
+      <th mat-header-cell *matHeaderCellDef>2027</th>
       <td mat-cell *matCellDef="let element">{{element.year6 | currencyExtended}}</td>
     </ng-container>
     <ng-container matColumnDef="year7">
-      <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before" arrowPosition="before">2028</th>
+      <th mat-header-cell *matHeaderCellDef>2028</th>
       <td mat-cell *matCellDef="let element">{{element.year7 | currencyExtended}}</td>
     </ng-container>
     <ng-container matColumnDef="year8">
-      <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before" arrowPosition="before">2029</th>
+      <th mat-header-cell *matHeaderCellDef>2029</th>
       <td mat-cell *matCellDef="let element">{{element.year8 | currencyExtended}}</td>
     </ng-container>
     <ng-container matColumnDef="year9">
-      <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before" arrowPosition="before">2030</th>
+      <th mat-header-cell *matHeaderCellDef>2030</th>
       <td mat-cell *matCellDef="let element">{{element.year9 | currencyExtended}}</td>
     </ng-container>
     <tr mat-header-row *matHeaderRowDef="displayHeaders;"></tr>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.html
@@ -5,15 +5,15 @@
       <span> Industry Information </span>
     </div>
     <form [formGroup]="form" *ngIf="form">
-      <table mat-table [dataSource]="dataSource" formArrayName="items">
+      <table mat-table [dataSource]="dataSource" formArrayName="items" class="table-full-width">
         <ng-container matColumnDef="labelText">
-          <th class="row-title" mat-header-cell *matHeaderCellDef> Intervention year </th>
-          <td class="row-title" mat-cell *matCellDef="let element">
+          <th class="row-title-left" mat-header-cell *matHeaderCellDef> Intervention year </th>
+          <td class="row-title-left" mat-cell *matCellDef="let element">
             {{element.labelText}} </td>
         </ng-container>
         <ng-container matColumnDef="year0">
-          <th class="column-title" mat-header-cell *matHeaderCellDef> 2021 </th>
-          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+          <th mat-header-cell *matHeaderCellDef> 2021 </th>
+          <td mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
               <input type="text" appDecimalInput required [value]=element.year0 formControlName="year0">
             </div>
@@ -24,8 +24,8 @@
           </td>
         </ng-container>
         <ng-container matColumnDef="year1">
-          <th class="column-title" mat-header-cell *matHeaderCellDef> 2022 </th>
-          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+          <th mat-header-cell *matHeaderCellDef> 2022 </th>
+          <td mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
               <input type="text" appDecimalInput required [value]=element.year1 formControlName="year1">
             </div>
@@ -36,8 +36,8 @@
           </td>
         </ng-container>
         <ng-container matColumnDef="year2">
-          <th class="column-title" mat-header-cell *matHeaderCellDef> 2023 </th>
-          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+          <th mat-header-cell *matHeaderCellDef> 2023 </th>
+          <td mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
               <input type="text" appDecimalInput required [value]=element.year2 formControlName="year2">
             </div>
@@ -48,8 +48,8 @@
           </td>
         </ng-container>
         <ng-container matColumnDef="year3">
-          <th class="column-title" mat-header-cell *matHeaderCellDef> 2024 </th>
-          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+          <th mat-header-cell *matHeaderCellDef> 2024 </th>
+          <td mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
               <input type="text" appDecimalInput required [value]=element.year3 formControlName="year3">
             </div>
@@ -60,8 +60,8 @@
           </td>
         </ng-container>
         <ng-container matColumnDef="year4">
-          <th class="column-title" mat-header-cell *matHeaderCellDef> 2025 </th>
-          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+          <th mat-header-cell *matHeaderCellDef> 2025 </th>
+          <td mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
               <input type="text" appDecimalInput required [value]=element.year4 formControlName="year4">
             </div>
@@ -72,8 +72,8 @@
           </td>
         </ng-container>
         <ng-container matColumnDef="year5">
-          <th class="column-title" mat-header-cell *matHeaderCellDef> 2026 </th>
-          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+          <th mat-header-cell *matHeaderCellDef> 2026 </th>
+          <td mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
               <input type="text" appDecimalInput required [value]=element.year5 formControlName="year5">
             </div>
@@ -84,8 +84,8 @@
           </td>
         </ng-container>
         <ng-container matColumnDef="year6">
-          <th class="column-title" mat-header-cell *matHeaderCellDef> 2027</th>
-          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+          <th mat-header-cell *matHeaderCellDef> 2027</th>
+          <td mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
               <input type="text" appDecimalInput required [value]=element.year6 formControlName="year6">
             </div>
@@ -96,8 +96,8 @@
           </td>
         </ng-container>
         <ng-container matColumnDef="year7">
-          <th class="column-title" mat-header-cell *matHeaderCellDef> 2028 </th>
-          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+          <th mat-header-cell *matHeaderCellDef> 2028 </th>
+          <td mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
               <input type="text" appDecimalInput required [value]=element.year7 formControlName="year7">
             </div>
@@ -108,8 +108,8 @@
           </td>
         </ng-container>
         <ng-container matColumnDef="year8">
-          <th class="column-title" mat-header-cell *matHeaderCellDef> 2029 </th>
-          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+          <th mat-header-cell *matHeaderCellDef> 2029 </th>
+          <td mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
               <input type="text" appDecimalInput required [value]=element.year8 formControlName="year8">
             </div>
@@ -120,8 +120,8 @@
           </td>
         </ng-container>
         <ng-container matColumnDef="year9">
-          <th class="column-title" mat-header-cell *matHeaderCellDef> 2030 </th>
-          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+          <th mat-header-cell *matHeaderCellDef> 2030 </th>
+          <td mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
               <input type="text" appDecimalInput required [value]=element.year9 formControlName="year9">
             </div>
@@ -132,8 +132,8 @@
           </td>
         </ng-container>
         <ng-container matColumnDef="source">
-          <th class="column-title" mat-header-cell *matHeaderCellDef> Source </th>
-          <td class="column-title" mat-cell *matCellDef="let element">
+          <th mat-header-cell *matHeaderCellDef> Source </th>
+          <td mat-cell *matCellDef="let element">
             <span>
               <button mat-button color="primary">
                 GFDx<mat-icon>arrow_right_alt</mat-icon>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionMonitoringInformation/interventionMonitoringInformation.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionMonitoringInformation/interventionMonitoringInformation.component.html
@@ -5,15 +5,15 @@
       <span>Program Monitoring Information</span>
     </div>
     <form [formGroup]="form" *ngIf="form">
-      <table mat-table [dataSource]="dataSource" formArrayName="items">
+      <table mat-table [dataSource]="dataSource" formArrayName="items" class="table-full-width">
         <ng-container matColumnDef="labelText">
-          <th class="row-title" mat-header-cell *matHeaderCellDef> Intervention year </th>
-          <td class="row-title" mat-cell *matCellDef="let element">
+          <th class="row-title-left" mat-header-cell *matHeaderCellDef> Intervention year </th>
+          <td class="row-title-left" mat-cell *matCellDef="let element">
             {{element.labelText}} </td>
         </ng-container>
         <ng-container matColumnDef="year0">
-          <th class="column-title" mat-header-cell *matHeaderCellDef> 2021 </th>
-          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+          <th mat-header-cell *matHeaderCellDef> 2021 </th>
+          <td mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
               <input type="text" appDecimalInput required [value]=element.year0 formControlName="year0">
             </div>
@@ -24,8 +24,8 @@
           </td>
         </ng-container>
         <ng-container matColumnDef="year1">
-          <th class="column-title" mat-header-cell *matHeaderCellDef> 2022 </th>
-          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+          <th mat-header-cell *matHeaderCellDef> 2022 </th>
+          <td mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
               <input type="text" appDecimalInput required [value]=element.year1 formControlName="year1">
             </div>
@@ -36,8 +36,8 @@
           </td>
         </ng-container>
         <ng-container matColumnDef="year2">
-          <th class="column-title" mat-header-cell *matHeaderCellDef> 2023 </th>
-          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+          <th mat-header-cell *matHeaderCellDef> 2023 </th>
+          <td mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
               <input type="text" appDecimalInput required [value]=element.year2 formControlName="year2">
             </div>
@@ -48,8 +48,8 @@
           </td>
         </ng-container>
         <ng-container matColumnDef="year3">
-          <th class="column-title" mat-header-cell *matHeaderCellDef> 2024 </th>
-          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+          <th mat-header-cell *matHeaderCellDef> 2024 </th>
+          <td mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
               <input type="text" appDecimalInput required [value]=element.year3 formControlName="year3">
             </div>
@@ -60,8 +60,8 @@
           </td>
         </ng-container>
         <ng-container matColumnDef="year4">
-          <th class="column-title" mat-header-cell *matHeaderCellDef> 2025 </th>
-          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+          <th mat-header-cell *matHeaderCellDef> 2025 </th>
+          <td mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
               <input type="text" appDecimalInput required [value]=element.year4 formControlName="year4">
             </div>
@@ -72,8 +72,8 @@
           </td>
         </ng-container>
         <ng-container matColumnDef="year5">
-          <th class="column-title" mat-header-cell *matHeaderCellDef> 2026 </th>
-          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+          <th mat-header-cell *matHeaderCellDef> 2026 </th>
+          <td mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
               <input type="text" appDecimalInput required [value]=element.year5 formControlName="year5">
             </div>
@@ -84,8 +84,8 @@
           </td>
         </ng-container>
         <ng-container matColumnDef="year6">
-          <th class="column-title" mat-header-cell *matHeaderCellDef> 2027</th>
-          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+          <th mat-header-cell *matHeaderCellDef> 2027</th>
+          <td mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
               <input type="text" appDecimalInput required [value]=element.year6 formControlName="year6">
             </div>
@@ -96,8 +96,8 @@
           </td>
         </ng-container>
         <ng-container matColumnDef="year7">
-          <th class="column-title" mat-header-cell *matHeaderCellDef> 2028 </th>
-          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+          <th mat-header-cell *matHeaderCellDef> 2028 </th>
+          <td mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
               <input type="text" appDecimalInput required [value]=element.year7 formControlName="year7">
             </div>
@@ -108,8 +108,8 @@
           </td>
         </ng-container>
         <ng-container matColumnDef="year8">
-          <th class="column-title" mat-header-cell *matHeaderCellDef> 2029 </th>
-          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+          <th mat-header-cell *matHeaderCellDef> 2029 </th>
+          <td mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
               <input type="text" appDecimalInput required [value]=element.year8 formControlName="year8">
             </div>
@@ -120,8 +120,8 @@
           </td>
         </ng-container>
         <ng-container matColumnDef="year9">
-          <th class="column-title" mat-header-cell *matHeaderCellDef> 2030 </th>
-          <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
+          <th mat-header-cell *matHeaderCellDef> 2030 </th>
+          <td mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
               <input type="text" appDecimalInput required [value]=element.year9 formControlName="year9">
             </div>
@@ -132,8 +132,8 @@
           </td>
         </ng-container>
         <ng-container matColumnDef="source">
-          <th class="column-title" mat-header-cell *matHeaderCellDef> Source </th>
-          <td class="column-title" mat-cell *matCellDef="let element">
+          <th mat-header-cell *matHeaderCellDef> Source </th>
+          <td mat-cell *matCellDef="let element">
             <span>
               <button matTooltip="Source: Global Fortification Data Exchange" mat-button color="primary">
                 GFDx<mat-icon>arrow_right_alt</mat-icon>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionReviewPages.scss
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionReviewPages.scss
@@ -88,14 +88,14 @@ table {
 
   td.mat-mdc-cell {
     border-bottom-color: rgba(0, 0, 0, 0);
-    text-align: left;
+    text-align: center;
 
-    &.mat-column-micronutrient {
-      color: mat.get-color-from-palette($_primary_pallete, A700);
-      font-weight: 700;
-      font-family: 'Quicksand', sans-serif;
-      padding: 0 1.25rem;
-    }
+    // &.mat-column-micronutrient {
+    //   color: mat.get-color-from-palette($_primary_pallete, A700);
+    //   font-weight: 700;
+    //   font-family: 'Quicksand', sans-serif;
+    //   padding: 0 1.25rem;
+    // }
   }
 }
 

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/utilities/microNutrientsInPremixTable/premixTableRow/premixTable.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/utilities/microNutrientsInPremixTable/premixTableRow/premixTable.component.html
@@ -1,75 +1,74 @@
-<table mat-table [dataSource]="dataSource">
-    <ng-container matColumnDef="micronutrient">
-        <td class="column-title" mat-cell *matCellDef="let element">
-            <ng-container *ngIf="!editable">
-                <span class="micronutrient-title">{{ element.micronutrient }}</span>
-            </ng-container>
-            <ng-container *ngIf="editable">
-                <!-- <button class="remove-mn" *ngIf="editable" mat-button (click)="removeMn(element)">
+<table mat-table [dataSource]="dataSource" class="table-full-width">
+  <ng-container matColumnDef="micronutrient">
+    <td class="column-title" mat-cell *matCellDef="let element">
+      <ng-container *ngIf="!editable">
+        <span class="micronutrient-title">{{ element.micronutrient }}</span>
+      </ng-container>
+      <ng-container *ngIf="editable">
+        <!-- <button class="remove-mn" *ngIf="editable" mat-button (click)="removeMn(element)">
                     <mat-icon color="danger">highlight_off</mat-icon>
                 </button> -->
-                <span class="micronutrient-title">{{ element.micronutrient }}</span>
-            </ng-container>
-        </td>
-    </ng-container>
-    <ng-container matColumnDef="compounds">
-        <td class="column-title" mat-cell *matCellDef="let element">
-            <mat-form-field appearance="outline" class="override">
-                <mat-select [(ngModel)]="selectedCompound" matNativeControl
-                    (selectionChange)="handleSelectCompound($event)">
-                    <mat-option *ngFor="let item of element.compounds" [value]="item">
-                        {{ item.id }}
-                        {{ item.compound }}
-                    </mat-option>
-                </mat-select>
-            </mat-form-field>
-        </td>
-    </ng-container>
-    <ng-container matColumnDef="targetVal">
-        <td class="column-title" mat-cell *matCellDef="let element;">
-            <div class="double-cell">
-                <input type="number" matInput required [value]="selectedCompound.targetVal">
-                <button mat-button>
-                    GFDx<mat-icon>arrow_right_alt</mat-icon>
-                </button>
-            </div>
-        </td>
-    </ng-container>
-    <ng-container matColumnDef="avgVal">
-        <td class="column-title" mat-cell *matCellDef="let element;">
-            <div class="double-cell">
-                <span>
-                    {{ selectedCompound.targetVal * baselineAssumptions.potentiallyFortified.year0 | sigFig: 3 }}
-                </span>
-                <span>
-                    <button mat-button>
-                        GFDx<mat-icon>arrow_right_alt</mat-icon>
-                    </button>
-                </span>
-            </div>
-        </td>
-    </ng-container>
-    <ng-container matColumnDef="optFort">
-        <td class="column-title" mat-cell *matCellDef="let element">
-            <div class="double-cell">
-                <input type="number" matInput required [(ngModel)]="optionalUserEnteredAverageAtPointOfFortification">
-                <span>
-                    <button mat-button>
-                        GFDx<mat-icon>arrow_right_alt</mat-icon>
-                    </button>
-                </span>
-            </div>
-        </td>
-    </ng-container>
-    <ng-container matColumnDef="calcFort">
-        <td class="column-title" mat-cell *matCellDef="let element">
-            <span>
-                {{ (optionalUserEnteredAverageAtPointOfFortification *
-                baselineAssumptions.actuallyFortified.year0 *
-                baselineAssumptions.potentiallyFortified.year0) | sigFig: 3 }}
-            </span>
-        </td>
-    </ng-container>
+        <span class="micronutrient-title">{{ element.micronutrient }}</span>
+      </ng-container>
+    </td>
+  </ng-container>
+  <ng-container matColumnDef="compounds">
+    <td class="column-title" mat-cell *matCellDef="let element">
+      <mat-form-field appearance="outline" class="override">
+        <mat-select [(ngModel)]="selectedCompound" matNativeControl (selectionChange)="handleSelectCompound($event)">
+          <mat-option *ngFor="let item of element.compounds" [value]="item">
+            {{ item.id }}
+            {{ item.compound }}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+    </td>
+  </ng-container>
+  <ng-container matColumnDef="targetVal">
+    <td class="column-title" mat-cell *matCellDef="let element;">
+      <div class="double-cell">
+        <input type="number" matInput required [value]="selectedCompound.targetVal">
+        <button mat-button>
+          GFDx<mat-icon>arrow_right_alt</mat-icon>
+        </button>
+      </div>
+    </td>
+  </ng-container>
+  <ng-container matColumnDef="avgVal">
+    <td class="column-title" mat-cell *matCellDef="let element;">
+      <div class="double-cell">
+        <span>
+          {{ selectedCompound.targetVal * baselineAssumptions.potentiallyFortified.year0 | sigFig: 3 }}
+        </span>
+        <span>
+          <button mat-button>
+            GFDx<mat-icon>arrow_right_alt</mat-icon>
+          </button>
+        </span>
+      </div>
+    </td>
+  </ng-container>
+  <ng-container matColumnDef="optFort">
+    <td class="column-title" mat-cell *matCellDef="let element">
+      <div class="double-cell">
+        <input type="number" matInput required [(ngModel)]="optionalUserEnteredAverageAtPointOfFortification">
+        <span>
+          <button mat-button>
+            GFDx<mat-icon>arrow_right_alt</mat-icon>
+          </button>
+        </span>
+      </div>
+    </td>
+  </ng-container>
+  <ng-container matColumnDef="calcFort">
+    <td class="column-title" mat-cell *matCellDef="let element">
+      <span>
+        {{ (optionalUserEnteredAverageAtPointOfFortification *
+        baselineAssumptions.actuallyFortified.year0 *
+        baselineAssumptions.potentiallyFortified.year0) | sigFig: 3 }}
+      </span>
+    </td>
+  </ng-container>
 
-    <tr mat-row *matRowDef="let row; columns: addedFVdisplayedColumns;"></tr>
+  <tr mat-row *matRowDef="let row; columns: addedFVdisplayedColumns;"></tr>
 </table>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/utilities/reusableCostTable/reusableCostTable.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/utilities/reusableCostTable/reusableCostTable.component.html
@@ -1,60 +1,61 @@
-<table mat-table *ngIf="null != recurringCost" [dataSource]="dataSource" matSort>
+<table mat-table *ngIf="null != recurringCost" [dataSource]="dataSource" matSort class="table-full-width">
   <ng-container matColumnDef="section">
-    <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">Years of start-up or scale-up</th>
-    <td mat-cell *matCellDef="let element">
-      <button mat-button color="primary" (click)="openSectionRecurringCostReviewDialog(element)">
+    <th class="row-title-left" mat-header-cell *matHeaderCellDef>Years of start-up or scale-up</th>
+    <td class="row-title-left" mat-cell *matCellDef="let element">
+      <button class="table-edit-button" mat-button color="primary"
+        (click)="openSectionRecurringCostReviewDialog(element)">
         <mat-icon>edit</mat-icon>{{element.section}}
       </button>
     </td>
-    <td mat-footer-cell *matFooterCellDef> Total </td>
+    <td class="row-title-left" mat-footer-cell *matFooterCellDef> Total </td>
   </ng-container>
   <ng-container matColumnDef="year0Total">
-    <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2021</th>
+    <th mat-header-cell *matHeaderCellDef>2021</th>
     <td mat-cell *matCellDef="let element">{{element.year0Total | currencyExtended}}</td>
     <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year0Total') | currencyExtended}} </td>
   </ng-container>
   <ng-container matColumnDef="year1Total">
-    <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2022</th>
+    <th mat-header-cell *matHeaderCellDef>2022</th>
     <td mat-cell *matCellDef="let element">{{element.year1Total | currencyExtended}}</td>
     <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year1Total') | currencyExtended}} </td>
   </ng-container>
   <ng-container matColumnDef="year2Total">
-    <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2023</th>
+    <th mat-header-cell *matHeaderCellDef>2023</th>
     <td mat-cell *matCellDef="let element">{{element.year2Total | currencyExtended}}</td>
     <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year2Total') | currencyExtended}} </td>
   </ng-container>
   <ng-container matColumnDef="year3Total">
-    <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2024</th>
+    <th mat-header-cell *matHeaderCellDef>2024</th>
     <td mat-cell *matCellDef="let element">{{element.year3Total | currencyExtended}}</td>
     <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year3Total') | currencyExtended}} </td>
   </ng-container>
   <ng-container matColumnDef="year4Total">
-    <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2025</th>
+    <th mat-header-cell *matHeaderCellDef>2025</th>
     <td mat-cell *matCellDef="let element">{{element.year4Total | currencyExtended}}</td>
     <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year4Total') | currencyExtended}} </td>
   </ng-container>
   <ng-container matColumnDef="year5Total">
-    <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2026</th>
+    <th mat-header-cell *matHeaderCellDef>2026</th>
     <td mat-cell *matCellDef="let element">{{element.year5Total | currencyExtended}}</td>
     <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year5Total') | currencyExtended}} </td>
   </ng-container>
   <ng-container matColumnDef="year6Total">
-    <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2027</th>
+    <th mat-header-cell *matHeaderCellDef>2027</th>
     <td mat-cell *matCellDef="let element">{{element.year6Total | currencyExtended}}</td>
     <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year6Total') | currencyExtended}} </td>
   </ng-container>
   <ng-container matColumnDef="year7Total">
-    <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2028</th>
+    <th mat-header-cell *matHeaderCellDef>2028</th>
     <td mat-cell *matCellDef="let element">{{element.year7Total | currencyExtended}}</td>
     <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year7Total') | currencyExtended}} </td>
   </ng-container>
   <ng-container matColumnDef="year8Total">
-    <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2029</th>
+    <th mat-header-cell *matHeaderCellDef>2029</th>
     <td mat-cell *matCellDef="let element">{{element.year8Total | currencyExtended}}</td>
     <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year8Total') | currencyExtended}} </td>
   </ng-container>
   <ng-container matColumnDef="year9Total">
-    <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2030</th>
+    <th mat-header-cell *matHeaderCellDef>2030</th>
     <td mat-cell *matCellDef="let element">{{element.year9Total | currencyExtended}}</td>
     <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year9Total') | currencyExtended}} </td>
   </ng-container>
@@ -64,24 +65,25 @@
   <tr mat-footer-row *matFooterRowDef="headers"></tr>
 </table>
 
-<table mat-table *ngIf="null != startUpScaleUpCost" [dataSource]="dataSource" matSort>
+<table mat-table *ngIf="null != startUpScaleUpCost" [dataSource]="dataSource" matSort class="table-full-width">
   <ng-container matColumnDef="section">
-    <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">Years of start-up or scale-up</th>
-    <td mat-cell *matCellDef="let element">
-      <button mat-button color="primary" (click)="openSectionStartUpCostReviewDialog(element)">
+    <th class="row-title-left" mat-header-cell *matHeaderCellDef>Years of start-up or scale-up</th>
+    <td class="row-title-left" mat-cell *matCellDef="let element">
+      <button class="table-edit-button" mat-button color="primary"
+        (click)="openSectionStartUpCostReviewDialog(element)">
         <mat-icon>edit</mat-icon>
         {{element.section}}
       </button>
     </td>
-    <td mat-footer-cell *matFooterCellDef> Total </td>
+    <td class="row-title-left" mat-footer-cell *matFooterCellDef> Total </td>
   </ng-container>
   <ng-container matColumnDef="year0Total">
-    <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2021</th>
+    <th mat-header-cell *matHeaderCellDef>2021</th>
     <td mat-cell *matCellDef="let element">{{element.year0Total | currencyExtended}}</td>
     <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year0Total') | currencyExtended}} </td>
   </ng-container>
   <ng-container matColumnDef="year1Total">
-    <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">2022</th>
+    <th mat-header-cell *matHeaderCellDef>2022</th>
     <td mat-cell *matCellDef="let element">{{element.year1Total | currencyExtended}}</td>
     <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year1Total') | currencyExtended}} </td>
   </ng-container>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/utilities/reusableCostTable/reusableCostTable.component.scss
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/utilities/reusableCostTable/reusableCostTable.component.scss
@@ -1,4 +1,4 @@
-@use '../../../interventionReview.component.scss';
+// @use '../../../interventionReview.component.scss';
 
 table {
   width: 95%;

--- a/src/assets/scss/_angular_material_components.scss
+++ b/src/assets/scss/_angular_material_components.scss
@@ -126,6 +126,9 @@ mat-tooltip-component .mat-mdc-tooltip {
 .mat-vertical-stepper-header {
   pointer-events: none !important;
 }
+.mat-step-label {
+  white-space: unset !important;
+}
 .mat-step-label-selected .mat-step-text-label {
   font-size: 20px;
   font-weight: bold;

--- a/src/assets/scss/_tables.scss
+++ b/src/assets/scss/_tables.scss
@@ -1,18 +1,55 @@
 @import './colour';
 
-.mat-mdc-table {
+.mat-mdc-header-cell {
   font-family: 'Ubuntu Mono' !important;
-  text-align: right !important;
+  text-align: center !important;
+}
+.mat-sort-header-container {
+  flex-direction: column !important;
+  justify-content: center !important;
+}
+.mat-mdc-cell {
+  font-family: 'Ubuntu Mono' !important;
+  text-align: center !important;
+}
+.mat-mdc-footer-cell {
+  font-family: 'Ubuntu Mono' !important;
+  text-align: center !important;
+}
+
+.column-title {
+  text-align: center !important;
+  &-left {
+    text-align: left !important;
+  }
+}
+.row-title {
+  text-align: center !important;
+  &-left {
+    text-align: left !important;
+  }
 }
 
 .table-full-width {
   width: 100%;
 }
 
+.table-edit-button {
+  text-align: left !important;
+  font-size: 12px !important;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 th.mat-mdc-header-cell {
-  text-align: right !important;
+  // text-align: right !important;
 }
 
 .mdc-data-table__table {
   min-width: 1px !important;
+}
+
+.mdc-data-table__cell {
+  padding: 0px !important;
 }

--- a/src/assets/scss/_typography.scss
+++ b/src/assets/scss/_typography.scss
@@ -25,5 +25,6 @@ $custom-typography: mat.define-typography-config(
   $headline-1: mat.define-typography-level(48px, 48px, 600),
   $subtitle-1: mat.define-typography-level(25px, 30px, 400),
   $body-1: mat.define-typography-level(14px, 20px, 500),
+  $body-2: mat.define-typography-level(14px, 20px, 500),
   $button: mat.define-typography-level(14px, 20px, 600, 'Quicksand', normal),
 );

--- a/src/environments/environment.base.ts
+++ b/src/environments/environment.base.ts
@@ -14,7 +14,7 @@ export const environment = {
 
   //main API
   // apiBaseUrl: 'https://api.micronutrient.support/dev/v2',
-  apiBaseUrl: 'https://api.micronutrient.support/',
+  apiBaseUrl: 'https://api.micronutrient.support/v2',
 
   //temp api:
   //apiBaseUrl: 'http://zhwldock002.ad.nerc.ac.uk:3001/',


### PR DESCRIPTION
- tables use monospace font across the app again, this was disabled by css changes
- table columns centralised by default unless specified to left align
- dialogs using in-built title instead of custom one
- intervention review sidebar word wrapping instead of truncating

## testing
- do tables look ok?
- do table fonts look ok?
- do table headers align correctly?
- are there any elements missing the correct font and alignment to match similar?