### PR TITLE
Cost effectiveness standalone entry

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,24 +14,5 @@
   "[json]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
-  "peacock.color": "#9b51e0",
-  "workbench.colorCustomizations": {
-    "activityBar.activeBackground": "#b47ce8",
-    "activityBar.background": "#b47ce8",
-    "activityBar.foreground": "#15202b",
-    "activityBar.inactiveForeground": "#15202b99",
-    "activityBarBadge.background": "#f1d0ae",
-    "activityBarBadge.foreground": "#15202b",
-    "commandCenter.border": "#e7e7e799",
-    "sash.hoverBorder": "#b47ce8",
-    "statusBar.background": "#9b51e0",
-    "statusBar.foreground": "#e7e7e7",
-    "statusBarItem.hoverBackground": "#b47ce8",
-    "statusBarItem.remoteBackground": "#9b51e0",
-    "statusBarItem.remoteForeground": "#e7e7e7",
-    "titleBar.activeBackground": "#9b51e0",
-    "titleBar.activeForeground": "#e7e7e7",
-    "titleBar.inactiveBackground": "#9b51e099",
-    "titleBar.inactiveForeground": "#e7e7e799"
-  }
+  "peacock.color": "#9b51e0"
 }

--- a/src/app/apiAndObjects/api/api.service.ts
+++ b/src/app/apiAndObjects/api/api.service.ts
@@ -40,6 +40,7 @@ import { GetInterventionCostSummary } from './intervention/interventionCostSumma
 import { PostIntervention } from './intervention/intervention/postIntervention';
 import { PatchInterventionData } from './intervention/interventionData/patchInterventionData';
 import { GetApiMetadata } from './misc/getApiMetadata';
+import { GetRegions } from './region/getRegions';
 
 @Injectable()
 export class ApiService extends BaseApi {
@@ -86,6 +87,9 @@ export class ApiService extends BaseApi {
     misc: {
       postFeedback: new postFeedback(ApiService.USE_LIVE_API),
       getApiMetadata: new GetApiMetadata(ApiService.USE_LIVE_API),
+    },
+    region: {
+      getRegions: new GetRegions(ApiService.USE_LIVE_API),
     },
   };
 

--- a/src/app/apiAndObjects/api/intervention/intervention/postIntervention.ts
+++ b/src/app/apiAndObjects/api/intervention/intervention/postIntervention.ts
@@ -23,6 +23,9 @@ export class PostIntervention extends Endpoint<Intervention, PostInterventionPar
       parentInterventionId: params.parentInterventionId,
       newInterventionName: params.newInterventionName,
       newInterventionDescription: params.newInterventionDescription,
+      newInterventionNation: params.newInterventionNation,
+      newInterventionFocusGeography: params.newInterventionFocusGeography,
+      newInterventionFocusMicronutrient: params.newInterventionFocusMicronutrient,
     });
     return this.buildObjectFromResponse(Intervention, callResponsePromise);
   }
@@ -47,4 +50,7 @@ export interface PostInterventionParams {
   parentInterventionId: number;
   newInterventionName?: string;
   newInterventionDescription?: string;
+  newInterventionNation?: string;
+  newInterventionFocusGeography?: string;
+  newInterventionFocusMicronutrient?: string;
 }

--- a/src/app/apiAndObjects/api/region/getRegions.ts
+++ b/src/app/apiAndObjects/api/region/getRegions.ts
@@ -1,0 +1,22 @@
+import { CacheableEndpoint } from '../../_lib_code/api/cacheableEndpoint.abstract';
+import { RequestMethod } from '../../_lib_code/api/requestMethod.enum';
+import { Region } from '../../objects/region';
+
+export class GetRegions extends CacheableEndpoint<Array<Region>, GetRegionsParams, Region> {
+  protected getCacheKey(params: GetRegionsParams): string {
+    return JSON.stringify(params);
+  }
+
+  protected callLive(params: GetRegionsParams): Promise<Region[]> {
+    const callResponsePromise = this.apiCaller.doCall([`countries/${params.countryId}/regions`], RequestMethod.GET);
+    return this.buildObjectsFromResponse(Region, callResponsePromise);
+  }
+
+  protected callMock(): Promise<Region[]> {
+    return null;
+  }
+}
+
+export interface GetRegionsParams {
+  countryId: string;
+}

--- a/src/app/apiAndObjects/objects/costEffectivenessRequest.interface.ts
+++ b/src/app/apiAndObjects/objects/costEffectivenessRequest.interface.ts
@@ -1,0 +1,8 @@
+export interface CostEffectivenessRequest {
+  nation: string;
+  focusGeography: string;
+  focusMicronutrient: string;
+  interventionType: string;
+  foodVehicle: string;
+  interventionStatus: string;
+}

--- a/src/app/apiAndObjects/objects/costEffectivenessRequest.interface.ts
+++ b/src/app/apiAndObjects/objects/costEffectivenessRequest.interface.ts
@@ -1,8 +1,0 @@
-export interface CostEffectivenessRequest {
-  nation: string;
-  focusGeography: string;
-  focusMicronutrient: string;
-  interventionType: string;
-  foodVehicle: string;
-  interventionStatus: string;
-}

--- a/src/app/apiAndObjects/objects/interventionCE.interface.ts
+++ b/src/app/apiAndObjects/objects/interventionCE.interface.ts
@@ -1,0 +1,17 @@
+export interface CEFormBody {
+  nation: string;
+  focusGeography: string;
+  focusMicronutrient: string;
+  interventionType: string;
+  foodVehicle: string;
+  interventionStatus: string;
+}
+
+export interface InterventionCERequest {
+  parentInterventionId: number;
+  newInterventionName: string;
+  newInterventionDescription: string;
+  newInterventionNation: string;
+  newInterventionFocusGeography: string;
+  newInterventionFocusMicronutrient: string;
+}

--- a/src/app/apiAndObjects/objects/region.ts
+++ b/src/app/apiAndObjects/objects/region.ts
@@ -1,0 +1,31 @@
+import { BaseObject } from '../_lib_code/objects/baseObject';
+import { Named } from './named.interface';
+
+export class Region extends BaseObject implements Named {
+  public static readonly KEYS = {
+    ID: 'id',
+    NAME: 'name',
+    COUNTRY: 'country',
+    TYPE: 'type',
+    ADMIN_LEVEL: 'adminLevel',
+    GEOMETRY: 'geometry',
+  };
+
+  public readonly id: string;
+  public readonly name: string;
+  public readonly country: string;
+  public readonly type: string;
+  public readonly adminLevel: number;
+  public readonly geometry: GeoJSON.Geometry;
+
+  protected constructor(sourceObject?: Record<string, unknown>) {
+    super(sourceObject);
+
+    this.id = this._getString(Region.KEYS.ID);
+    this.name = this._getString(Region.KEYS.NAME);
+    this.country = this._getString(Region.KEYS.COUNTRY);
+    this.type = this._getString(Region.KEYS.TYPE);
+    this.adminLevel = this._getNumber(Region.KEYS.ADMIN_LEVEL);
+    this.geometry = this._getValue(Region.KEYS.GEOMETRY) as GeoJSON.Geometry;
+  }
+}

--- a/src/app/components/dialogs/costEffectivenessSelectionDialog/costEffectivenessSelectionDialog.component.html
+++ b/src/app/components/dialogs/costEffectivenessSelectionDialog/costEffectivenessSelectionDialog.component.html
@@ -34,8 +34,7 @@
                 <h4>2. Focus geography</h4>
                 <mat-form-field>
                   <mat-label>Select</mat-label>
-                  <mat-select [disabled]="regionOptionArray.length === 0" name="focusGeography"
-                    formControlName="focusGeography">
+                  <mat-select name="focusGeography" formControlName="focusGeography">
                     <mat-option *ngFor="let item of regionOptionArray" [value]="item.id">
                       {{ item.name }}
                     </mat-option>
@@ -56,8 +55,8 @@
               <div>
                 <h4>4. Intervention type</h4>
                 <mat-form-field>
-                  <mat-select [disabled]="true" [value]="interventionTypeOptionArray[0]?.fortificationTypeId"
-                    name="interventionType" formControlName="interventionType">
+                  <mat-select [value]="interventionTypeOptionArray[0]?.fortificationTypeId" name="interventionType"
+                    formControlName="interventionType">
                     <mat-option *ngFor="let item of interventionTypeOptionArray" [value]="item.fortificationTypeId">
                       {{ item.fortificationTypeName }}
                     </mat-option>
@@ -67,7 +66,7 @@
               <div>
                 <h4>5. Food vehicle</h4>
                 <mat-form-field>
-                  <mat-select [disabled]="true" [value]="foodVehicleOptionArray[0]?.foodVehicleId" name="foodVehicle"
+                  <mat-select [value]="foodVehicleOptionArray[0]?.foodVehicleId" name="foodVehicle"
                     formControlName="foodVehicle">
                     <mat-option *ngFor="let item of foodVehicleOptionArray" [value]="item.foodVehicleId">
                       {{ item.foodVehicleName }}
@@ -78,7 +77,7 @@
               <div>
                 <h4>6. Intervention status</h4>
                 <mat-form-field>
-                  <mat-select [disabled]="true" name="interventionStatus" formControlName="interventionStatus">
+                  <mat-select name="interventionStatus" formControlName="interventionStatus">
                     <mat-option value="option1">Option 1</mat-option>
                     <mat-option value="option2" disabled>Option 2 (disabled)</mat-option>
                     <mat-option value="option3">Option 3</mat-option>

--- a/src/app/components/dialogs/costEffectivenessSelectionDialog/costEffectivenessSelectionDialog.component.html
+++ b/src/app/components/dialogs/costEffectivenessSelectionDialog/costEffectivenessSelectionDialog.component.html
@@ -9,14 +9,88 @@
         <h2 class="dropdown-title">Select intervention template</h2>
         <mat-form-field appearance="outline">
           <mat-select (empty)="null" placeholder="Select an intervention" [(ngModel)]="selectedInterventionEdit"
-            matNativeControl required>
+            (selectionChange)="handleInterventionChange($event)" matNativeControl required>
             <mat-option *ngFor="let intervention of interventions" [value]="intervention">
               {{ intervention.name }}
             </mat-option>
           </mat-select>
         </mat-form-field>
+        <ng-container *ngIf="parameterForm">
+          <form [formGroup]="parameterForm" id="parameter-form">
+            <div class="form-flex-wrapper">
+              <div>
+                <h4>1. Nation</h4>
+                <mat-form-field>
+                  <mat-label>Select</mat-label>
+                  <mat-select [(value)]="selectedCountry" (selectionChange)="handleNationChange($event)">
+                    <mat-option *ngFor="let item of countryOptionArray" [value]="item.id">
+                      {{ item.name }}
+                    </mat-option>
+                  </mat-select>
+                </mat-form-field>
+              </div>
+              <div>
+                <h4>2. Focus geography</h4>
+                <mat-form-field>
+                  <mat-label>Select</mat-label>
+                  <mat-select [disabled]="regionOptionArray.length === 0">
+                    <mat-option *ngFor="let item of regionOptionArray" [value]="item.id">
+                      {{ item.name }}
+                    </mat-option>
+                  </mat-select>
+                </mat-form-field>
+              </div>
+              <div>
+                <h4>3. Focus micronutrient</h4>
+                <mat-form-field>
+                  <mat-label>Select</mat-label>
+                  <mat-select [(value)]="selectedMn">
+                    <mat-option *ngFor="let item of micronutrientsOptionArray" [value]="item.id">
+                      {{ item.name }}
+                    </mat-option>
+                  </mat-select>
+                </mat-form-field>
+              </div>
+              <div>
+                <h4>4. Intervention type</h4>
+                <mat-form-field>
+                  <mat-label>Select</mat-label>
+                  <mat-select [disabled]="interventionTypeOptionArray.length === 0"
+                    [value]="interventionTypeOptionArray[0]">
+                    <mat-option *ngFor="let item of interventionTypeOptionArray" [value]="item">
+                      {{ item }}
+                    </mat-option>
+                  </mat-select>
+                </mat-form-field>
+              </div>
+              <div>
+                <h4>5. Food vehicle</h4>
+                <mat-form-field>
+                  <mat-label>Select</mat-label>
+                  <mat-select [disabled]="foodVehicleOptionArray.length === 0" [value]="foodVehicleOptionArray[0]">
+                    <mat-option *ngFor="let item of foodVehicleOptionArray" [value]="item">
+                      {{ item }}
+                    </mat-option>
+                  </mat-select>
+                </mat-form-field>
+              </div>
+              <div>
+                <h4>6. Intervention status</h4>
+                <mat-form-field>
+                  <mat-label>Select</mat-label>
+                  <mat-select>
+                    <mat-option value="option1">Option 1</mat-option>
+                    <mat-option value="option2" disabled>Option 2 (disabled)</mat-option>
+                    <mat-option value="option3">Option 3</mat-option>
+                  </mat-select>
+                </mat-form-field>
+              </div>
+            </div>
+          </form>
+          <mat-divider *ngIf="selectedInterventionEdit"></mat-divider>
+        </ng-container>
         <ng-container *ngIf="selectedInterventionEdit">
-          <form [formGroup]="interventionForm" (ngSubmit)="handleSubmit()" id="form">
+          <form [formGroup]="interventionForm" (ngSubmit)="handleSubmit()" id="intervention-form">
             <mat-form-field appearance="outline">
               <mat-label>Intervention name</mat-label>
               <input matInput [placeholder]="selectedInterventionEdit.name" name="newInterventionName"

--- a/src/app/components/dialogs/costEffectivenessSelectionDialog/costEffectivenessSelectionDialog.component.html
+++ b/src/app/components/dialogs/costEffectivenessSelectionDialog/costEffectivenessSelectionDialog.component.html
@@ -22,7 +22,8 @@
                 <h4>1. Nation</h4>
                 <mat-form-field>
                   <mat-label>Select</mat-label>
-                  <mat-select [(value)]="selectedCountry" (selectionChange)="handleNationChange($event)">
+                  <mat-select [(value)]="selectedCountry" (selectionChange)="handleNationChange($event)" name="nation"
+                    formControlName="nation">
                     <mat-option *ngFor="let item of countryOptionArray" [value]="item.id">
                       {{ item.name }}
                     </mat-option>
@@ -33,7 +34,8 @@
                 <h4>2. Focus geography</h4>
                 <mat-form-field>
                   <mat-label>Select</mat-label>
-                  <mat-select [disabled]="regionOptionArray.length === 0">
+                  <mat-select [disabled]="regionOptionArray.length === 0" name="focusGeography"
+                    formControlName="focusGeography">
                     <mat-option *ngFor="let item of regionOptionArray" [value]="item.id">
                       {{ item.name }}
                     </mat-option>
@@ -44,7 +46,7 @@
                 <h4>3. Focus micronutrient</h4>
                 <mat-form-field>
                   <mat-label>Select</mat-label>
-                  <mat-select [(value)]="selectedMn">
+                  <mat-select [(value)]="selectedMn" name="focusMicronutrient" formControlName="focusMicronutrient">
                     <mat-option *ngFor="let item of micronutrientsOptionArray" [value]="item.id">
                       {{ item.name }}
                     </mat-option>
@@ -54,11 +56,10 @@
               <div>
                 <h4>4. Intervention type</h4>
                 <mat-form-field>
-                  <mat-label>Select</mat-label>
-                  <mat-select [disabled]="interventionTypeOptionArray.length === 0"
-                    [value]="interventionTypeOptionArray[0]">
-                    <mat-option *ngFor="let item of interventionTypeOptionArray" [value]="item">
-                      {{ item }}
+                  <mat-select [disabled]="true" [value]="interventionTypeOptionArray[0]?.fortificationTypeId"
+                    name="interventionType" formControlName="interventionType">
+                    <mat-option *ngFor="let item of interventionTypeOptionArray" [value]="item.fortificationTypeId">
+                      {{ item.fortificationTypeName }}
                     </mat-option>
                   </mat-select>
                 </mat-form-field>
@@ -66,10 +67,10 @@
               <div>
                 <h4>5. Food vehicle</h4>
                 <mat-form-field>
-                  <mat-label>Select</mat-label>
-                  <mat-select [disabled]="foodVehicleOptionArray.length === 0" [value]="foodVehicleOptionArray[0]">
-                    <mat-option *ngFor="let item of foodVehicleOptionArray" [value]="item">
-                      {{ item }}
+                  <mat-select [disabled]="true" [value]="foodVehicleOptionArray[0]?.foodVehicleId" name="foodVehicle"
+                    formControlName="foodVehicle">
+                    <mat-option *ngFor="let item of foodVehicleOptionArray" [value]="item.foodVehicleId">
+                      {{ item.foodVehicleName }}
                     </mat-option>
                   </mat-select>
                 </mat-form-field>
@@ -77,8 +78,7 @@
               <div>
                 <h4>6. Intervention status</h4>
                 <mat-form-field>
-                  <mat-label>Select</mat-label>
-                  <mat-select>
+                  <mat-select [disabled]="true" name="interventionStatus" formControlName="interventionStatus">
                     <mat-option value="option1">Option 1</mat-option>
                     <mat-option value="option2" disabled>Option 2 (disabled)</mat-option>
                     <mat-option value="option3">Option 3</mat-option>

--- a/src/app/components/dialogs/costEffectivenessSelectionDialog/costEffectivenessSelectionDialog.component.html
+++ b/src/app/components/dialogs/costEffectivenessSelectionDialog/costEffectivenessSelectionDialog.component.html
@@ -45,7 +45,8 @@
                 <h4>3. Focus micronutrient</h4>
                 <mat-form-field>
                   <mat-label>Select</mat-label>
-                  <mat-select [(value)]="selectedMn" name="focusMicronutrient" formControlName="focusMicronutrient">
+                  <mat-select [(value)]="selectedMn" name="focusMicronutrient" formControlName="focusMicronutrient"
+                    (valueChange)="handleMnChange($event)">
                     <mat-option *ngFor="let item of micronutrientsOptionArray" [value]="item.id">
                       {{ item.name }}
                     </mat-option>

--- a/src/app/components/dialogs/costEffectivenessSelectionDialog/costEffectivenessSelectionDialog.component.scss
+++ b/src/app/components/dialogs/costEffectivenessSelectionDialog/costEffectivenessSelectionDialog.component.scss
@@ -38,3 +38,28 @@ mat-form-field {
 .result-wrapper {
   margin: 10px 0 5px 0;
 }
+
+form {
+  &#parameter-form {
+    margin: 2rem 0 1rem 0;
+  }
+
+  &#intervention-form {
+    margin-top: 1rem;
+  }
+
+  .form-flex-wrapper {
+    display: flex;
+    flex-wrap: wrap;
+    width: 100%;
+
+    div {
+      width: 50%;
+      margin-bottom: 0.5rem;
+
+      h4 {
+        margin-bottom: 0;
+      }
+    }
+  }
+}

--- a/src/app/components/dialogs/costEffectivenessSelectionDialog/costEffectivenessSelectionDialog.component.ts
+++ b/src/app/components/dialogs/costEffectivenessSelectionDialog/costEffectivenessSelectionDialog.component.ts
@@ -262,7 +262,7 @@ export class CostEffectivenessSelectionDialogComponent implements OnInit {
       // TODO: POST to endpoint with parameterFormObj as body
       this.interventionDataService
         .setIntervention(
-          this.interventionRequestBody.parentInterventionId,
+          Number(this.interventionRequestBody.parentInterventionId),
           this.interventionRequestBody.newInterventionName,
           this.interventionRequestBody.newInterventionDescription,
           this.interventionRequestBody.newInterventionNation,
@@ -274,6 +274,7 @@ export class CostEffectivenessSelectionDialogComponent implements OnInit {
           this.closeDialog();
         })
         .catch((err) => {
+          console.log(err);
           throw new Error(err);
         });
     }

--- a/src/app/components/dialogs/costEffectivenessSelectionDialog/costEffectivenessSelectionDialog.component.ts
+++ b/src/app/components/dialogs/costEffectivenessSelectionDialog/costEffectivenessSelectionDialog.component.ts
@@ -16,7 +16,6 @@ import { Params } from '@angular/router';
 import { MatSelectChange } from '@angular/material/select';
 import { ApiService } from 'src/app/apiAndObjects/api/api.service';
 import { Region } from 'src/app/apiAndObjects/objects/region';
-import { HttpClient } from '@angular/common/http';
 import { CEFormBody, InterventionCERequest } from 'src/app/apiAndObjects/objects/interventionCE.interface';
 
 interface InterventionType {
@@ -66,10 +65,12 @@ export class CostEffectivenessSelectionDialogComponent implements OnInit {
     private interventionDataService: InterventionDataService,
     private formBuilder: UntypedFormBuilder,
     private dictionariesService: DictionaryService,
-    private http: HttpClient,
     private readonly route: ActivatedRoute,
     private apiService: ApiService,
   ) {
+    this.interventions = dialogData.dataIn.interventions as Array<InterventionsDictionaryItem>;
+    this.queryParams = dialogData.dataIn.params;
+
     this.route.queryParamMap.subscribe(async (queryParams) => {
       const currentlySelectedInterventionIDs: Array<string> = queryParams.get('intIds')
         ? JSON.parse(queryParams.get('intIds'))
@@ -81,7 +82,7 @@ export class CostEffectivenessSelectionDialogComponent implements OnInit {
         currentlySelectedInterventionIDsAsStrings.push(value.toString());
       });
 
-      this.interventions = dialogData.dataIn as Array<InterventionsDictionaryItem>;
+
       // Only allow interventions to be loaded directly which are above an ID.
       // This can be updated to check for an intervention parameter when API allows it.
       this.interventionsAllowedToUse = this.interventions.filter(
@@ -92,17 +93,8 @@ export class CostEffectivenessSelectionDialogComponent implements OnInit {
       this.interventionsAllowedToUse = this.interventionsAllowedToUse.filter(
         (i) => !currentlySelectedInterventionIDsAsStrings.includes(i.id),
       );
+      this.createParameterForm();
     });
-    this.interventions = this.dialogData.dataIn.interventions as Array<InterventionsDictionaryItem>;
-    this.queryParams = this.dialogData.dataIn.params;
-    /**
-     * Only allow interventions to be loaded directly which are above an ID.
-     * This can be updated to check for an intervention parameter when API allows it.
-     */
-    this.interventionsAllowedToUse = this.interventions.filter(
-      (item: InterventionsDictionaryItem) => Number(item.id) > this.onlyAllowInterventionsAboveID,
-    );
-    this.createParameterForm();
   }
 
   ngOnInit(): void {

--- a/src/app/components/dialogs/costEffectivenessSelectionDialog/costEffectivenessSelectionDialog.component.ts
+++ b/src/app/components/dialogs/costEffectivenessSelectionDialog/costEffectivenessSelectionDialog.component.ts
@@ -17,6 +17,7 @@ import { MatSelectChange } from '@angular/material/select';
 import { ApiService } from 'src/app/apiAndObjects/api/api.service';
 import { Region } from 'src/app/apiAndObjects/objects/region';
 import { CEFormBody, InterventionCERequest } from 'src/app/apiAndObjects/objects/interventionCE.interface';
+import { MicronutrientDictionaryItem } from 'src/app/apiAndObjects/objects/dictionaries/micronutrientDictionaryItem';
 
 interface InterventionType {
   fortificationTypeId?: string;
@@ -218,6 +219,13 @@ export class CostEffectivenessSelectionDialogComponent implements OnInit {
       });
   }
 
+  private setUrlParams(param: string, value: string): void {
+    const searchParams = new URLSearchParams(window.location.search);
+    searchParams.set(param, value);
+    const newRelativePathQuery = window.location.pathname + '?' + searchParams.toString();
+    history.pushState(null, '', newRelativePathQuery);
+  }
+
   public handleTabChange(event: MatTabChangeEvent): void {
     this.interventionForm.reset();
     this.proceed.next(false);
@@ -274,7 +282,7 @@ export class CostEffectivenessSelectionDialogComponent implements OnInit {
           this.closeDialog();
         })
         .catch((err) => {
-          console.log(err);
+          console.error(err);
           throw new Error(err);
         });
     }
@@ -288,6 +296,7 @@ export class CostEffectivenessSelectionDialogComponent implements OnInit {
       .then((response: Region[]) => {
         this.toggleRegionDropdown(response);
         this.regionOptionArray = response.sort(this.sort);
+        this.setUrlParams('country-id', change.value);
       });
   }
 
@@ -301,5 +310,14 @@ export class CostEffectivenessSelectionDialogComponent implements OnInit {
       foodVehicleId: change.value.foodVehicleId,
       foodVehicleName: change.value.foodVehicleName,
     });
+  }
+
+  public handleMnChange(mnId: string): void {
+    const copy = [...this.micronutrientsOptionArray];
+    const filtered = copy.filter((item) => item.id === mnId);
+    if (filtered.length > 0) {
+      const micronutrient = filtered.shift() as MicronutrientDictionaryItem;
+      this.setUrlParams('mnd-id', micronutrient.id);
+    }
   }
 }

--- a/src/app/components/dialogs/costEffectivenessSelectionDialog/costEffectivenessSelectionDialog.component.ts
+++ b/src/app/components/dialogs/costEffectivenessSelectionDialog/costEffectivenessSelectionDialog.component.ts
@@ -3,7 +3,7 @@ import { UntypedFormBuilder, UntypedFormControl, UntypedFormGroup, Validators } 
 import { MatDialog, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatTabChangeEvent } from '@angular/material/tabs';
 import { ActivatedRoute } from '@angular/router';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, map } from 'rxjs';
 import { InterventionsDictionaryItem } from 'src/app/apiAndObjects/objects/dictionaries/interventionDictionaryItem';
 import { Intervention } from 'src/app/apiAndObjects/objects/intervention';
 import { InterventionDataService } from 'src/app/services/interventionData.service';
@@ -17,6 +17,7 @@ import { MatSelectChange } from '@angular/material/select';
 import { ApiService } from 'src/app/apiAndObjects/api/api.service';
 import { Region } from 'src/app/apiAndObjects/objects/region';
 import { HttpClient } from '@angular/common/http';
+import { CostEffectivenessRequest } from 'src/app/apiAndObjects/objects/costEffectivenessRequest.interface';
 
 interface InterventionType {
   fortificationTypeId?: string;
@@ -53,6 +54,7 @@ export class CostEffectivenessSelectionDialogComponent implements OnInit {
   public foodVehicleOptionArray: FoodVehicle[] = [];
   public selectedCountry = '';
   public selectedMn = '';
+  public parameterFormObj: CostEffectivenessRequest;
   private onlyAllowInterventionsAboveID = 3;
   private countriesDictionary: Dictionary;
   private micronutrientsDictionary: Dictionary;
@@ -175,9 +177,12 @@ export class CostEffectivenessSelectionDialogComponent implements OnInit {
       foodVehicle: new UntypedFormControl({ value: '', disabled: true }, []),
       interventionStatus: new UntypedFormControl({ value: '', disabled: true }, []),
     });
-    this.parameterForm.valueChanges.subscribe((changes) => {
-      console.log(changes);
-    });
+    this.parameterForm.valueChanges
+      .pipe(map(() => this.parameterForm.getRawValue()))
+      .subscribe((changes: CostEffectivenessRequest) => {
+        console.log(changes);
+        this.parameterFormObj = changes;
+      });
   }
 
   private createInterventionForm(): void {
@@ -239,6 +244,9 @@ export class CostEffectivenessSelectionDialogComponent implements OnInit {
         this.dialogData.dataOut = this.selectedInterventionLoad;
         this.closeDialog();
       }
+    } else if (this.tabID === 'copy') {
+      // TODO: POST to endpoint with paramaterFormObj as body
+      console.log(this.parameterFormObj);
     }
   }
 

--- a/src/app/components/dialogs/costEffectivenessSelectionDialog/costEffectivenessSelectionDialog.component.ts
+++ b/src/app/components/dialogs/costEffectivenessSelectionDialog/costEffectivenessSelectionDialog.component.ts
@@ -82,7 +82,6 @@ export class CostEffectivenessSelectionDialogComponent implements OnInit {
         currentlySelectedInterventionIDsAsStrings.push(value.toString());
       });
 
-
       // Only allow interventions to be loaded directly which are above an ID.
       // This can be updated to check for an intervention parameter when API allows it.
       this.interventionsAllowedToUse = this.interventions.filter(
@@ -260,8 +259,23 @@ export class CostEffectivenessSelectionDialogComponent implements OnInit {
         this.closeDialog();
       }
     } else if (this.tabID === 'copy') {
-      // TODO: POST to endpoint with paramaterFormObj as body
-      console.log(this.parameterFormObj);
+      // TODO: POST to endpoint with parameterFormObj as body
+      this.interventionDataService
+        .setIntervention(
+          this.interventionRequestBody.parentInterventionId,
+          this.interventionRequestBody.newInterventionName,
+          this.interventionRequestBody.newInterventionDescription,
+          this.interventionRequestBody.newInterventionNation,
+          this.interventionRequestBody.newInterventionFocusGeography,
+          this.interventionRequestBody.newInterventionFocusMicronutrient,
+        )
+        .then((result) => {
+          this.dialogData.dataOut = result;
+          this.closeDialog();
+        })
+        .catch((err) => {
+          throw new Error(err);
+        });
     }
   }
 

--- a/src/app/components/dialogs/dialog.service.ts
+++ b/src/app/components/dialogs/dialog.service.ts
@@ -25,6 +25,13 @@ import { SectionStartUpCostReviewDialogComponent } from './sectionStartUpCostRev
 import { SectionSummaryRecurringCostReviewDialogComponent } from './sectionSummaryRecurringCostReviewDialog/sectionSummaryRecurringCostReviewDialog.component';
 import { ShareDialogComponent } from './shareDialog/dialogShare.component';
 import { WelcomeDialogComponent } from './welcomeDialog/dialogWelcome.component';
+import { Params } from '@angular/router';
+
+type InterventionDialogParams = {
+  interventions: Array<InterventionsDictionaryItem>;
+  params: Params;
+};
+
 @Injectable()
 export class DialogService extends BaseDialogService {
   constructor(public dialog: MatDialog) {
@@ -70,12 +77,16 @@ export class DialogService extends BaseDialogService {
 
   public openCESelectionDialog(
     interventions: Array<InterventionsDictionaryItem>,
-  ): Promise<DialogData<Array<InterventionsDictionaryItem>>> {
+    queryParams: Params,
+  ): Promise<DialogData<InterventionDialogParams>> {
     return this.openDialog(
       'costEffectivenessSelectionDialog',
       CostEffectivenessSelectionDialogComponent,
       false,
-      interventions,
+      {
+        interventions: interventions,
+        params: queryParams,
+      },
       {},
     );
   }

--- a/src/app/pages/mapsTool/mapsTool.component.html
+++ b/src/app/pages/mapsTool/mapsTool.component.html
@@ -46,7 +46,9 @@
           <i class="fas fa-coins fa-5x" style="color: #703AA3;"></i>
           <div class="text text-center margin-top-auto">
             <h2>Cost & Effectiveness</h2>
-            <p>Test!</p>
+            <p>Go straight to exploring cost-effectiveness scenarios by experimenting with model parameters and
+              configuration.
+            </p>
           </div>
           <button class="full-width margin-top-auto" mat-flat-button color="primary"
             [routerLink]="ROUTES.STANDALONE_COST_EFFECTIVENESS | route" queryParamsHandling="merge">View</button>

--- a/src/app/pages/mapsTool/mapsTool.component.html
+++ b/src/app/pages/mapsTool/mapsTool.component.html
@@ -1,5 +1,4 @@
 <div role="main">
-
   <div class="wave-header">
     <img src="/assets/images/purple-opacity-wave.svg" alt="">
   </div>
@@ -34,21 +33,34 @@
             <h2>Quick MAPS</h2>
             <p>Launch the MAPS Tool using default mode settings to explore micronutrient
               deficiencies risks in your
-              geography of interest and possible interventions to reduce the risk of micronutrient deficiencies</p>
-
+              geography of interest and possible interventions to reduce the risk of micronutrient deficiencies
+            </p>
           </div>
           <button class="full-width margin-top-auto" mat-flat-button color="primary"
             [routerLink]="ROUTES.QUICK_MAPS | route">View</button>
         </div>
       </div>
+
+      <div class="tool-cell mdc-layout-grid__cell mdc-layout-grid__cell--span-3-desktop">
+        <div class="basic-card tool-options-card">
+          <i class="fas fa-coins fa-5x" style="color: #703AA3;"></i>
+          <div class="text text-center margin-top-auto">
+            <h2>Cost & Effectiveness</h2>
+            <p>Test!</p>
+          </div>
+          <button class="full-width margin-top-auto" mat-flat-button color="primary"
+            [routerLink]="ROUTES.STANDALONE_COST_EFFECTIVENESS | route" queryParamsHandling="merge">View</button>
+        </div>
+      </div>
+
       <div class="tool-cell mdc-layout-grid__cell mdc-layout-grid__cell--span-3-desktop">
         <div class="basic-card tool-options-card">
           <i class="fas fa-user-cog fa-5x" style="color: #703AA3;"></i>
           <div class="text text-center margin-top-auto">
             <h2>My MAPS</h2>
             <p>Log-in to create or access your stored workspace, including uploading your own
-              data</p>
-
+              data
+            </p>
           </div>
           <button class="full-width margin-top-auto" mat-flat-button color="primary" disabled>Coming Soon</button>
         </div>
@@ -60,8 +72,8 @@
           <div class="text text-center margin-top-auto">
             <h2>Choices in MAPS</h2>
             <p>Launch the MAPS Tool with data and model selection options enabled for you to
-              make customised choices</p>
-
+              make customised choices
+            </p>
           </div>
           <button class="full-width margin-top-auto" mat-flat-button color="primary" disabled>Coming Soon</button>
         </div>
@@ -73,12 +85,10 @@
           <div class="text text-center margin-top-auto">
             <h2>Sharing MAPS</h2>
             <p>Log-in to a shared MAPS Tool workspace</p>
-
           </div>
           <button class="full-width margin-top-auto" mat-flat-button color="primary" disabled>Coming Soon</button>
         </div>
       </div>
     </div>
   </div>
-
 </div>

--- a/src/app/pages/quickMaps/pages/baselineDetails/baselineDescription/baselineDescription.component.html
+++ b/src/app/pages/quickMaps/pages/baselineDetails/baselineDescription/baselineDescription.component.html
@@ -39,7 +39,7 @@
       </p>
     </div>
   </mat-expansion-panel>
-  <mat-expansion-panel [expanded]="false" *ngIf="matches" class="match-panel">
+  <mat-expansion-panel [expanded]="false" *ngIf="matches && matches.length > 0" class="match-panel">
     <mat-expansion-panel-header class="desc-header">
       <mat-panel-title>
         <div class="match-summary">

--- a/src/app/pages/quickMaps/pages/costEffectiveness/components/interventionCreation/interventionCreation.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/components/interventionCreation/interventionCreation.component.ts
@@ -60,15 +60,19 @@ export class InterventionCreationComponent {
       .openCESelectionDialog(this.interventionsDictionaryItems, this.route.snapshot.queryParams)
       .then((data: DialogData) => {
         if (data !== null && data.dataOut.id) {
+          this.quickMapsService.getMicronutrientRefresh();
           const interventionIds = this.route.snapshot.queryParamMap.get('intIds')
             ? JSON.parse(this.route.snapshot.queryParamMap.get('intIds')).map(Number)
             : [];
           const filtered = interventionIds.filter((x: number) => x); // remove null & zero values
           this.router.navigate([], {
             relativeTo: this.route,
-            queryParams: { intIds: JSON.stringify([...filtered, Number(data.dataOut.id)]) },
+            queryParams: {
+              intIds: JSON.stringify([...filtered, Number(data.dataOut.id)]),
+            },
             queryParamsHandling: 'merge',
           });
+          this.quickMapsService.updateQueryParams();
           this.selectedInterventions.push(data.dataOut);
           this.interventionCreationService.updateCurrentInterventionsCount(this.selectedInterventions.length);
           this.updateInterventionsFromAPI();

--- a/src/app/pages/quickMaps/pages/costEffectiveness/components/interventionCreation/interventionCreation.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/components/interventionCreation/interventionCreation.component.ts
@@ -56,23 +56,25 @@ export class InterventionCreationComponent {
       .unsubscribe();
   }
   public openCESelectionDialog(): void {
-    void this.dialogService.openCESelectionDialog(this.interventionsDictionaryItems).then((data: DialogData) => {
-      if (data !== null && data.dataOut.id) {
-        const interventionIds = this.route.snapshot.queryParamMap.get('intIds')
-          ? JSON.parse(this.route.snapshot.queryParamMap.get('intIds')).map(Number)
-          : [];
-        const filtered = interventionIds.filter((x: number) => x); // remove null & zero values
-        this.router.navigate([], {
-          relativeTo: this.route,
-          queryParams: { intIds: JSON.stringify([...filtered, Number(data.dataOut.id)]) },
-          queryParamsHandling: 'merge',
-        });
-        this.selectedInterventions.push(data.dataOut);
-        this.interventionCreationService.updateCurrentInterventionsCount(this.selectedInterventions.length);
-        this.updateInterventionsFromAPI();
-        this.cdr.detectChanges();
-      }
-    });
+    void this.dialogService
+      .openCESelectionDialog(this.interventionsDictionaryItems, this.route.snapshot.queryParams)
+      .then((data: DialogData) => {
+        if (data !== null && data.dataOut.id) {
+          const interventionIds = this.route.snapshot.queryParamMap.get('intIds')
+            ? JSON.parse(this.route.snapshot.queryParamMap.get('intIds')).map(Number)
+            : [];
+          const filtered = interventionIds.filter((x: number) => x); // remove null & zero values
+          this.router.navigate([], {
+            relativeTo: this.route,
+            queryParams: { intIds: JSON.stringify([...filtered, Number(data.dataOut.id)]) },
+            queryParamsHandling: 'merge',
+          });
+          this.selectedInterventions.push(data.dataOut);
+          this.interventionCreationService.updateCurrentInterventionsCount(this.selectedInterventions.length);
+          this.updateInterventionsFromAPI();
+          this.cdr.detectChanges();
+        }
+      });
   }
 
   public updateInterventionsFromAPI(): void {

--- a/src/app/pages/quickMaps/quickMaps.service.ts
+++ b/src/app/pages/quickMaps/quickMaps.service.ts
@@ -15,6 +15,7 @@ import { QuickMapsQueryParams } from './queryParams/quickMapsQueryParams';
 import { QuickMapsQueryParamKey } from './queryParams/quickMapsQueryParamKey.enum';
 import { DictItemConverter } from './queryParams/converters/dictItemConverter';
 import { StringConverter } from './queryParams/converters/stringConverter';
+import { ActivatedRoute } from '@angular/router';
 
 @Injectable()
 export class QuickMapsService {
@@ -54,13 +55,16 @@ export class QuickMapsService {
     private dietDataService: DietDataService,
     private biomarkerDataService: BiomarkerDataService,
     private dictionaryService: DictionaryService,
+    private readonly route: ActivatedRoute,
   ) {
     this.quickMapsParameters = new QuickMapsQueryParams(injector);
 
     // set from query params etc. on init
     void Promise.all([
       this.quickMapsParameters.getCountry().then((country) => this.country.set(country)),
-      this.quickMapsParameters.getMicronutrient().then((micronutrient) => this.micronutrient.set(micronutrient)),
+      this.quickMapsParameters.getMicronutrient().then((micronutrient) => {
+        this.micronutrient.set(micronutrient);
+      }),
       this.quickMapsParameters.getAgeGenderGroup().then((ageGenderGroupFromParams) =>
         (null != ageGenderGroupFromParams
           ? // use one from params
@@ -85,6 +89,13 @@ export class QuickMapsService {
         this.initSubscriptions();
         this.init.set(true);
       });
+  }
+
+  public getMicronutrientRefresh(): void {
+    this.quickMapsParameters.getMicronutrient(this.route.snapshot.queryParamMap).then((micronutrient) => {
+      console.log('refresh', micronutrient);
+      this.micronutrient.set(micronutrient);
+    });
   }
 
   public sideNavOpen(): void {

--- a/src/app/pages/quickMaps/quickMapsRouteGuard.service.ts
+++ b/src/app/pages/quickMaps/quickMapsRouteGuard.service.ts
@@ -119,7 +119,6 @@ export class QuickMapsRouteGuardService implements CanActivate {
   }
 
   private validateParamsConsistency(queryParamMap: ParamMap, snapshot: ActivatedRouteSnapshot): Promise<boolean> {
-    console.log(snapshot.routeConfig.path);
     if (snapshot.routeConfig.path === 'food-systems/cost-effectiveness') {
       return Promise.resolve(true);
     }

--- a/src/app/pages/quickMaps/quickMapsRouteGuard.service.ts
+++ b/src/app/pages/quickMaps/quickMapsRouteGuard.service.ts
@@ -30,13 +30,13 @@ export class QuickMapsRouteGuardService implements CanActivate {
     // state: RouterStateSnapshot,
   ): Promise<boolean | UrlTree> {
     const promises = new Array<Promise<boolean>>();
-    // console.debug('canActivate', snapshot);
 
     // code for potentially having different validity checks for different routes
-    // switch (route.routeConfig.path) {
+    // switch (this.route.routeConfig.path) {
     //   case AppRoutes.QUICK_MAPS_BASELINE.segments:
     //   case AppRoutes.QUICK_MAPS_PROJECTION.segments:
-    promises.push(this.validateParamsConsistency(snapshot.queryParamMap));
+
+    promises.push(this.validateParamsConsistency(snapshot.queryParamMap, snapshot));
     promises.push(this.validateMeasureForRoute(snapshot));
     promises.push(this.validateMicronutrientForRoute(snapshot));
 
@@ -118,7 +118,11 @@ export class QuickMapsRouteGuardService implements CanActivate {
     });
   }
 
-  private validateParamsConsistency(queryParamMap: ParamMap): Promise<boolean> {
+  private validateParamsConsistency(queryParamMap: ParamMap, snapshot: ActivatedRouteSnapshot): Promise<boolean> {
+    console.log(snapshot.routeConfig.path);
+    if (snapshot.routeConfig.path === 'food-systems/cost-effectiveness') {
+      return Promise.resolve(true);
+    }
     return Promise.all([
       this.quickMapsParameters.getCountry(queryParamMap),
       this.quickMapsParameters.getMicronutrient(queryParamMap),

--- a/src/app/routes/routes.ts
+++ b/src/app/routes/routes.ts
@@ -48,6 +48,7 @@ export class AppRoutes {
     segments: 'quick-maps',
     routerRoot: true,
   };
+  public static readonly;
   public static readonly EDUCATIONAL_RESOURCES = {
     ...BASE_ROUTE,
     segments: 'educational-resources',
@@ -113,6 +114,12 @@ export class AppRoutes {
     parent: AppRoutes.QUICK_MAPS,
   };
   // *** quick maps end ***
+
+  public static readonly STANDALONE_COST_EFFECTIVENESS = {
+    ...BASE_ROUTE,
+    segments: 'food-systems/cost-effectiveness',
+    parent: AppRoutes.QUICK_MAPS,
+  };
 
   // used in intervention review sub-router
   public static readonly INTERVENTION_REVIEW = {

--- a/src/app/services/interventionData.service.ts
+++ b/src/app/services/interventionData.service.ts
@@ -135,11 +135,17 @@ export class InterventionDataService {
     parentInterventionId: number,
     newInterventionName: string,
     newInterventionDescription: string,
+    newInterventionNation?: string,
+    newInterventionFocusGeography?: string,
+    newInterventionFocusMicronutrient?: string,
   ): Promise<Intervention> {
     return this.apiService.endpoints.intervention.postIntervention.call({
       parentInterventionId,
       newInterventionName,
       newInterventionDescription,
+      newInterventionNation,
+      newInterventionFocusGeography,
+      newInterventionFocusMicronutrient,
     });
   }
 

--- a/src/assets/scss/_bmgf_maps_theme.scss
+++ b/src/assets/scss/_bmgf_maps_theme.scss
@@ -16,6 +16,7 @@
 @import 'tables';
 @import 'forms';
 @import 'dialog';
+@import 'divider';
 
 /*
   Generated here:

--- a/src/assets/scss/_divider.scss
+++ b/src/assets/scss/_divider.scss
@@ -1,0 +1,6 @@
+@import './colour';
+
+.mat-divider {
+  border-top-color: $color_primary !important;
+  border-top-width: 2px !important;
+}


### PR DESCRIPTION
Resolves #1129 & #1130 

Implemented:

- Created button next to 'Quick Maps' to take user straight to cost effectiveness route (ignore required root params for country-id & mnd-id
- Built new 'parameter' form in CE dialog for user to select country, region, micronutrient etc.
- Added class in API structure to call /countries/{countryId}/regions directly

To-do:

 - [x] Still need to implement POST functionality to submit form, but waiting on further details for that. 
 - [ ] Stage 6 select value waiting TBC 