### PR TITLE
Svea reset

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,6 +32,9 @@
     "titleBar.activeBackground": "#9b51e0",
     "titleBar.activeForeground": "#e7e7e7",
     "titleBar.inactiveBackground": "#9b51e099",
-    "titleBar.inactiveForeground": "#e7e7e799"
+    "titleBar.inactiveForeground": "#e7e7e799",
+    "statusBar.border": "#9b51e0",
+    "tab.activeBorder": "#b47ce8",
+    "titleBar.border": "#9b51e0"
   }
 }

--- a/src/app/components/dialogs/ceResetDialog/ceResetDialog.component.ts
+++ b/src/app/components/dialogs/ceResetDialog/ceResetDialog.component.ts
@@ -1,5 +1,5 @@
 import { Component, Inject, OnInit } from '@angular/core';
-import { MatDialog, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { InterventionMonitoringInformation } from 'src/app/apiAndObjects/objects/interventionMonitoringInformation';
 import { DialogData } from '../baseDialogService.abstract';
 
@@ -10,7 +10,7 @@ import { DialogData } from '../baseDialogService.abstract';
 })
 export class CeResetDialogComponent implements OnInit {
   public monitoringInformation: InterventionMonitoringInformation;
-  constructor(public dialog: MatDialog, @Inject(MAT_DIALOG_DATA) public dialogData: DialogData) {
+  constructor(@Inject(MAT_DIALOG_DATA) public dialogData: DialogData) {
     //add content
   }
 
@@ -19,12 +19,12 @@ export class CeResetDialogComponent implements OnInit {
   }
   public closeDialog(): void {
     this.dialogData.dataOut = false;
-    this.dialog.closeAll();
+    this.dialogData.close();
   }
 
   public resetAll(): void {
     //reset all needes to only reset values in the current review component
     this.dialogData.dataOut = true;
-    this.dialog.closeAll();
+    this.dialogData.close();
   }
 }

--- a/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.html
+++ b/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.html
@@ -184,7 +184,8 @@
         <tr mat-footer-row *matFooterRowDef="displayedColumns"></tr>
       </table>
     </form>
-    <app-dialog-step-details [resetDefaultValues]="true" [showUserValues]="true"></app-dialog-step-details>
+    <app-dialog-step-details (resetValues)="resetForm()" [resetDefaultValues]="true"
+      [showUserValues]="true"></app-dialog-step-details>
     <div class="button-container">
       <button mat-stroked-button (click)="dialogData.close()">Back</button>
       <button class="confirm" mat-stroked-button color="primary" (click)="confirmChanges()">Confirm</button>

--- a/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.ts
+++ b/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.ts
@@ -134,24 +134,34 @@ export class SectionRecurringCostReviewDialogComponent {
       rowIndex: [item.rowIndex, []],
       year0: [Number(item.year0), []],
       year0Edited: [Boolean(item.year0Edited), []],
+      year0Default: [Number(item.year0Default), []],
       year1: [Number(item.year1), []],
       year1Edited: [Boolean(item.year1Edited), []],
+      year1Default: [Number(item.year1Default), []],
       year2: [Number(item.year2), []],
       year2Edited: [Boolean(item.year2Edited), []],
+      year2Default: [Number(item.year2Default), []],
       year3: [Number(item.year3), []],
       year3Edited: [Boolean(item.year3Edited), []],
+      year3Default: [Number(item.year3Default), []],
       year4: [Number(item.year4), []],
       year4Edited: [Boolean(item.year4Edited), []],
+      year4Default: [Number(item.year4Default), []],
       year5: [Number(item.year5), []],
       year5Edited: [Boolean(item.year5Edited), []],
+      year5Default: [Number(item.year5Default), []],
       year6: [Number(item.year6), []],
       year6Edited: [Boolean(item.year6Edited), []],
+      year6Default: [Number(item.year6Default), []],
       year7: [Number(item.year7), []],
       year7Edited: [Boolean(item.year7Edited), []],
+      year7Default: [Number(item.year7Default), []],
       year8: [Number(item.year8), []],
       year8Edited: [Boolean(item.year8Edited), []],
+      year8Default: [Number(item.year8Default), []],
       year9: [Number(item.year9), []],
       year9Edited: [Boolean(item.year9Edited), []],
+      year9Default: [Number(item.year9Default), []],
     });
   }
 
@@ -172,8 +182,18 @@ export class SectionRecurringCostReviewDialogComponent {
       this.dialogData.close();
     }
   }
-  public resetAll(): void {
-    //reset all needes to only reset values in the current review component
-    this.dialogData.dataOut = true;
+  public resetForm() {
+    // set fields to default values as delivered per api
+    this.form.controls.items['controls'].forEach((formRow: FormGroup) => {
+      let yearIndex = 0;
+      Object.keys(formRow.controls).forEach((key: string) => {
+        if (key === 'year' + yearIndex) {
+          if (formRow.controls['year' + yearIndex + 'Default'].value !== formRow.controls['year' + yearIndex].value) {
+            formRow.controls[key].setValue(formRow.controls['year' + yearIndex + 'Default'].value); // set the default value
+          }
+          yearIndex++;
+        }
+      });
+    });
   }
 }

--- a/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.ts
+++ b/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.ts
@@ -195,5 +195,7 @@ export class SectionRecurringCostReviewDialogComponent {
         }
       });
     });
+    //on reset mark forma as pristine to remove blue highlights
+    this.form.markAsPristine();
   }
 }

--- a/src/app/components/dialogs/sectionStartUpCostReviewDialog/sectionStartUpCostReviewDialog.component.html
+++ b/src/app/components/dialogs/sectionStartUpCostReviewDialog/sectionStartUpCostReviewDialog.component.html
@@ -55,6 +55,7 @@
       <button mat-stroked-button (click)="dialogData.close()">Back</button>
       <button class="confirm" mat-stroked-button color="primary" (click)="confirmChanges()">Confirm</button>
     </div>
-    <app-dialog-step-details [resetDefaultValues]="true" [showUserValues]="true"></app-dialog-step-details>
+    <app-dialog-step-details (resetValues)="resetForm()" [resetDefaultValues]="true"
+      [showUserValues]="true"></app-dialog-step-details>
   </div>
 </app-base-dialog>

--- a/src/app/components/dialogs/sectionStartUpCostReviewDialog/sectionStartUpCostReviewDialog.component.ts
+++ b/src/app/components/dialogs/sectionStartUpCostReviewDialog/sectionStartUpCostReviewDialog.component.ts
@@ -154,5 +154,7 @@ export class SectionStartUpCostReviewDialogComponent {
         }
       });
     });
+    //on reset mark forma as pristine to remove blue highlights
+    this.form.markAsPristine();
   }
 }

--- a/src/app/components/dialogs/sectionStartUpCostReviewDialog/sectionStartUpCostReviewDialog.component.ts
+++ b/src/app/components/dialogs/sectionStartUpCostReviewDialog/sectionStartUpCostReviewDialog.component.ts
@@ -119,8 +119,10 @@ export class SectionStartUpCostReviewDialogComponent {
       rowIndex: [item.rowIndex, []],
       year0: [Number(item.year0), []],
       year0Edited: [Boolean(item.year0Edited), []],
+      year0Default: [Number(item.year0Default), []],
       year1: [Number(item.year1), []],
       year1Edited: [Boolean(item.year1Edited), []],
+      year1Default: [Number(item.year1Default), []],
     });
   }
 
@@ -137,5 +139,20 @@ export class SectionStartUpCostReviewDialogComponent {
     } else {
       this.dialogData.close();
     }
+  }
+
+  public resetForm() {
+    // set fields to default values as delivered per api
+    this.form.controls.items['controls'].forEach((formRow: FormGroup) => {
+      let yearIndex = 0;
+      Object.keys(formRow.controls).forEach((key: string) => {
+        if (key === 'year' + yearIndex) {
+          if (formRow.controls['year' + yearIndex + 'Default'].value !== formRow.controls['year' + yearIndex].value) {
+            formRow.controls[key].setValue(formRow.controls['year' + yearIndex + 'Default'].value); // set the default value
+          }
+          yearIndex++;
+        }
+      });
+    });
   }
 }

--- a/src/app/components/dialogs/sectionSummaryRecurringCostReviewDialog/sectionSummaryRecurringCostReviewDialog.component.html
+++ b/src/app/components/dialogs/sectionSummaryRecurringCostReviewDialog/sectionSummaryRecurringCostReviewDialog.component.html
@@ -61,7 +61,6 @@
       <tr class="mat-row" *matNoDataRow></tr>
       <tr mat-footer-row *matFooterRowDef="displayHeaders"></tr>
     </table>
-    <app-dialog-step-details [resetDefaultValues]="true" [showUserValues]="true"></app-dialog-step-details>
     <div class="button-container">
       <button mat-stroked-button (click)="dialogData.close()">Close</button>
     </div>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionBaseline/interventionBaseline.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionBaseline/interventionBaseline.component.html
@@ -162,8 +162,8 @@
       <app-micro-nutrients-in-premix-table [editable]="true"
         [micronutrient]="newMnInPremix"></app-micro-nutrients-in-premix-table>
     </div>
-    <app-intervention-step-details [resetDefaultValues]="true" [showFocusMn]="true" [showUserValues]="true"
-      [showMnUnits]="true" [showAddMicronutrient]="true" (onAddMn)="handleAddMn($event)">
+    <app-intervention-step-details (resetValues)="resetForm()" [resetDefaultValues]="true" [showFocusMn]="true"
+      [showUserValues]="true" [showMnUnits]="true" [showAddMicronutrient]="true" (onAddMn)="handleAddMn($event)">
     </app-intervention-step-details>
   </div>
 

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionBaseline/interventionBaseline.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionBaseline/interventionBaseline.component.ts
@@ -198,6 +198,8 @@ export class InterventionBaselineComponent implements AfterViewInit {
         }
       });
     });
+    //on reset mark forma as pristine to remove blue highlights
+    this.form.markAsPristine();
   }
 
   public handleAddMn(micronutrient: MicronutrientDictionaryItem): void {

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionBaseline/interventionBaseline.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionBaseline/interventionBaseline.component.ts
@@ -18,7 +18,7 @@ import { QuickMapsService } from 'src/app/pages/quickMaps/quickMaps.service';
 import { AppRoutes } from 'src/app/routes/routes';
 import { InterventionDataService, InterventionForm } from 'src/app/services/interventionData.service';
 import { InterventionSideNavContentService } from '../../components/interventionSideNavContent/interventionSideNavContent.service';
-import { NonNullableFormBuilder, UntypedFormGroup } from '@angular/forms';
+import { FormGroup, NonNullableFormBuilder, UntypedFormGroup } from '@angular/forms';
 
 @Component({
   selector: 'app-intervention-baseline',
@@ -156,6 +156,8 @@ export class InterventionBaselineComponent implements AfterViewInit {
     return this.formBuilder.group({
       rowIndex: [item.rowIndex, []],
       year0: [Number(item.year0), []],
+      year0Edited: [Number(item.year0Edited), []],
+      year0Default: [Number(item.year0Default), []],
     });
   }
 
@@ -184,7 +186,18 @@ export class InterventionBaselineComponent implements AfterViewInit {
   }
 
   public resetForm() {
-    this.form.reset();
+    // set fields to default values as delivered per api
+    this.form.controls.items['controls'].forEach((formRow: FormGroup) => {
+      let yearIndex = 0;
+      Object.keys(formRow.controls).forEach((key: string) => {
+        if (key === 'year' + yearIndex) {
+          if (formRow.controls['year' + yearIndex + 'Default'].value !== formRow.controls['year' + yearIndex].value) {
+            formRow.controls[key].setValue(formRow.controls['year' + yearIndex + 'Default'].value); // set the default value
+          }
+          yearIndex++;
+        }
+      });
+    });
   }
 
   public handleAddMn(micronutrient: MicronutrientDictionaryItem): void {

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionBaseline/interventionBaseline.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionBaseline/interventionBaseline.component.ts
@@ -200,6 +200,8 @@ export class InterventionBaselineComponent implements AfterViewInit {
     });
     //on reset mark forma as pristine to remove blue highlights
     this.form.markAsPristine();
+    //remove dirty indexes to reset button to GFDx input
+    this.dirtyIndexes.splice(0);
   }
 
   public handleAddMn(micronutrient: MicronutrientDictionaryItem): void {

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCompliance/interventionCompliance.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCompliance/interventionCompliance.component.html
@@ -221,8 +221,8 @@
       </table>
     </div>
     <app-micro-nutrients-in-premix-table [editable]="false"></app-micro-nutrients-in-premix-table>
-    <app-intervention-step-details [resetDefaultValues]="true" [showFocusMn]="true" [showUserValues]="true"
-      [showAddMicronutrient]="false" [showMnUnits]="true"></app-intervention-step-details>
+    <app-intervention-step-details (resetValues)="resetForm()" [resetDefaultValues]="true" [showFocusMn]="true"
+      [showUserValues]="true" [showAddMicronutrient]="false" [showMnUnits]="true"></app-intervention-step-details>
 
   </div>
   <footer>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCompliance/interventionCompliance.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCompliance/interventionCompliance.component.ts
@@ -197,28 +197,53 @@ export class InterventionComplianceComponent implements OnInit {
       rowIndex: [item.rowIndex, []],
       year0: [Number(item.year0), []],
       year0Edited: [Boolean(item.year0Edited), []],
+      year0Default: [Number(item.year0Default), []],
       year1: [Number(item.year1), []],
       year1Edited: [Boolean(item.year1Edited), []],
+      year1Default: [Number(item.year1Default), []],
       year2: [Number(item.year2), []],
       year2Edited: [Boolean(item.year2Edited), []],
+      year2Default: [Number(item.year2Default), []],
       year3: [Number(item.year3), []],
       year3Edited: [Boolean(item.year3Edited), []],
+      year3Default: [Number(item.year3Default), []],
       year4: [Number(item.year4), []],
       year4Edited: [Boolean(item.year4Edited), []],
+      year4Default: [Number(item.year4Default), []],
       year5: [Number(item.year5), []],
       year5Edited: [Boolean(item.year5Edited), []],
+      year5Default: [Number(item.year5Default), []],
       year6: [Number(item.year6), []],
       year6Edited: [Boolean(item.year6Edited), []],
+      year6Default: [Number(item.year6Default), []],
       year7: [Number(item.year7), []],
       year7Edited: [Boolean(item.year7Edited), []],
+      year7Default: [Number(item.year7Default), []],
       year8: [Number(item.year8), []],
       year8Edited: [Boolean(item.year8Edited), []],
+      year8Default: [Number(item.year8Default), []],
       year9: [Number(item.year9), []],
       year9Edited: [Boolean(item.year9Edited), []],
+      year9Default: [Number(item.year9Default), []],
     });
   }
   public confirmAndContinue(): void {
     this.interventionDataService.interventionPageConfirmContinue();
+  }
+
+  public resetForm() {
+    // set fields to default values as delivered per api
+    this.form.controls.items['controls'].forEach((formRow: FormGroup) => {
+      let yearIndex = 0;
+      Object.keys(formRow.controls).forEach((key: string) => {
+        if (key === 'year' + yearIndex) {
+          if (formRow.controls['year' + yearIndex + 'Default'].value !== formRow.controls['year' + yearIndex].value) {
+            formRow.controls[key].setValue(formRow.controls['year' + yearIndex + 'Default'].value); // set the default value
+          }
+          yearIndex++;
+        }
+      });
+    });
   }
 }
 

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCompliance/interventionCompliance.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCompliance/interventionCompliance.component.ts
@@ -244,6 +244,8 @@ export class InterventionComplianceComponent implements OnInit {
         }
       });
     });
+    //on reset mark forma as pristine to remove blue highlights
+    this.form.markAsPristine();
   }
 }
 

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.html
@@ -4,7 +4,7 @@
     <div class="title">
       <span> Industry Information </span>
     </div>
-    <form [formGroup]="form" *ngIf="form" [formControl]="defaultFormInput">
+    <form [formGroup]="form" *ngIf="form">
       <table mat-table [dataSource]="dataSource" formArrayName="items" class="table-full-width">
         <ng-container matColumnDef="labelText">
           <th class="row-title-left" mat-header-cell *matHeaderCellDef> Intervention year </th>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.html
@@ -4,7 +4,7 @@
     <div class="title">
       <span> Industry Information </span>
     </div>
-    <form [formGroup]="form" *ngIf="form">
+    <form [formGroup]="form" *ngIf="form" [formControl]="defaultFormInput">
       <table mat-table [dataSource]="dataSource" formArrayName="items" class="table-full-width">
         <ng-container matColumnDef="labelText">
           <th class="row-title-left" mat-header-cell *matHeaderCellDef> Intervention year </th>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.ts
@@ -196,6 +196,8 @@ export class InterventionIndustryInformationComponent implements OnInit {
     });
     //on reset mark forma as pristine to remove blue highlights
     this.form.markAsPristine();
+    //remove dirty indexes to reset button to GFDx input
+    this.dirtyIndexes.splice(0);
   }
 
   public storeIndex(index: number) {

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.ts
@@ -194,6 +194,8 @@ export class InterventionIndustryInformationComponent implements OnInit {
         }
       });
     });
+    //on reset mark forma as pristine to remove blue highlights
+    this.form.markAsPristine();
   }
 
   public storeIndex(index: number) {

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.ts
@@ -7,7 +7,7 @@ import {
 import { AppRoutes } from 'src/app/routes/routes';
 import { InterventionDataService, InterventionForm } from 'src/app/services/interventionData.service';
 import { InterventionSideNavContentService } from '../../components/interventionSideNavContent/interventionSideNavContent.service';
-import { UntypedFormArray, UntypedFormGroup, NonNullableFormBuilder } from '@angular/forms';
+import { UntypedFormArray, UntypedFormGroup, NonNullableFormBuilder, FormControl } from '@angular/forms';
 import { pairwise, map, filter, startWith } from 'rxjs/operators';
 
 @Component({
@@ -121,19 +121,55 @@ export class InterventionIndustryInformationComponent implements OnInit {
     return this.form.get('items')['controls'] as UntypedFormArray;
   }
 
+  public defaultFormInput = new FormControl(this.createDefaultIndustryGroup);
+  private createDefaultIndustryGroup(item: IndustryInformation): UntypedFormGroup {
+    return this.formBuilder.group({
+      year0Default: [Number(item.year0Default), []],
+      year1Default: [Number(item.year1Default), []],
+      year2Default: [Number(item.year2Default), []],
+      year3Default: [Number(item.year3Default), []],
+      year4Default: [Number(item.year4Default), []],
+      year5Default: [Number(item.year5Default), []],
+      year6Default: [Number(item.year6Default), []],
+      year7Default: [Number(item.year7Default), []],
+      year8Default: [Number(item.year8Default), []],
+      year9Default: [Number(item.year9Default), []],
+    });
+  }
+
   private createIndustryGroup(item: IndustryInformation): UntypedFormGroup {
     return this.formBuilder.group({
       rowIndex: [item.rowIndex, []],
       year0: [Number(item.year0), []],
+      year0Edited: [Number(item.year0Edited), []],
+      year0Default: [Number(item.year0Default), []],
       year1: [Number(item.year1), []],
+      year1Edited: [Number(item.year1Edited), []],
+      year1Default: [Number(item.year1Default), []],
       year2: [Number(item.year2), []],
+      year2Edited: [Number(item.year2Edited), []],
+      year2Default: [Number(item.year2Default), []],
       year3: [Number(item.year3), []],
+      year3Edited: [Number(item.year3Edited), []],
+      year3Default: [Number(item.year3Default), []],
       year4: [Number(item.year4), []],
+      year4Edited: [Number(item.year4Edited), []],
+      year4Default: [Number(item.year4Default), []],
       year5: [Number(item.year5), []],
+      year5Edited: [Number(item.year5Edited), []],
+      year5Default: [Number(item.year5Default), []],
       year6: [Number(item.year6), []],
+      year6Edited: [Number(item.year6Edited), []],
+      year6Default: [Number(item.year6Default), []],
       year7: [Number(item.year7), []],
+      year7Edited: [Number(item.year7Edited), []],
+      year7Default: [Number(item.year7Default), []],
       year8: [Number(item.year8), []],
+      year8Edited: [Number(item.year8Edited), []],
+      year8Default: [Number(item.year8Default), []],
       year9: [Number(item.year9), []],
+      year9Edited: [Number(item.year9Edited), []],
+      year9Default: [Number(item.year9Default), []],
     });
   }
 

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.ts
@@ -7,7 +7,7 @@ import {
 import { AppRoutes } from 'src/app/routes/routes';
 import { InterventionDataService, InterventionForm } from 'src/app/services/interventionData.service';
 import { InterventionSideNavContentService } from '../../components/interventionSideNavContent/interventionSideNavContent.service';
-import { UntypedFormArray, UntypedFormGroup, NonNullableFormBuilder, FormGroup, FormControl } from '@angular/forms';
+import { UntypedFormArray, UntypedFormGroup, NonNullableFormBuilder, FormGroup } from '@angular/forms';
 import { pairwise, map, filter, startWith } from 'rxjs/operators';
 
 @Component({

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.ts
@@ -156,34 +156,34 @@ export class InterventionIndustryInformationComponent implements OnInit {
     return this.formBuilder.group({
       rowIndex: [item.rowIndex, []],
       year0: [Number(item.year0), []],
-      year0Edited: [Number(item.year0Edited), []],
+      year0Edited: [Boolean(item.year0Edited), []],
       year0Default: [Number(item.year0Default), []],
       year1: [Number(item.year1), []],
-      year1Edited: [Number(item.year1Edited), []],
+      year1Edited: [Boolean(item.year1Edited), []],
       year1Default: [Number(item.year1Default), []],
       year2: [Number(item.year2), []],
-      year2Edited: [Number(item.year2Edited), []],
+      year2Edited: [Boolean(item.year2Edited), []],
       year2Default: [Number(item.year2Default), []],
       year3: [Number(item.year3), []],
-      year3Edited: [Number(item.year3Edited), []],
+      year3Edited: [Boolean(item.year3Edited), []],
       year3Default: [Number(item.year3Default), []],
       year4: [Number(item.year4), []],
-      year4Edited: [Number(item.year4Edited), []],
+      year4Edited: [Boolean(item.year4Edited), []],
       year4Default: [Number(item.year4Default), []],
       year5: [Number(item.year5), []],
-      year5Edited: [Number(item.year5Edited), []],
+      year5Edited: [Boolean(item.year5Edited), []],
       year5Default: [Number(item.year5Default), []],
       year6: [Number(item.year6), []],
-      year6Edited: [Number(item.year6Edited), []],
+      year6Edited: [Boolean(item.year6Edited), []],
       year6Default: [Number(item.year6Default), []],
       year7: [Number(item.year7), []],
-      year7Edited: [Number(item.year7Edited), []],
+      year7Edited: [Boolean(item.year7Edited), []],
       year7Default: [Number(item.year7Default), []],
       year8: [Number(item.year8), []],
-      year8Edited: [Number(item.year8Edited), []],
+      year8Edited: [Boolean(item.year8Edited), []],
       year8Default: [Number(item.year8Default), []],
       year9: [Number(item.year9), []],
-      year9Edited: [Number(item.year9Edited), []],
+      year9Edited: [Boolean(item.year9Edited), []],
       year9Default: [Number(item.year9Default), []],
     });
   }
@@ -198,7 +198,18 @@ export class InterventionIndustryInformationComponent implements OnInit {
   }
 
   public resetForm() {
-    this.form.reset();
+    // set fields to default values as delivered per api
+    this.form.controls.items['controls'].forEach((formRow: FormGroup) => {
+      let yearIndex = 0;
+      Object.keys(formRow.controls).forEach((key: string) => {
+        if (key === 'year' + yearIndex) {
+          if (formRow.controls['year' + yearIndex + 'Default'].value !== formRow.controls['year' + yearIndex].value) {
+            formRow.controls[key].setValue(formRow.controls['year' + yearIndex + 'Default'].value); // set the default value
+          }
+          yearIndex++;
+        }
+      });
+    });
   }
 
   public storeIndex(index: number) {

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.ts
@@ -136,22 +136,6 @@ export class InterventionIndustryInformationComponent implements OnInit {
     return this.form.get('items')['controls'] as UntypedFormArray;
   }
 
-  public defaultFormInput = new FormControl(this.createDefaultIndustryGroup);
-  private createDefaultIndustryGroup(item: IndustryInformation): UntypedFormGroup {
-    return this.formBuilder.group({
-      year0Default: [Number(item.year0Default), []],
-      year1Default: [Number(item.year1Default), []],
-      year2Default: [Number(item.year2Default), []],
-      year3Default: [Number(item.year3Default), []],
-      year4Default: [Number(item.year4Default), []],
-      year5Default: [Number(item.year5Default), []],
-      year6Default: [Number(item.year6Default), []],
-      year7Default: [Number(item.year7Default), []],
-      year8Default: [Number(item.year8Default), []],
-      year9Default: [Number(item.year9Default), []],
-    });
-  }
-
   private createIndustryGroup(item: IndustryInformation): UntypedFormGroup {
     return this.formBuilder.group({
       rowIndex: [item.rowIndex, []],

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionMonitoringInformation/interventionMonitoringInformation.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionMonitoringInformation/interventionMonitoringInformation.component.ts
@@ -141,24 +141,34 @@ export class InterventionMonitoringInformationComponent implements OnInit {
       rowIndex: [item.rowIndex, []],
       year0: [Number(item.year0), []],
       year0Edited: [Boolean(item.year0Edited), []],
+      year0Default: [Number(item.year0Default), []],
       year1: [Number(item.year1), []],
       year1Edited: [Boolean(item.year1Edited), []],
+      year1Default: [Number(item.year1Default), []],
       year2: [Number(item.year2), []],
       year2Edited: [Boolean(item.year2Edited), []],
+      year2Default: [Number(item.year2Default), []],
       year3: [Number(item.year3), []],
       year3Edited: [Boolean(item.year3Edited), []],
+      year3Default: [Number(item.year3Default), []],
       year4: [Number(item.year4), []],
       year4Edited: [Boolean(item.year4Edited), []],
+      year4Default: [Number(item.year4Default), []],
       year5: [Number(item.year5), []],
       year5Edited: [Boolean(item.year5Edited), []],
+      year5Default: [Number(item.year5Default), []],
       year6: [Number(item.year6), []],
       year6Edited: [Boolean(item.year6Edited), []],
+      year6Default: [Number(item.year6Default), []],
       year7: [Number(item.year7), []],
       year7Edited: [Boolean(item.year7Edited), []],
+      year7Default: [Number(item.year7Default), []],
       year8: [Number(item.year8), []],
       year8Edited: [Boolean(item.year8Edited), []],
+      year8Default: [Number(item.year8Default), []],
       year9: [Number(item.year9), []],
       year9Edited: [Boolean(item.year9Edited), []],
+      year9Default: [Number(item.year9Default), []],
     });
   }
 
@@ -172,7 +182,18 @@ export class InterventionMonitoringInformationComponent implements OnInit {
   }
 
   public resetForm() {
-    this.form.reset();
+    // set fields to default values as delivered per api
+    this.form.controls.items['controls'].forEach((formRow: FormGroup) => {
+      let yearIndex = 0;
+      Object.keys(formRow.controls).forEach((key: string) => {
+        if (key === 'year' + yearIndex) {
+          if (formRow.controls['year' + yearIndex + 'Default'].value !== formRow.controls['year' + yearIndex].value) {
+            formRow.controls[key].setValue(formRow.controls['year' + yearIndex + 'Default'].value); // set the default value
+          }
+          yearIndex++;
+        }
+      });
+    });
   }
 
   public storeIndex(index: number) {

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionMonitoringInformation/interventionMonitoringInformation.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionMonitoringInformation/interventionMonitoringInformation.component.ts
@@ -194,6 +194,8 @@ export class InterventionMonitoringInformationComponent implements OnInit {
         }
       });
     });
+    //on reset mark forma as pristine to remove blue highlights
+    this.form.markAsPristine();
   }
 
   public storeIndex(index: number) {

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionMonitoringInformation/interventionMonitoringInformation.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionMonitoringInformation/interventionMonitoringInformation.component.ts
@@ -196,6 +196,8 @@ export class InterventionMonitoringInformationComponent implements OnInit {
     });
     //on reset mark forma as pristine to remove blue highlights
     this.form.markAsPristine();
+    //remove dirty indexes to reset button to GFDx input
+    this.dirtyIndexes.splice(0);
   }
 
   public storeIndex(index: number) {


### PR DESCRIPTION
-  wire up reset button to reset inputs to default values delivered via api

- [x] #1030 reset in baseline assumptions
- [x] #1031 reset in compliance over time
- [x] #1035 reset in industry information & monitoring info
- [x] #1033 reset in startup scaleup costs
- [x] #1034 reset in recurring costs
- [x] #1049 dialogs reset working

## to test

- [ ] In "Explore Cost Effectiveness Scenario" select intervention ID:7 and click through pages, edit inputs and navigate to the next page

- [ ] navigate back and reset values
- [ ] values should be reset to default values as defined in the api --> i.e. year0Default
- [ ] test same behaviour in dialogs (recurring costs/ scale-up costs)