### PR TITLE
User edited inputs visible

### DIFF
--- a/src/app/apiAndObjects/objects/dictionaries/interventionDictionaryItem.ts
+++ b/src/app/apiAndObjects/objects/dictionaries/interventionDictionaryItem.ts
@@ -11,6 +11,9 @@ export class InterventionsDictionaryItem extends MapsDictionaryItem {
     FOOD_VEHICLE_NAME: 'foodVehicleName',
     BASE_YEAR: 'baseYear',
     TEN_YEAR_TOTAL: 'tenYearTotalCost',
+    LAST_EDITED: 'lastEdited',
+    IS_TEMPLATE_INTERVENTION: 'isTemplateIntervention',
+    PARENT_INTERVENTION: 'parentIntervention',
   };
   public readonly countryId: string;
   public readonly fortificationTypeId: string;
@@ -20,6 +23,9 @@ export class InterventionsDictionaryItem extends MapsDictionaryItem {
   public readonly foodVehicleName: string;
   public readonly baseYear: number;
   public readonly tenYearTotalCost: number;
+  public readonly lastEdited: string;
+  public readonly isTemplateIntervention: boolean;
+  public readonly parentIntervention: number;
 
   protected constructor(sourceObject: Record<string, unknown>, id: string, name: string, description: string) {
     super(sourceObject, id, name, description);
@@ -32,5 +38,8 @@ export class InterventionsDictionaryItem extends MapsDictionaryItem {
     this.foodVehicleName = this._getString(InterventionsDictionaryItem.KEYS.FOOD_VEHICLE_NAME);
     this.baseYear = this._getNumber(InterventionsDictionaryItem.KEYS.BASE_YEAR);
     this.tenYearTotalCost = this._getNumber(InterventionsDictionaryItem.KEYS.TEN_YEAR_TOTAL);
+    this.lastEdited = this._getString(InterventionsDictionaryItem.KEYS.LAST_EDITED);
+    this.isTemplateIntervention = this._getBoolean(InterventionsDictionaryItem.KEYS.IS_TEMPLATE_INTERVENTION);
+    this.parentIntervention = this._getNumber(InterventionsDictionaryItem.KEYS.PARENT_INTERVENTION);
   }
 }

--- a/src/app/apiAndObjects/objects/intervention.ts
+++ b/src/app/apiAndObjects/objects/intervention.ts
@@ -15,13 +15,15 @@ export class Intervention extends BaseObject implements Named {
     FOOD_VEHICLE_NAME: 'foodVehicleName',
     BASE_YEAR: 'baseYear',
     TEN_YEAR_TOTAL: 'tenYearTotalCost',
+    LAST_EDITED: 'lastEdited',
+    IS_TEMPLATE_INTERVENTION: 'isTemplateIntervention',
+    PARENT_INTERVENTION: 'parentIntervention',
   };
 
   public readonly id: number;
   public readonly name: string;
   public readonly description: string;
   public readonly dataLevel: DataLevel;
-
   public readonly countryId: string;
   public readonly fortificationTypeId: string;
   public readonly fortificationTypeName: string;
@@ -30,6 +32,10 @@ export class Intervention extends BaseObject implements Named {
   public readonly foodVehicleName: string;
   public readonly baseYear: number;
   public readonly tenYearTotalCost: number;
+  public readonly lastEdited: string;
+  public readonly isTemplateIntervention: boolean;
+  public readonly parentIntervention: number;
+
   protected constructor(sourceObject?: Record<string, unknown>) {
     super(sourceObject);
     this.id = this._getNumber(Intervention.KEYS.ID);
@@ -46,5 +52,8 @@ export class Intervention extends BaseObject implements Named {
     this.foodVehicleName = this._getString(Intervention.KEYS.FOOD_VEHICLE_NAME);
     this.baseYear = this._getNumber(Intervention.KEYS.BASE_YEAR);
     this.tenYearTotalCost = this._getNumber(Intervention.KEYS.TEN_YEAR_TOTAL);
+    this.lastEdited = this._getString(Intervention.KEYS.LAST_EDITED);
+    this.isTemplateIntervention = this._getBoolean(Intervention.KEYS.IS_TEMPLATE_INTERVENTION);
+    this.parentIntervention = this._getNumber(Intervention.KEYS.PARENT_INTERVENTION);
   }
 }

--- a/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.ts
+++ b/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.ts
@@ -5,7 +5,7 @@ import { RecurringCosts, RecurringCostBreakdown } from 'src/app/apiAndObjects/ob
 import { DialogData } from '../baseDialogService.abstract';
 import { pairwise, map, filter, startWith } from 'rxjs/operators';
 import { InterventionDataService, InterventionForm } from 'src/app/services/interventionData.service';
-import { UntypedFormArray, UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
+import { FormGroup, UntypedFormArray, UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
 @Injectable({ providedIn: 'root' })
 @Component({
   selector: 'app-section-recurring-cost-review-dialog',
@@ -63,6 +63,20 @@ export class SectionRecurringCostReviewDialogComponent {
       this.form = this.formBuilder.group({
         items: this.formBuilder.array(reucrringGroupArr),
       });
+
+      // Mark fields as touched/dirty if they have been previously edited and stored via the API
+      this.form.controls.items['controls'].forEach((formRow: FormGroup) => {
+        let yearIndex = 0;
+        Object.keys(formRow.controls).forEach((key: string) => {
+          if (key === 'year' + yearIndex) {
+            if (formRow.controls['year' + yearIndex + 'Edited'].value === true) {
+              formRow.controls[key].markAsDirty(); // mark field as ng-dirty i.e. user edited
+            }
+            yearIndex++;
+          }
+        });
+      });
+
       const compareObjs = (a: Record<string, unknown>, b: Record<string, unknown>) => {
         return Object.entries(b).filter(([key, value]) => value !== a[key]);
       };
@@ -119,15 +133,25 @@ export class SectionRecurringCostReviewDialogComponent {
     return this.formBuilder.group({
       rowIndex: [item.rowIndex, []],
       year0: [Number(item.year0), []],
+      year0Edited: [Boolean(item.year0Edited), []],
       year1: [Number(item.year1), []],
+      year1Edited: [Boolean(item.year1Edited), []],
       year2: [Number(item.year2), []],
+      year2Edited: [Boolean(item.year2Edited), []],
       year3: [Number(item.year3), []],
+      year3Edited: [Boolean(item.year3Edited), []],
       year4: [Number(item.year4), []],
+      year4Edited: [Boolean(item.year4Edited), []],
       year5: [Number(item.year5), []],
+      year5Edited: [Boolean(item.year5Edited), []],
       year6: [Number(item.year6), []],
+      year6Edited: [Boolean(item.year6Edited), []],
       year7: [Number(item.year7), []],
+      year7Edited: [Boolean(item.year7Edited), []],
       year8: [Number(item.year8), []],
+      year8Edited: [Boolean(item.year8Edited), []],
       year9: [Number(item.year9), []],
+      year9Edited: [Boolean(item.year9Edited), []],
     });
   }
 

--- a/src/app/components/dialogs/sectionStartUpCostReviewDialog/sectionStartUpCostReviewDialog.component.ts
+++ b/src/app/components/dialogs/sectionStartUpCostReviewDialog/sectionStartUpCostReviewDialog.component.ts
@@ -3,7 +3,7 @@ import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatTableDataSource } from '@angular/material/table';
 import { StartUpCostBreakdown, StartUpCosts } from 'src/app/apiAndObjects/objects/interventionStartupCosts';
 import { DialogData } from '../baseDialogService.abstract';
-import { UntypedFormBuilder, UntypedFormArray, UntypedFormGroup } from '@angular/forms';
+import { UntypedFormBuilder, UntypedFormArray, UntypedFormGroup, FormGroup } from '@angular/forms';
 import { pairwise, map, filter, startWith } from 'rxjs/operators';
 import { InterventionDataService, InterventionForm } from 'src/app/services/interventionData.service';
 
@@ -48,6 +48,20 @@ export class SectionStartUpCostReviewDialogComponent {
       this.form = this.formBuilder.group({
         items: this.formBuilder.array(startupGroupArr),
       });
+
+      // Mark fields as touched/dirty if they have been previously edited and stored via the API
+      this.form.controls.items['controls'].forEach((formRow: FormGroup) => {
+        let yearIndex = 0;
+        Object.keys(formRow.controls).forEach((key: string) => {
+          if (key === 'year' + yearIndex) {
+            if (formRow.controls['year' + yearIndex + 'Edited'].value === true) {
+              formRow.controls[key].markAsDirty(); // mark field as ng-dirty i.e. user edited
+            }
+            yearIndex++;
+          }
+        });
+      });
+
       const compareObjs = (a: Record<string, unknown>, b: Record<string, unknown>) => {
         return Object.entries(b).filter(([key, value]) => value !== a[key]);
       };
@@ -104,7 +118,9 @@ export class SectionStartUpCostReviewDialogComponent {
     return this.formBuilder.group({
       rowIndex: [item.rowIndex, []],
       year0: [Number(item.year0), []],
+      year0Edited: [Boolean(item.year0Edited), []],
       year1: [Number(item.year1), []],
+      year1Edited: [Boolean(item.year1Edited), []],
     });
   }
 

--- a/src/app/pages/quickMaps/pages/costEffectiveness/components/intervention/intervention.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/components/intervention/intervention.component.html
@@ -20,7 +20,7 @@
             10-year total cost: <strong>{{ intervention.tenYearTotalCost | currency }}</strong>
           </div>
           <div class="item">
-            Last updated: <strong>{{today | date:'medium'}}</strong>
+            Last updated: <strong>{{(intervention.lastEdited | date:'medium') || 'Not available'}}</strong>
           </div>
         </div>
       </div>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCompliance/interventionCompliance.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCompliance/interventionCompliance.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { NonNullableFormBuilder, UntypedFormGroup } from '@angular/forms';
+import { FormGroup, NonNullableFormBuilder, UntypedFormGroup } from '@angular/forms';
 import { MatTableDataSource } from '@angular/material/table';
 import { filter, map, pairwise, startWith, Subscription } from 'rxjs';
 import { MicronutrientDictionaryItem } from 'src/app/apiAndObjects/objects/dictionaries/micronutrientDictionaryItem';
@@ -80,6 +80,20 @@ export class InterventionComplianceComponent implements OnInit {
                 this.form = this.formBuilder.group({
                   items: this.formBuilder.array(assumptionsGroupArr),
                 });
+
+                // Mark fields as touched/dirty if they have been previously edited and stored via the API
+                this.form.controls.items['controls'].forEach((formRow: FormGroup) => {
+                  let yearIndex = 0;
+                  Object.keys(formRow.controls).forEach((key: string) => {
+                    if (key === 'year' + yearIndex) {
+                      if (formRow.controls['year' + yearIndex + 'Edited'].value === true) {
+                        formRow.controls[key].markAsDirty(); // mark field as ng-dirty i.e. user edited
+                      }
+                      yearIndex++;
+                    }
+                  });
+                });
+
                 const compareObjs = (a: Record<string, unknown>, b: Record<string, unknown>) => {
                   return Object.entries(b).filter(([key, value]) => value !== a[key]);
                 };
@@ -182,15 +196,25 @@ export class InterventionComplianceComponent implements OnInit {
     return this.formBuilder.group({
       rowIndex: [item.rowIndex, []],
       year0: [Number(item.year0), []],
+      year0Edited: [Boolean(item.year0Edited), []],
       year1: [Number(item.year1), []],
+      year1Edited: [Boolean(item.year1Edited), []],
       year2: [Number(item.year2), []],
+      year2Edited: [Boolean(item.year2Edited), []],
       year3: [Number(item.year3), []],
+      year3Edited: [Boolean(item.year3Edited), []],
       year4: [Number(item.year4), []],
+      year4Edited: [Boolean(item.year4Edited), []],
       year5: [Number(item.year5), []],
+      year5Edited: [Boolean(item.year5Edited), []],
       year6: [Number(item.year6), []],
+      year6Edited: [Boolean(item.year6Edited), []],
       year7: [Number(item.year7), []],
+      year7Edited: [Boolean(item.year7Edited), []],
       year8: [Number(item.year8), []],
+      year8Edited: [Boolean(item.year8Edited), []],
       year9: [Number(item.year9), []],
+      year9Edited: [Boolean(item.year9Edited), []],
     });
   }
   public confirmAndContinue(): void {

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.ts
@@ -7,7 +7,7 @@ import {
 import { AppRoutes } from 'src/app/routes/routes';
 import { InterventionDataService, InterventionForm } from 'src/app/services/interventionData.service';
 import { InterventionSideNavContentService } from '../../components/interventionSideNavContent/interventionSideNavContent.service';
-import { UntypedFormArray, UntypedFormGroup, NonNullableFormBuilder } from '@angular/forms';
+import { UntypedFormArray, UntypedFormGroup, NonNullableFormBuilder, FormGroup } from '@angular/forms';
 import { pairwise, map, filter, startWith } from 'rxjs/operators';
 
 @Component({
@@ -68,6 +68,21 @@ export class InterventionIndustryInformationComponent implements OnInit {
           this.form = this.formBuilder.group({
             items: this.formBuilder.array(industryGroupArr),
           });
+
+          // Mark fields as touched/dirty if they have been previously edited and stored via the API
+          this.form.controls.items['controls'].forEach((formRow: FormGroup, rowIndex: number) => {
+            let yearIndex = 0;
+            Object.keys(formRow.controls).forEach((key: string) => {
+              if (key === 'year' + yearIndex) {
+                if (formRow.controls['year' + yearIndex + 'Edited'].value === true) {
+                  formRow.controls[key].markAsDirty(); // mark field as ng-dirty i.e. user edited
+                  this.storeIndex(rowIndex); // mark row as containing user info
+                }
+                yearIndex++;
+              }
+            });
+          });
+
           const compareObjs = (a: Record<string, unknown>, b: Record<string, unknown>) => {
             return Object.entries(b).filter(([key, value]) => value !== a[key]);
           };
@@ -125,15 +140,25 @@ export class InterventionIndustryInformationComponent implements OnInit {
     return this.formBuilder.group({
       rowIndex: [item.rowIndex, []],
       year0: [Number(item.year0), []],
+      year0Edited: [Boolean(item.year0Edited), []],
       year1: [Number(item.year1), []],
+      year1Edited: [Boolean(item.year1Edited), []],
       year2: [Number(item.year2), []],
+      year2Edited: [Boolean(item.year2Edited), []],
       year3: [Number(item.year3), []],
+      year3Edited: [Boolean(item.year3Edited), []],
       year4: [Number(item.year4), []],
+      year4Edited: [Boolean(item.year4Edited), []],
       year5: [Number(item.year5), []],
+      year5Edited: [Boolean(item.year5Edited), []],
       year6: [Number(item.year6), []],
+      year6Edited: [Boolean(item.year6Edited), []],
       year7: [Number(item.year7), []],
+      year7Edited: [Boolean(item.year7Edited), []],
       year8: [Number(item.year8), []],
+      year8Edited: [Boolean(item.year8Edited), []],
       year9: [Number(item.year9), []],
+      year9Edited: [Boolean(item.year9Edited), []],
     });
   }
 

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionMonitoringInformation/interventionMonitoringInformation.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionMonitoringInformation/interventionMonitoringInformation.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { UntypedFormGroup, NonNullableFormBuilder } from '@angular/forms';
+import { UntypedFormGroup, NonNullableFormBuilder, FormGroup } from '@angular/forms';
 import { MatTableDataSource } from '@angular/material/table';
 import {
   InterventionMonitoringInformation,
@@ -66,6 +66,21 @@ export class InterventionMonitoringInformationComponent implements OnInit {
           this.form = this.formBuilder.group({
             items: this.formBuilder.array(monitoringGroupArr),
           });
+
+          // Mark fields as touched/dirty if they have been previously edited and stored via the API
+          this.form.controls.items['controls'].forEach((formRow: FormGroup, rowIndex: number) => {
+            let yearIndex = 0;
+            Object.keys(formRow.controls).forEach((key: string) => {
+              if (key === 'year' + yearIndex) {
+                if (formRow.controls['year' + yearIndex + 'Edited'].value === true) {
+                  formRow.controls[key].markAsDirty(); // mark field as ng-dirty i.e. user edited
+                  this.storeIndex(rowIndex); // mark row as containing user info
+                }
+                yearIndex++;
+              }
+            });
+          });
+
           const compareObjs = (a: Record<string, unknown>, b: Record<string, unknown>) => {
             return Object.entries(b).filter(([key, value]) => value !== a[key]);
           };
@@ -125,15 +140,25 @@ export class InterventionMonitoringInformationComponent implements OnInit {
     return this.formBuilder.group({
       rowIndex: [item.rowIndex, []],
       year0: [Number(item.year0), []],
+      year0Edited: [Boolean(item.year0Edited), []],
       year1: [Number(item.year1), []],
+      year1Edited: [Boolean(item.year1Edited), []],
       year2: [Number(item.year2), []],
+      year2Edited: [Boolean(item.year2Edited), []],
       year3: [Number(item.year3), []],
+      year3Edited: [Boolean(item.year3Edited), []],
       year4: [Number(item.year4), []],
+      year4Edited: [Boolean(item.year4Edited), []],
       year5: [Number(item.year5), []],
+      year5Edited: [Boolean(item.year5Edited), []],
       year6: [Number(item.year6), []],
+      year6Edited: [Boolean(item.year6Edited), []],
       year7: [Number(item.year7), []],
+      year7Edited: [Boolean(item.year7Edited), []],
       year8: [Number(item.year8), []],
+      year8Edited: [Boolean(item.year8Edited), []],
       year9: [Number(item.year9), []],
+      year9Edited: [Boolean(item.year9Edited), []],
     });
   }
 


### PR DESCRIPTION
-  show user edited fields in industry and monitoring stages
  - [x]  compliance over time
  - [x] industry information
  - [x] monitoring information
  - [x] startup/scaleup
  - [x] recurring costs
  
![image](https://user-images.githubusercontent.com/4210022/219069056-a434188e-2d88-43dd-bb59-f029a3612487.png)

- intervention object updated to include extra API params like last edited and parent ID
- intervention card now shows last edited date

todo: baseline page, but currently its being poked so steering clear for now

## to test

- [x] open intervention id 22 and click through pages, they should be highlighted where inputs have been edited
- [x] open another intervention id and be able to edit/highlight/PATCH/go back to confirm changes 
- [x] edit a field, confirm and continue, then go back and check that the edited field is still highlighted
- [x] if table has a source column (with user input/gdx), if says gdx, make a change, confirm that changes to 'user input', confirm and continue, then go back and confirm that the input is highlighted AND the source says user input
- [x] check intervention card 'last edited' date, go into intervention and make edit/save and close, then check the card date has been updated to now
