### PR TITLE
fix: interventions now loading after change to API#

### DIFF
--- a/src/app/components/dialogs/mnAdditionDialog/mnAdditionDialog.component.ts
+++ b/src/app/components/dialogs/mnAdditionDialog/mnAdditionDialog.component.ts
@@ -59,7 +59,7 @@ export class MnAdditionDialogComponent {
             .getItems()
             .sort((a, b) => (a.name < b.name ? -1 : 1)) as Array<MicronutrientDictionaryItem>;
 
-          this.micronutrientsFiltered = dict.filter((item) => available.includes(item.name.toLocaleLowerCase()));
+          this.micronutrientsFiltered = dict.filter((item) => available.includes(item.id));
           this.micronutrientsSelected = this.micronutrientsFiltered[0];
         }
       });

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionBaseline/interventionBaseline.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionBaseline/interventionBaseline.component.ts
@@ -76,7 +76,7 @@ export class InterventionBaselineComponent implements AfterViewInit {
             .then((data: InterventionFoodVehicleStandards) => {
               if (null != data) {
                 this.activeNutrientFVS = data.foodVehicleStandard.filter((standard: FoodVehicleStandard) => {
-                  return standard.micronutrient.includes(mn.name.toLocaleLowerCase());
+                  return standard.micronutrient.includes(mn.id);
                 });
                 this.createFVTableObject(this.activeNutrientFVS);
                 this.compoundAvailable = true;

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/utilities/microNutrientsInPremixTable/microNutrientsInPremixTable.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/utilities/microNutrientsInPremixTable/microNutrientsInPremixTable.component.ts
@@ -54,7 +54,7 @@ export class MicroNutrientsInPremixTableComponent {
         .then((data: InterventionFoodVehicleStandards) => {
           if (data != null) {
             const addedNutrientFVS = data.foodVehicleStandard.filter((standard: FoodVehicleStandard) => {
-              return standard.micronutrient.includes(micronutrient.name.toLocaleLowerCase());
+              return standard.micronutrient.includes(micronutrient.id);
             });
             this.interventionDataService.addMnToCachedMnInPremix(addedNutrientFVS);
             this.micronutrients = addedNutrientFVS;


### PR DESCRIPTION
- Filters results on 'id' not 'name' that has been parsed.