### PR TITLE
Fix Cypress tests 

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,10 +15,8 @@ jobs:
         with:
           # build: npm run build
           start: npm run start-cypress
-          # config: requestTimeout=41000
-          wait-on: http://localhost:8100
-          # 120 //secs
-          wait-on-timeout: 120
+          # config: requestTimeout=120s
+          wait-on: 'npx wait-on --timeout 120000 http://localhost:8100'
 
       - name: Upload Cypress Screenshots
         uses: actions/upload-artifact@v3

--- a/cypress/integration/ui/quickMaps/baseline.ts
+++ b/cypress/integration/ui/quickMaps/baseline.ts
@@ -5,7 +5,7 @@ describe('Quick maps - Baseline', () => {
   });
 
   it('checks page for a11y compliance', () => {
-    cy.visit('/quick-maps/food-systems/baseline?country-id=MWI&mnd-id=Fe');
+    cy.visit('/quick-maps/food-systems/baseline?country-id=MWI&mnd-id=Fe&measure=food systems');
     cy.wait(8000);
     cy.injectAxe();
     cy.checkA11y(
@@ -25,7 +25,9 @@ describe('Quick maps - Baseline', () => {
   /* ==== Test Created with Cypress Studio ==== */
   it('baseline description panel show/hide', function () {
     /* ==== Generated with Cypress Studio ==== */
-    cy.visit('/quick-maps/food-systems/baseline?country-id=MWI&mnd-id=Ca&age-gender-group-id=WRA&sm=0&si=');
+    cy.visit(
+      '/quick-maps/food-systems/baseline?country-id=MWI&mnd-id=Ca&measure=food systems&age-gender-group-id=WRA&sm=0&si=',
+    );
     cy.get('.head-panel .mat-expansion-panel-body').should('be.visible');
     cy.get('.head-panel .mat-expansion-indicator').click();
     cy.get('.head-panel .mat-expansion-panel-body').should('be.hidden');
@@ -37,14 +39,16 @@ describe('Quick maps - Baseline', () => {
   /* ==== Test Created with Cypress Studio ==== */
   it('baseline estimate panel showing correct data', function () {
     /* ==== Generated with Cypress Studio ==== */
-    cy.visit('/quick-maps/food-systems/baseline?country-id=MWI&mnd-id=Ca&age-gender-group-id=WRA&sm=0&si=');
+    cy.visit(
+      '/quick-maps/food-systems/baseline?country-id=MWI&mnd-id=Ca&measure=food systems&age-gender-group-id=WRA&sm=0&si=',
+    );
     cy.wait(3000);
-    cy.get('.nation > .estimateValue').should('be.visible');
-    cy.get('.nation > .estimateValue').should('have.text', ' 296 ');
-    cy.get('.vitamin > .estimateValue').should('be.visible');
-    cy.get('.vitamin > .estimateValue').should('have.text', '759');
-    cy.get('.baseline > .estimateValue').should('be.visible');
-    cy.get('.baseline > .estimateValue').should('have.text', ' -61% ');
+    cy.get('.median > .estimateValue').should('be.visible');
+    cy.get('.median > .estimateValue').should('have.text', ' 88.2 ');
+    cy.get('.adequacy > .estimateValue').should('be.visible');
+    cy.get('.adequacy > .estimateValue').should('have.text', '814');
+    cy.get('.prevalence > .wrap-15').should('be.visible');
+    cy.get('.prevalence > .wrap-15').should('have.text', '99.87% of sampled households (12396/12412)');
     cy.get('.right-text > :nth-child(1) > strong').should('be.visible');
     cy.get('.right-text > :nth-child(1) > strong').should('have.text', 'Beyond 2050');
     /* ==== End Cypress Studio ==== */

--- a/cypress/integration/ui/quickMaps/dietary-change.ts
+++ b/cypress/integration/ui/quickMaps/dietary-change.ts
@@ -6,7 +6,7 @@ describe('Quick maps - Dietary Change', () => {
 
   it('checks page for a11y compliance', () => {
     cy.visit(
-      '/quick-maps/food-systems/dietary-change?country-id=MWI&mnd-id=Ca&data-level=household&age-gender-group=all',
+      '/quick-maps/food-systems/dietary-change?country-id=MWI&mnd-id=Ca&measure=food systems&data-level=household&age-gender-group=all',
     );
     cy.wait(8000);
     cy.get('.minimize-button').click();

--- a/cypress/integration/ui/quickMaps/projections.ts
+++ b/cypress/integration/ui/quickMaps/projections.ts
@@ -5,7 +5,9 @@ describe('Quick maps - Projections', () => {
   });
 
   it('checks page for a11y compliance', () => {
-    cy.visit('/quick-maps/food-systems/projection?country-id=MWI&mnd-id=Ca&data-level=household&age-gender-group=all');
+    cy.visit(
+      '/quick-maps/food-systems/projection?country-id=MWI&mnd-id=Ca&measure=food systems&data-level=household&age-gender-group=all',
+    );
     cy.wait(4000);
     cy.get('.minimize-button').click();
     cy.wait(2000);

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint:fix": "eslint \"*/**/*.{ts,tsx}\" --fix",
     "lint:quiet": "eslint \"*/**/*.{ts,tsx}\" --quiet --fix",
     "e2e": "ng e2e",
-    "ci:cypress-run": "node --max_old_space_size=8000 ./node_modules/@angular/cli/bin/ng run app:cypress-run",
+    "ci:cypress-run": "node --max_old_space_size=8000 ./node_modules/@angular/cli/bin/ng run micronutrient-support-tool:cypress-run",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",
     "build:stats": "ng build --stats-json",

--- a/src/app/pages/quickMaps/components/estimate/estimate.component.html
+++ b/src/app/pages/quickMaps/components/estimate/estimate.component.html
@@ -2,7 +2,7 @@
   <mat-spinner aria-label="spinner" *ngIf="loading" color="accent"></mat-spinner>
   <ng-container *ngIf="!loading">
     <div class="wideItem left-text" *ngIf="!showFullData">
-      <div>
+      <div class="median">
         <span class="estimateHeader">National Median:</span>
         <span class="estimateValue blue">
           {{(null == projectionsSummary?.nationalMedian) ? '-' : projectionsSummary.nationalMedian | sigFig:3 | number}}
@@ -14,13 +14,13 @@
           *ngIf="DATA_LEVEL.COUNTRY === (quickMapsService.FoodSystemsDataSource.obs | async)?.dataLevel">({{quickMapsService.micronutrient.get().unit}}
           per capita per day)</small>
       </div>
-      <div>
+      <div class="adequacy">
         <span class="estimateHeader">Adequacy Threshold:</span>
         <span class="estimateValue green">{{(null == targetCalc) ? '-' : targetCalc | sigFig:3 | number}}</span>
         <small>({{quickMapsService.micronutrient.get().unit}}
           (AFE) per day)</small>
       </div>
-      <div>
+      <div class="prevalence">
         <span class="estimateHeader"
           *ngIf="DATA_LEVEL.HOUSEHOLD === (quickMapsService.FoodSystemsDataSource.obs | async)?.dataLevel">Prevalence of
           inadequate supply:</span>


### PR DESCRIPTION
Some Cypress tests were failing since the URLs were missing parameter '&measure=food systems', so an error dialog was shown and hence Cypress couldn't run the UI tests properly.

There was also an issue with class selectors on `ui/quickMaps/baseline.ts`. A new boolean flag was recently added to toggle content in the HTML file `src/app/pages/quickMaps/components/estimate/estimate.component.html`, but the test was looking for selectors that did not exist in the new HTML content block. Updated the test to look for these new selectors.