### PR TITLE
feat: update add and load intervention dialog

### DIFF
--- a/src/app/components/dialogs/costEffectivenessSelectionDialog/costEffectivenessSelectionDialog.component.html
+++ b/src/app/components/dialogs/costEffectivenessSelectionDialog/costEffectivenessSelectionDialog.component.html
@@ -8,23 +8,23 @@
       <mat-tab label="Copy & edit intervention template">
         <h2 class="dropdown-title">Select intervention template</h2>
         <mat-form-field appearance="outline">
-          <mat-select (empty)="null" placeholder="Select an intervention" [(ngModel)]="selectedIntervention"
+          <mat-select (empty)="null" placeholder="Select an intervention" [(ngModel)]="selectedInterventionEdit"
             matNativeControl required>
             <mat-option *ngFor="let intervention of interventions" [value]="intervention">
               {{ intervention.name }}
             </mat-option>
           </mat-select>
         </mat-form-field>
-        <ng-container *ngIf="selectedIntervention">
+        <ng-container *ngIf="selectedInterventionEdit">
           <form [formGroup]="interventionForm" (ngSubmit)="handleSubmit()" id="form">
             <mat-form-field appearance="outline">
               <mat-label>Intervention name</mat-label>
-              <input matInput [placeholder]="selectedIntervention.name" name="newInterventionName"
+              <input matInput [placeholder]="selectedInterventionEdit.name" name="newInterventionName"
                 formControlName="newInterventionName" required>
             </mat-form-field>
             <mat-form-field appearance="outline">
               <mat-label>Intervention description</mat-label>
-              <textarea matInput [placeholder]="selectedIntervention.description" name="newInterventionDesc"
+              <textarea matInput [placeholder]="selectedInterventionEdit.description" name="newInterventionDesc"
                 formControlName="newInterventionDesc"></textarea>
             </mat-form-field>
           </form>
@@ -32,23 +32,24 @@
       </mat-tab>
       <mat-tab label="Load an existing intervention">
         <div class="content-container">
-          <mat-form-field appearance="outline" class="intervention-form-field">
-            <mat-label>Intervention ID</mat-label>
-            <input matInput placeholder="Enter intervention ID" type="text" [(ngModel)]="interventionId"
-              (ngModelChange)="handleChange()">
+          <mat-form-field appearance="outline">
+            <mat-select (empty)="null" placeholder="Select an intervention" [(ngModel)]="selectedInterventionLoad"
+              (ngModelChange)="this.proceed.next(true);" matNativeControl required>
+              <mat-option *ngFor="let intervention of interventions" [value]="intervention">
+                (<strong>ID:</strong> {{ intervention.id }}) <strong>Name:</strong> {{ intervention.name }}
+              </mat-option>
+            </mat-select>
           </mat-form-field>
-          <button mat-stroked-button color="primary" (click)="handleLookup()">
-            Look up ID
-          </button>
         </div>
         <div class="result-wrapper" [ngClass]="(showResults.asObservable() | async) === true ? 'visible' : 'hidden'">
-          <ng-container *ngIf="selectedIntervention">
+          <ng-container *ngIf="selectedInterventionLoad">
             <ng-container *ngIf="(err.asObservable() | async) === false">
-              <p><strong>Intervention Name:</strong> {{ selectedIntervention.name }}</p>
-              <p><strong>Description:</strong> {{ selectedIntervention.description }}</p>
+              <h2>Selected Intervention Summary</h2>
+              <p><strong>Intervention Name:</strong> {{ selectedInterventionLoad.name }}</p>
+              <p><strong>Description:</strong> {{ selectedInterventionLoad.description }}</p>
             </ng-container>
           </ng-container>
-          <ng-container *ngIf="(err.asObservable() | async) === true || selectedIntervention === null">
+          <ng-container *ngIf="(err.asObservable() | async) === true || selectedInterventionLoad === null">
             <strong>No intervention found with ID: {{ interventionId }}</strong>
           </ng-container>
         </div>

--- a/src/app/components/dialogs/costEffectivenessSelectionDialog/costEffectivenessSelectionDialog.component.html
+++ b/src/app/components/dialogs/costEffectivenessSelectionDialog/costEffectivenessSelectionDialog.component.html
@@ -35,7 +35,7 @@
           <mat-form-field appearance="outline">
             <mat-select (empty)="null" placeholder="Select an intervention" [(ngModel)]="selectedInterventionLoad"
               (ngModelChange)="this.proceed.next(true);" matNativeControl required>
-              <mat-option *ngFor="let intervention of interventions" [value]="intervention">
+              <mat-option *ngFor="let intervention of interventionsAllowedToUse" [value]="intervention">
                 (<strong>ID:</strong> {{ intervention.id }}) <strong>Name:</strong> {{ intervention.name }}
               </mat-option>
             </mat-select>

--- a/src/app/components/dialogs/costEffectivenessSelectionDialog/costEffectivenessSelectionDialog.component.ts
+++ b/src/app/components/dialogs/costEffectivenessSelectionDialog/costEffectivenessSelectionDialog.component.ts
@@ -15,6 +15,7 @@ import { DialogData } from '../baseDialogService.abstract';
 })
 export class CostEffectivenessSelectionDialogComponent implements OnInit {
   public interventions: Array<InterventionsDictionaryItem>;
+  public interventionsAllowedToUse: Array<InterventionsDictionaryItem>;
   public selectedInterventionEdit: Intervention;
   public selectedInterventionLoad: Intervention;
   public interventionId = '';
@@ -23,6 +24,7 @@ export class CostEffectivenessSelectionDialogComponent implements OnInit {
   public interventionForm: UntypedFormGroup;
   public proceed = new BehaviorSubject<boolean>(false);
   public showResults = new BehaviorSubject<boolean>(false);
+  private onlyAllowInterventionsAboveID = 3;
 
   constructor(
     public dialog: MatDialog,
@@ -31,6 +33,10 @@ export class CostEffectivenessSelectionDialogComponent implements OnInit {
     private formBuilder: UntypedFormBuilder,
   ) {
     this.interventions = dialogData.dataIn as Array<InterventionsDictionaryItem>;
+    // Only allow interventions to be loaded directly which are above an ID. This can be updated to check for an intervention parameter when API allows it.
+    this.interventionsAllowedToUse = this.interventions.filter(
+      (item: InterventionsDictionaryItem) => Number(item.id) > this.onlyAllowInterventionsAboveID,
+    );
   }
 
   ngOnInit(): void {

--- a/src/app/components/dialogs/costEffectivenessSelectionDialog/costEffectivenessSelectionDialog.component.ts
+++ b/src/app/components/dialogs/costEffectivenessSelectionDialog/costEffectivenessSelectionDialog.component.ts
@@ -15,7 +15,8 @@ import { DialogData } from '../baseDialogService.abstract';
 })
 export class CostEffectivenessSelectionDialogComponent implements OnInit {
   public interventions: Array<InterventionsDictionaryItem>;
-  public selectedIntervention: Intervention;
+  public selectedInterventionEdit: Intervention;
+  public selectedInterventionLoad: Intervention;
   public interventionId = '';
   public tabID = 'copy';
   public err = new BehaviorSubject<boolean>(false);
@@ -50,23 +51,9 @@ export class CostEffectivenessSelectionDialogComponent implements OnInit {
     });
   }
 
-  public getInterventionById(id: string) {
-    this.interventionDataService
-      .getIntervention(id)
-      .then((response) => {
-        this.err.next(false);
-        this.selectedIntervention = response;
-        this.proceed.next(true);
-      })
-      .catch((err) => {
-        console.error(err);
-        this.err.next(true);
-      });
-  }
-
   private createInterventionCopy(newName: string, newDesc: string): void {
     this.interventionDataService
-      .setIntervention(Number(this.selectedIntervention.id), newName, newDesc)
+      .setIntervention(Number(this.selectedInterventionEdit.id), newName, newDesc)
       .then((result) => {
         this.dialogData.dataOut = result;
         this.closeDialog();
@@ -93,11 +80,6 @@ export class CostEffectivenessSelectionDialogComponent implements OnInit {
     this.proceed.next(false);
   }
 
-  public handleLookup(): void {
-    this.getInterventionById(this.interventionId);
-    this.showResults.next(true);
-  }
-
   public handleChange(): void {
     this.proceed.next(false);
     this.showResults.next(false);
@@ -117,8 +99,8 @@ export class CostEffectivenessSelectionDialogComponent implements OnInit {
 
   public createIntervention(): void {
     if (this.tabID === 'load') {
-      if (this.selectedIntervention !== null) {
-        this.dialogData.dataOut = this.selectedIntervention;
+      if (this.selectedInterventionLoad !== null) {
+        this.dialogData.dataOut = this.selectedInterventionLoad;
         this.closeDialog();
       }
     }

--- a/src/app/pages/quickMaps/pages/costEffectiveness/components/interventionCreation/interventionCreation.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/components/interventionCreation/interventionCreation.component.ts
@@ -29,7 +29,7 @@ export class InterventionCreationComponent {
     private router: Router,
     private interventionCreationService: InterventionCreationService,
   ) {
-    void dictionariesService.getDictionaries([DictionaryType.INTERVENTIONS]).then((dicts: Array<Dictionary>) => {
+    void dictionariesService.getDictionaries([DictionaryType.INTERVENTIONS], false).then((dicts: Array<Dictionary>) => {
       this.interventionsDictionaryItems = dicts.shift().getItems();
       this.loadInterventions();
     });
@@ -69,9 +69,18 @@ export class InterventionCreationComponent {
         });
         this.selectedInterventions.push(data.dataOut);
         this.interventionCreationService.updateCurrentInterventionsCount(this.selectedInterventions.length);
+        this.updateInterventionsFromAPI();
         this.cdr.detectChanges();
       }
     });
+  }
+
+  public updateInterventionsFromAPI(): void {
+    void this.dictionariesService
+      .getDictionaries([DictionaryType.INTERVENTIONS], false)
+      .then((dicts: Array<Dictionary>) => {
+        this.interventionsDictionaryItems = dicts.shift().getItems();
+      });
   }
 
   public removeInterventionById(interventionToRemove: string): void {

--- a/src/app/pages/quickMaps/quickMaps.component.html
+++ b/src/app/pages/quickMaps/quickMaps.component.html
@@ -1,6 +1,6 @@
 <div role="main">
   <div *ngIf="(quickMapsService.init.obs | async) === false" class="service-down">
-    <div class="flex-col">
+    <!-- <div class="flex-col">
       <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-alert-triangle" width="150"
         height="150" viewBox="0 0 24 24" stroke-width="1.5" stroke="#703aa3" fill="none" stroke-linecap="round"
         stroke-linejoin="round">
@@ -13,7 +13,7 @@
       <p class="status">Alternatively, you can monitor the status of services by clicking on
         <a href="https://stats.uptimerobot.com/g8Vr6ulQEm" rel="noopen noreferrer" target="_blank">this link.</a>
       </p>
-    </div>
+    </div> -->
   </div>
   <mat-sidenav-container class="sidenav-container" *ngIf="quickMapsService.init.obs | async">
     <mat-sidenav [disableClose]="true" opened mode="side"

--- a/src/app/pages/quickMaps/quickMaps.component.scss
+++ b/src/app/pages/quickMaps/quickMaps.component.scss
@@ -17,6 +17,9 @@ router-outlet ::ng-deep + * {
   left: 0;
   right: 0;
 }
+.map-placeholder {
+  background-color: #dddddd;
+}
 
 // fix the footer position
 ::ng-deep app-footer-light {

--- a/src/app/services/dictionary.service.ts
+++ b/src/app/services/dictionary.service.ts
@@ -15,7 +15,7 @@ export class DictionaryService {
   public getDictionary(type: DictionaryType): Promise<Dictionary> {
     return this.apiService.getDictionary(type);
   }
-  public getDictionaries(types: Array<DictionaryType>): Promise<Array<Dictionary>> {
-    return this.apiService.getDictionaries(types);
+  public getDictionaries(types: Array<DictionaryType>, useCache?: boolean): Promise<Array<Dictionary>> {
+    return this.apiService.getDictionaries(types, useCache);
   }
 }


### PR DESCRIPTION
- fork/load intervention dialog updated to show latest interventions from api instead of only on first load
- load interventions input now a dropdown list of latest interventions instead of manual number input
- only interventions above ID 3 are allowed to be loaded. This is hard coded for now but can use intervention parameter when api enables it

## to test
- load an intervention from the dialog using the drop down list
- fork an intervention, then open the dialog again and confirm that the newly created intervention can be loaded from the dropdown list
- only interventions iD > 3 can be loaded from the dropdown list