### PR TITLE
fix: tweaks to tables, tidy js warnings

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -27,7 +27,10 @@
               "unleash-proxy-client",
               "merge-options",
               "file-saver",
-              "dom-to-image"
+              "dom-to-image",
+              "moment",
+              "chroma-js",
+              "driver.js"
             ],
             "outputPath": "dist/micronutrient-support-tool",
             "index": "src/index.html",
@@ -44,10 +47,7 @@
               },
               "src/manifest.webmanifest"
             ],
-            "styles": [
-              "src/styles.scss",
-              "./node_modules/leaflet/dist/leaflet.css"
-            ],
+            "styles": ["src/styles.scss", "./node_modules/leaflet/dist/leaflet.css"],
             "scripts": [],
             "vendorChunk": true,
             "extractLicenses": false,
@@ -149,14 +149,8 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.spec.json",
             "karmaConfig": "karma.conf.js",
-            "assets": [
-              "src/favicon.ico",
-              "src/assets",
-              "src/manifest.webmanifest"
-            ],
-            "styles": [
-              "src/styles.scss"
-            ],
+            "assets": ["src/favicon.ico", "src/assets", "src/manifest.webmanifest"],
+            "styles": ["src/styles.scss"],
             "scripts": []
           }
         },

--- a/src/app/components/dialogs/costEffectivenessSelectionDialog/costEffectivenessSelectionDialog.component.scss
+++ b/src/app/components/dialogs/costEffectivenessSelectionDialog/costEffectivenessSelectionDialog.component.scss
@@ -36,5 +36,5 @@ mat-form-field {
 }
 
 .result-wrapper {
-  margin: 5px 0 5px 0;
+  margin: 10px 0 5px 0;
 }

--- a/src/app/pages/quickMaps/pages/baselineDetails/mapView/mapView.component.ts
+++ b/src/app/pages/quickMaps/pages/baselineDetails/mapView/mapView.component.ts
@@ -192,9 +192,11 @@ export class MapViewComponent implements AfterViewInit {
 
   private init(dataPromise: Promise<ExtendedRespose<MnAvailibiltyItem>>): void {
     this.loadingSrc.next(true);
+    console.log('map dataPromise: ', dataPromise);
     dataPromise
       .then((data: ExtendedRespose<MnAvailibiltyItem>) => {
         this.data = data.data;
+        console.debug('map dada: ', this.data);
         if (data.meta.bins) {
           const range = data.meta.bins.data as number[];
           if (range[0] === 0) {

--- a/src/app/pages/quickMaps/pages/baselineDetails/mapView/mapView.component.ts
+++ b/src/app/pages/quickMaps/pages/baselineDetails/mapView/mapView.component.ts
@@ -192,11 +192,9 @@ export class MapViewComponent implements AfterViewInit {
 
   private init(dataPromise: Promise<ExtendedRespose<MnAvailibiltyItem>>): void {
     this.loadingSrc.next(true);
-    console.log('map dataPromise: ', dataPromise);
     dataPromise
       .then((data: ExtendedRespose<MnAvailibiltyItem>) => {
         this.data = data.data;
-        console.debug('map dada: ', this.data);
         if (data.meta.bins) {
           const range = data.meta.bins.data as number[];
           if (range[0] === 0) {

--- a/src/app/pages/quickMaps/pages/costEffectiveness/components/intervention/intervention.component.scss
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/components/intervention/intervention.component.scss
@@ -34,7 +34,7 @@
   width: 50%;
   display: flex;
   flex-direction: row-reverse;
-  align-items: end;
+  align-items: flex-end;
 }
 
 .item-container {

--- a/src/assets/scss/_tables.scss
+++ b/src/assets/scss/_tables.scss
@@ -1,5 +1,8 @@
 @import './colour';
 
+table {
+  padding: 5px;
+}
 .mat-mdc-header-cell {
   font-family: 'Ubuntu Mono' !important;
   text-align: center !important;
@@ -28,6 +31,10 @@
   &-left {
     text-align: left !important;
   }
+}
+.mdc-data-table__cell,
+.mdc-data-table__header-cell {
+  padding: 0 0 0 0 !important;
 }
 
 .table-full-width {


### PR DESCRIPTION
- tables have padding to better fit within parent content
- table header cells removed padding to align with row content
- js defined in angular.json to mute warnings about bailouts