### PR TITLE
Skeleton loaders for drop-in to anywhere with a table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -93,6 +93,7 @@
         "karma-jasmine": "~5.1.0",
         "karma-jasmine-html-reporter": "^2.0.0",
         "ng-packagr": "^15.1.2",
+        "ngx-skeleton-loader": "^5.0.0",
         "prettier": "2.8.4",
         "ts-loader": "9.4.2",
         "ts-node": "~10.9.1",
@@ -15618,6 +15619,21 @@
         "rxjs": ">=6.0.0"
       }
     },
+    "node_modules/ngx-skeleton-loader": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ngx-skeleton-loader/-/ngx-skeleton-loader-5.0.0.tgz",
+      "integrity": "sha512-6cz8UAu4WcYnBp/LnU053LCIwjKNZWX8GX1v3bvqQVdDa1ubsEeJm+CZxk5B8W2jP9CcFhvWrBlmmVUyl1Yxug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "perf-marks": "^1.13.4",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/common": ">=8.0.0",
+        "@angular/core": ">=8.0.0"
+      }
+    },
     "node_modules/nice-napi": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/nice-napi/-/nice-napi-1.0.2.tgz",
@@ -16647,6 +16663,19 @@
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/perf-marks": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/perf-marks/-/perf-marks-1.14.2.tgz",
+      "integrity": "sha512-N0/bQcuTlETpgox/DsXS1voGjqaoamMoiyhncgeW3rSHy/qw8URVgmPRYfFDQns/+C6yFUHDbeSBGL7ixT6Y4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/performance-now": {
       "version": "2.1.0",
@@ -31688,6 +31717,16 @@
         "tslib": "^2.0.0"
       }
     },
+    "ngx-skeleton-loader": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ngx-skeleton-loader/-/ngx-skeleton-loader-5.0.0.tgz",
+      "integrity": "sha512-6cz8UAu4WcYnBp/LnU053LCIwjKNZWX8GX1v3bvqQVdDa1ubsEeJm+CZxk5B8W2jP9CcFhvWrBlmmVUyl1Yxug==",
+      "dev": true,
+      "requires": {
+        "perf-marks": "^1.13.4",
+        "tslib": "^2.0.0"
+      }
+    },
     "nice-napi": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/nice-napi/-/nice-napi-1.0.2.tgz",
@@ -32416,6 +32455,15 @@
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "dev": true
+    },
+    "perf-marks": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/perf-marks/-/perf-marks-1.14.2.tgz",
+      "integrity": "sha512-N0/bQcuTlETpgox/DsXS1voGjqaoamMoiyhncgeW3rSHy/qw8URVgmPRYfFDQns/+C6yFUHDbeSBGL7ixT6Y4A==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.1.0"
+      }
     },
     "performance-now": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "^2.0.0",
     "ng-packagr": "^15.1.2",
+    "ngx-skeleton-loader": "^5.0.0",
     "prettier": "2.8.4",
     "ts-loader": "9.4.2",
     "ts-node": "~10.9.1",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -15,6 +15,7 @@ import { FeatureFlagsService } from './services/featureFlags.service';
 import { DirectivesModule } from './directives/directives.module';
 import { NgCustomerFeedbackMapsModule } from 'ng-customer-feedback-maps';
 import { FeedbackComponent } from './components/feedback/feedback.component';
+import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 
 @NgModule({
   declarations: [AppComponent, FeedbackComponent],
@@ -35,6 +36,7 @@ import { FeedbackComponent } from './components/feedback/feedback.component';
     }),
     DirectivesModule,
     NgCustomerFeedbackMapsModule,
+    NgxSkeletonLoaderModule,
   ],
   exports: [],
   providers: [

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview.module.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview.module.ts
@@ -41,6 +41,8 @@ import { PremixTableComponent } from './interventionReview/utilities/microNutrie
 import { AvgMnTableComponent } from './interventionReview/utilities/avgMnTable/avgMnTable.component';
 import { DirectivesModule } from 'src/app/directives/directives.module';
 import { AddMicronutrientComponent } from './interventionReview/components/add-micronutrient/add-micronutrient.component';
+import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
+import { ReusableSkeletonTableComponent } from './interventionReview/utilities/reusableSkeletonTable/reusableSkeletonTable.component';
 
 @NgModule({
   declarations: [
@@ -63,6 +65,7 @@ import { AddMicronutrientComponent } from './interventionReview/components/add-m
     InterventionCostSummaryDetailedCostsGraphComponent,
     ReusableCostGraphComponent,
     ReusableCostTableComponent,
+    ReusableSkeletonTableComponent,
     InterventionStepDetailsComponent,
     MicroNutrientsInPremixTableComponent,
     PremixTableComponent,
@@ -85,6 +88,7 @@ import { AddMicronutrientComponent } from './interventionReview/components/add-m
     PipesModule,
     ComponentsModule,
     DirectivesModule,
+    NgxSkeletonLoaderModule,
   ],
   providers: [QuickMapsService, ExportService, PipesModule, DialogService, InterventionSideNavContentService],
   exports: [],

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionAssumptionsReview/interventionAssumptionsReview.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionAssumptionsReview/interventionAssumptionsReview.component.html
@@ -4,6 +4,9 @@
     <div class="title">
       <span>Review of program assumptions</span>
     </div>
+
+    <app-reusable-skeleton-table *ngIf="!dataLoaded" [setData]="{ columns: 11, rows: 2 }"></app-reusable-skeleton-table>
+
     <table class="no-margin" mat-table [dataSource]="dataSource" matSort class="table-full-width">
       <ng-container matColumnDef="title">
         <th class="row-title-left" mat-header-cell *matHeaderCellDef>Intervention year</th>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionAssumptionsReview/interventionAssumptionsReview.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionAssumptionsReview/interventionAssumptionsReview.component.ts
@@ -54,6 +54,8 @@ export class InterventionAssumptionsReviewComponent implements OnInit {
   public interventionName = 'IntName';
   private subscriptions = new Array<Subscription>();
 
+  public dataLoaded = false;
+
   constructor(
     public quickMapsService: QuickMapsService,
     private intSideNavService: InterventionSideNavContentService,
@@ -89,6 +91,7 @@ export class InterventionAssumptionsReviewComponent implements OnInit {
     const dataArray = [];
     const rawData = data.baselineAssumptions as BaselineAssumptions;
     dataArray.push(rawData.actuallyFortified, rawData.potentiallyFortified);
+    this.dataLoaded = true;
     this.dataSource = new MatTableDataSource(dataArray);
     this.createAvNutrientLevelTable(rawData);
   }

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionBaseline/interventionBaseline.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionBaseline/interventionBaseline.component.html
@@ -8,6 +8,10 @@
       <app-quickmaps-no-results></app-quickmaps-no-results>
     </div>
     <div *ngIf="this.compoundAvailable">
+
+      <app-reusable-skeleton-table *ngIf="!dataLoaded"
+        [setData]="{ columns: 3, rows: 2 }"></app-reusable-skeleton-table>
+
       <form [formGroup]="form" *ngIf="form">
 
         <table mat-table [dataSource]="dataSource" formArrayName="items" class="table-full-width">

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionBaseline/interventionBaseline.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionBaseline/interventionBaseline.component.ts
@@ -53,6 +53,8 @@ export class InterventionBaselineComponent implements AfterViewInit {
   public buttonOneEdited = false;
   public buttonTwoEdited = false;
 
+  public dataLoaded = false;
+
   constructor(
     public quickMapsService: QuickMapsService,
     private interventionDataService: InterventionDataService,
@@ -104,6 +106,9 @@ export class InterventionBaselineComponent implements AfterViewInit {
         this.form = this.formBuilder.group({
           items: this.formBuilder.array(baselineGroupArr),
         });
+
+        this.dataLoaded = true;
+
         const compareObjs = (a: Record<string, unknown>, b: Record<string, unknown>) => {
           return Object.entries(b).filter(([key, value]) => value !== a[key]);
         };

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCompliance/interventionCompliance.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCompliance/interventionCompliance.component.html
@@ -4,6 +4,9 @@
     <div class="title">
       <span>Review of program assumptions</span>
     </div>
+
+    <app-reusable-skeleton-table *ngIf="!dataLoaded" [setData]="{ columns: 11, rows: 2 }"></app-reusable-skeleton-table>
+
     <form [formGroup]="form" *ngIf="form">
 
       <table mat-table [dataSource]="dataSource" formArrayName="items" class="table-full-width">

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCompliance/interventionCompliance.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCompliance/interventionCompliance.component.ts
@@ -58,6 +58,8 @@ export class InterventionComplianceComponent implements OnInit {
   public form: UntypedFormGroup;
   public formChanges: InterventionForm['formChanges'] = {};
 
+  public dataLoaded = false;
+
   constructor(
     public quickMapsService: QuickMapsService,
     private intSideNavService: InterventionSideNavContentService,
@@ -80,6 +82,8 @@ export class InterventionComplianceComponent implements OnInit {
                 this.form = this.formBuilder.group({
                   items: this.formBuilder.array(assumptionsGroupArr),
                 });
+
+                this.dataLoaded = true;
 
                 // Mark fields as touched/dirty if they have been previously edited and stored via the API
                 this.form.controls.items['controls'].forEach((formRow: FormGroup) => {

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCostSummary/interventionCostSummary.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCostSummary/interventionCostSummary.component.html
@@ -9,10 +9,12 @@
           <p>Quick summary overview shows the total and discounted intervention costs for the upcoming 10 years.</p>
           <mat-tab-group mat-align-tabs="center" class="nested-tab-group">
             <mat-tab label="Table">
-
+              <app-reusable-skeleton-table *ngIf="!summaryCosts"
+                [setData]="{ columns: 11, rows: 1 }"></app-reusable-skeleton-table>
               <app-intervention-cost-summary-quick-undiscounted-table *ngIf="null != summaryCosts"
                 [summaryCosts]="summaryCosts">
               </app-intervention-cost-summary-quick-undiscounted-table>
+
               <app-intervention-cost-summary-quick-discounted-table *ngIf="null != summaryCosts"
                 [summaryCosts]="summaryCosts">
               </app-intervention-cost-summary-quick-discounted-table>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.html
@@ -4,6 +4,10 @@
     <div class="title">
       <span> Industry Information </span>
     </div>
+
+    <app-reusable-skeleton-table *ngIf="!dataLoaded"
+      [setData]="{ columns: 12, rows: 10 }"></app-reusable-skeleton-table>
+
     <form [formGroup]="form" *ngIf="form">
       <table mat-table [dataSource]="dataSource" formArrayName="items" class="table-full-width">
         <ng-container matColumnDef="labelText">

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.ts
@@ -38,6 +38,7 @@ export class InterventionIndustryInformationComponent implements OnInit {
   public interventionName = 'IntName';
   public form: UntypedFormGroup;
   public formChanges: InterventionForm['formChanges'] = {};
+  public dataLoaded = false;
 
   constructor(
     private intSideNavService: InterventionSideNavContentService,
@@ -68,6 +69,8 @@ export class InterventionIndustryInformationComponent implements OnInit {
           this.form = this.formBuilder.group({
             items: this.formBuilder.array(industryGroupArr),
           });
+
+          this.dataLoaded = true;
 
           // Mark fields as touched/dirty if they have been previously edited and stored via the API
           this.form.controls.items['controls'].forEach((formRow: FormGroup, rowIndex: number) => {

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionMonitoringInformation/interventionMonitoringInformation.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionMonitoringInformation/interventionMonitoringInformation.component.html
@@ -4,6 +4,10 @@
     <div class="title">
       <span>Program Monitoring Information</span>
     </div>
+
+    <app-reusable-skeleton-table *ngIf="!dataLoaded"
+      [setData]="{ columns: 12, rows: 10 }"></app-reusable-skeleton-table>
+
     <form [formGroup]="form" *ngIf="form">
       <table mat-table [dataSource]="dataSource" formArrayName="items" class="table-full-width">
         <ng-container matColumnDef="labelText">

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionMonitoringInformation/interventionMonitoringInformation.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionMonitoringInformation/interventionMonitoringInformation.component.ts
@@ -9,6 +9,7 @@ import { AppRoutes } from 'src/app/routes/routes';
 import { InterventionDataService, InterventionForm } from 'src/app/services/interventionData.service';
 import { InterventionSideNavContentService } from '../../components/interventionSideNavContent/interventionSideNavContent.service';
 import { pairwise, map, filter, startWith } from 'rxjs/operators';
+
 @Component({
   selector: 'app-intervention-monitoring-information',
   templateUrl: './interventionMonitoringInformation.component.html',
@@ -37,6 +38,8 @@ export class InterventionMonitoringInformationComponent implements OnInit {
   public form: UntypedFormGroup;
   public formChanges: InterventionForm['formChanges'] = {};
   public userInput = false;
+  public dataLoaded = false;
+
   constructor(
     private intSideNavService: InterventionSideNavContentService,
     private interventionDataService: InterventionDataService,
@@ -66,7 +69,7 @@ export class InterventionMonitoringInformationComponent implements OnInit {
           this.form = this.formBuilder.group({
             items: this.formBuilder.array(monitoringGroupArr),
           });
-
+          this.dataLoaded = true;
           // Mark fields as touched/dirty if they have been previously edited and stored via the API
           this.form.controls.items['controls'].forEach((formRow: FormGroup, rowIndex: number) => {
             let yearIndex = 0;

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionRecurringCosts/interventionRecurringCosts.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionRecurringCosts/interventionRecurringCosts.component.html
@@ -3,10 +3,13 @@
     <app-intervention-description></app-intervention-description>
     <mat-tab-group>
       <mat-tab label="Tables">
+        <app-reusable-skeleton-table *ngIf="!dataLoaded"
+          [setData]="{ columns: 11, rows: 6 }"></app-reusable-skeleton-table>
         <div *ngFor="let recurringCost of recurringCosts">
           <div class="title">
             <span>{{recurringCost.category}}</span>
           </div>
+
           <div class="recurringCostTable">
             <app-reusable-cost-table *ngIf="null != recurringCosts" [recurringCost]="recurringCost"
               [headers]="displayHeaders">

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionRecurringCosts/interventionRecurringCosts.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionRecurringCosts/interventionRecurringCosts.component.ts
@@ -29,6 +29,7 @@ export class InterventionRecurringCostsComponent implements OnInit {
   ];
 
   private subscriptions = new Array<Subscription>();
+  public dataLoaded = false;
 
   constructor(
     private intSideNavService: InterventionSideNavContentService,
@@ -39,6 +40,8 @@ export class InterventionRecurringCostsComponent implements OnInit {
       void this.interventionDataService
         .getInterventionRecurringCosts(activeInterventionId)
         .then((data: InterventionRecurringCosts) => {
+          this.dataLoaded = true;
+          console.log('bing');
           this.recurringCosts = data.recurringCosts;
           // console.debug('initial: ', this.recurringCosts);
         });
@@ -52,6 +55,7 @@ export class InterventionRecurringCostsComponent implements OnInit {
             void this.interventionDataService
               .getInterventionRecurringCosts(activeInterventionId)
               .then((data: InterventionRecurringCosts) => {
+                this.dataLoaded = true;
                 this.recurringCosts = data.recurringCosts;
               });
           }

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionStartupScaleupCosts/interventionStartupScaleupCosts.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionStartupScaleupCosts/interventionStartupScaleupCosts.component.html
@@ -1,6 +1,8 @@
 <div class="bmgf-maps-nice-scrollbar container">
   <div class="content">
     <app-intervention-description></app-intervention-description>
+    <app-reusable-skeleton-table *ngIf="!startupCosts"
+      [setData]="{ columns: 3, rows: 5 }"></app-reusable-skeleton-table>
     <div *ngFor="let startupCost of startupCosts">
       <div class="title">
         <span>{{startupCost.category}}</span>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/utilities/reusableSkeletonTable/reusableSkeletonTable.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/utilities/reusableSkeletonTable/reusableSkeletonTable.component.html
@@ -1,0 +1,10 @@
+<table mat-table [dataSource]="data">
+  <ng-container [matColumnDef]="column" *ngFor="let column of displayedColumns">
+    <th mat-header-cell *matHeaderCellDef><ngx-skeleton-loader [theme]="{height: '45px'}"></ngx-skeleton-loader></th>
+    <td mat-cell *matCellDef="let element"><ngx-skeleton-loader [theme]="{background: '#f1ecf6'}"></ngx-skeleton-loader>
+    </td>
+  </ng-container>
+
+  <tr mat-header-row *matHeaderRowDef="columnsToDisplay"></tr>
+  <tr mat-row *matRowDef="let row; columns: columnsToDisplay;"></tr>
+</table>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/utilities/reusableSkeletonTable/reusableSkeletonTable.component.scss
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/utilities/reusableSkeletonTable/reusableSkeletonTable.component.scss
@@ -1,0 +1,18 @@
+@import 'src/assets/scss/_colour.scss';
+
+table {
+  width: 95%;
+  margin-left: 2em;
+  background: none;
+  th.mat-mdc-header-cell {
+    border-bottom-color: rgba(0, 0, 0, 0);
+    padding: 5px !important;
+  }
+  td.mat-mdc-cell {
+    border-bottom-color: rgba(0, 0, 0, 0);
+    padding: 5px !important;
+  }
+  tr.mat-mdc-footer-row {
+    font-weight: bold;
+  }
+}

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/utilities/reusableSkeletonTable/reusableSkeletonTable.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/utilities/reusableSkeletonTable/reusableSkeletonTable.component.ts
@@ -1,5 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
-import { MatTableDataSource } from '@angular/material/table';
+import { Component, Input } from '@angular/core';
 
 @Component({
   selector: 'app-reusable-skeleton-table',

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/utilities/reusableSkeletonTable/reusableSkeletonTable.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/utilities/reusableSkeletonTable/reusableSkeletonTable.component.ts
@@ -1,0 +1,32 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { MatTableDataSource } from '@angular/material/table';
+
+@Component({
+  selector: 'app-reusable-skeleton-table',
+  templateUrl: './reusableSkeletonTable.component.html',
+  styleUrls: ['./reusableSkeletonTable.component.scss'],
+})
+export class ReusableSkeletonTableComponent {
+  public displayedColumns: string[];
+  public columnsToDisplay: string[];
+  public data: string[] = [];
+
+  @Input() set setData(config: SkeletonTableConfig) {
+    const cols = [];
+    for (let i = 0; i < config.columns; i++) {
+      cols.push(Math.floor(Math.random() * 999).toString());
+    }
+    this.columnsToDisplay = cols;
+    this.displayedColumns = cols;
+
+    for (let i = 0; i < config.rows; i++) {
+      const tempData = 'skeleton data';
+      this.data.push(tempData);
+    }
+  }
+}
+
+export interface SkeletonTableConfig {
+  columns: number;
+  rows: number;
+}

--- a/src/app/pipes/dataPropertyGetter.pipe.ts
+++ b/src/app/pipes/dataPropertyGetter.pipe.ts
@@ -1,0 +1,11 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'dataPropertyGetter',
+})
+export class DataPropertyGetterPipe implements PipeTransform {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  transform(object: any, keyName: string, ...args: unknown[]): unknown {
+    return object[keyName];
+  }
+}

--- a/src/app/pipes/dataPropertyGetter.pipe.ts
+++ b/src/app/pipes/dataPropertyGetter.pipe.ts
@@ -4,7 +4,7 @@ import { Pipe, PipeTransform } from '@angular/core';
   name: 'dataPropertyGetter',
 })
 export class DataPropertyGetterPipe implements PipeTransform {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
   transform(object: any, keyName: string, ...args: unknown[]): unknown {
     return object[keyName];
   }

--- a/src/app/pipes/pipes.module.ts
+++ b/src/app/pipes/pipes.module.ts
@@ -1,11 +1,12 @@
 import { NgModule } from '@angular/core';
 import { CastPipe } from './cast.pipe';
 import { CurrencyExtendedPipe } from './currency-extended.pipe';
+import { DataPropertyGetterPipe } from './dataPropertyGetter.pipe';
 import { SignificantFiguresPipe } from './significantFigures.pipe';
 
 @NgModule({
-  declarations: [SignificantFiguresPipe, CastPipe, CurrencyExtendedPipe],
+  declarations: [SignificantFiguresPipe, CastPipe, CurrencyExtendedPipe, DataPropertyGetterPipe],
   imports: [],
-  exports: [SignificantFiguresPipe, CastPipe, CurrencyExtendedPipe],
+  exports: [SignificantFiguresPipe, CastPipe, CurrencyExtendedPipe, DataPropertyGetterPipe],
 })
 export class PipesModule {}


### PR DESCRIPTION
- using skeleton loader package that can drop into any html template
- added dynamic table skeleton template with custom rows and columns
- added skeleton loaders into tables within intervention pages for slow connections

## to test
- view each page of the intervention steps and watch for a skeleton table to show before the data loads and a table of content replaces it
- this can be helped by turning dev tools > network > throttling to something like Fast 3G, as a wired network will get the data too quick to notice the change