### PR TITLE
refactor: ce form ux flow

### DIFF
--- a/src/app/components/dialogs/costEffectivenessSelectionDialog/costEffectivenessSelectionDialog.component.html
+++ b/src/app/components/dialogs/costEffectivenessSelectionDialog/costEffectivenessSelectionDialog.component.html
@@ -1,142 +1,119 @@
 <app-base-dialog [data]="dialogData" title="Select an intervention">
-  <div class="content-container">
-    <p>
-      Select one of the existing interventions and customise it for your scenario or load an existing
-      intervention by its ID.
-    </p>
-    <mat-tab-group animationDuration="0ms" (selectedTabChange)="handleTabChange($event)">
-      <mat-tab label="Copy & edit intervention template">
-        <h2 class="dropdown-title">Select intervention template</h2>
-        <mat-form-field appearance="outline">
-          <mat-select (empty)="null" placeholder="Select an intervention" [(ngModel)]="selectedInterventionEdit"
-            (selectionChange)="handleInterventionChange($event)" matNativeControl required>
-            <mat-option *ngFor="let intervention of interventions" [value]="intervention">
-              {{ intervention.name }}
-            </mat-option>
-          </mat-select>
-        </mat-form-field>
-        <ng-container *ngIf="parameterForm">
-          <form [formGroup]="parameterForm" id="parameter-form">
-            <div class="form-flex-wrapper">
-              <div>
-                <h4>1. Nation</h4>
-                <mat-form-field>
-                  <mat-label>Select</mat-label>
-                  <mat-select [(value)]="selectedCountry" (selectionChange)="handleNationChange($event)" name="nation"
-                    formControlName="nation">
-                    <mat-option *ngFor="let item of countryOptionArray" [value]="item.id">
-                      {{ item.name }}
-                    </mat-option>
-                  </mat-select>
+    <div class="content-container">
+        <p>
+            Select one of the existing interventions and customise it for your scenario or load an existing
+            intervention by its ID.
+        </p>
+        <mat-tab-group animationDuration="0ms" (selectedTabChange)="handleTabChange($event)">
+            <mat-tab label="Copy & edit intervention template">
+                <h2 class="dropdown-title">Select intervention template</h2>
+                <mat-form-field appearance="outline">
+                    <mat-label>Template</mat-label>
+                    <mat-select (empty)="null" placeholder="Select an intervention"
+                        [(ngModel)]="selectedInterventionEdit" (selectionChange)="handleInterventionChange($event)"
+                        matNativeControl required>
+                        <mat-option *ngFor="let intervention of interventions" [value]="intervention">
+                            {{ intervention.name }}
+                        </mat-option>
+                    </mat-select>
                 </mat-form-field>
-              </div>
-              <div>
-                <h4>2. Focus geography</h4>
-                <mat-form-field>
-                  <mat-label>Select</mat-label>
-                  <mat-select name="focusGeography" formControlName="focusGeography">
-                    <mat-option *ngFor="let item of regionOptionArray" [value]="item.id">
-                      {{ item.name }}
-                    </mat-option>
-                  </mat-select>
-                </mat-form-field>
-              </div>
-              <div>
-                <h4>3. Focus micronutrient</h4>
-                <mat-form-field>
-                  <mat-label>Select</mat-label>
-                  <mat-select [(value)]="selectedMn" name="focusMicronutrient" formControlName="focusMicronutrient"
-                    (valueChange)="handleMnChange($event)">
-                    <mat-option *ngFor="let item of micronutrientsOptionArray" [value]="item.id">
-                      {{ item.name }}
-                    </mat-option>
-                  </mat-select>
-                </mat-form-field>
-              </div>
-              <div>
-                <h4>4. Intervention type</h4>
-                <mat-form-field>
-                  <mat-select [value]="interventionTypeOptionArray[0]?.fortificationTypeId" name="interventionType"
-                    formControlName="interventionType">
-                    <mat-option *ngFor="let item of interventionTypeOptionArray" [value]="item.fortificationTypeId">
-                      {{ item.fortificationTypeName }}
-                    </mat-option>
-                  </mat-select>
-                </mat-form-field>
-              </div>
-              <div>
-                <h4>5. Food vehicle</h4>
-                <mat-form-field>
-                  <mat-select [value]="foodVehicleOptionArray[0]?.foodVehicleId" name="foodVehicle"
-                    formControlName="foodVehicle">
-                    <mat-option *ngFor="let item of foodVehicleOptionArray" [value]="item.foodVehicleId">
-                      {{ item.foodVehicleName }}
-                    </mat-option>
-                  </mat-select>
-                </mat-form-field>
-              </div>
-              <div>
-                <h4>6. Intervention status</h4>
-                <mat-form-field>
-                  <mat-select name="interventionStatus" formControlName="interventionStatus">
-                    <mat-option value="option1">Option 1</mat-option>
-                    <mat-option value="option2" disabled>Option 2 (disabled)</mat-option>
-                    <mat-option value="option3">Option 3</mat-option>
-                  </mat-select>
-                </mat-form-field>
-              </div>
-            </div>
-          </form>
-          <mat-divider *ngIf="selectedInterventionEdit"></mat-divider>
-        </ng-container>
-        <ng-container *ngIf="selectedInterventionEdit">
-          <form [formGroup]="interventionForm" (ngSubmit)="handleSubmit()" id="intervention-form">
-            <mat-form-field appearance="outline">
-              <mat-label>Intervention name</mat-label>
-              <input matInput [placeholder]="selectedInterventionEdit.name" name="newInterventionName"
-                formControlName="newInterventionName" required>
-            </mat-form-field>
-            <mat-form-field appearance="outline">
-              <mat-label>Intervention description</mat-label>
-              <textarea matInput [placeholder]="selectedInterventionEdit.description" name="newInterventionDesc"
-                formControlName="newInterventionDesc"></textarea>
-            </mat-form-field>
-          </form>
-        </ng-container>
-      </mat-tab>
-      <mat-tab label="Load an existing intervention">
-        <div class="content-container">
-          <mat-form-field appearance="outline">
-            <mat-select (empty)="null" placeholder="Select an intervention" [(ngModel)]="selectedInterventionLoad"
-              (ngModelChange)="this.proceed.next(true);" matNativeControl required>
-              <mat-option *ngFor="let intervention of interventionsAllowedToUse" [value]="intervention">
-                (<strong>ID:</strong> {{ intervention.id }}) <strong>Name:</strong> {{ intervention.name }}
-              </mat-option>
-            </mat-select>
-          </mat-form-field>
+                <ng-container *ngIf="selectedInterventionEdit">
+                    <form [formGroup]="interventionForm" (ngSubmit)="handleSubmit()" id="intervention-form">
+                        <mat-form-field appearance="outline">
+                            <mat-label>Intervention name</mat-label>
+                            <input matInput [placeholder]="selectedInterventionEdit.name" name="newInterventionName"
+                                formControlName="newInterventionName" required>
+                        </mat-form-field>
+                        <mat-form-field appearance="outline">
+                            <mat-label>Intervention description</mat-label>
+                            <textarea matInput [placeholder]="selectedInterventionEdit.description"
+                                name="newInterventionDesc" formControlName="newInterventionDesc"></textarea>
+                        </mat-form-field>
+                    </form>
+                    <mat-divider *ngIf="selectedInterventionEdit"></mat-divider>
+                    <ng-container *ngIf="parameterForm">
+                        <form [formGroup]="parameterForm" id="parameter-form">
+                            <div class="form-flex-wrapper">
+                                <div>
+                                    <h4>1. Nation</h4>
+                                    <mat-form-field>
+                                        <mat-label>Select</mat-label>
+                                        <mat-select [(value)]="selectedCountry"
+                                            (selectionChange)="handleNationChange($event)" name="nation"
+                                            formControlName="nation">
+                                            <mat-option *ngFor="let item of countryOptionArray" [value]="item.id">
+                                                {{ item.name }}
+                                            </mat-option>
+                                        </mat-select>
+                                    </mat-form-field>
+                                </div>
+                                <div>
+                                    <h4>2. Focus geography</h4>
+                                    <mat-form-field>
+                                        <mat-label>
+                                            {{ regionOptionArray.length > 0 ? 'Select' : 'No regions available.' }}
+                                        </mat-label>
+                                        <mat-select name="focusGeography" formControlName="focusGeography">
+                                            <mat-option *ngFor="let item of regionOptionArray" [value]="item.id">
+                                                {{ item.name }}
+                                            </mat-option>
+                                        </mat-select>
+                                    </mat-form-field>
+                                </div>
+                                <div>
+                                    <h4>3. Focus micronutrient</h4>
+                                    <mat-form-field>
+                                        <mat-label>Select</mat-label>
+                                        <mat-select [(value)]="selectedMn" name="focusMicronutrient"
+                                            formControlName="focusMicronutrient" (valueChange)="handleMnChange($event)">
+                                            <mat-option *ngFor="let item of micronutrientsOptionArray"
+                                                [value]="item.id">
+                                                {{ item.name }}
+                                            </mat-option>
+                                        </mat-select>
+                                    </mat-form-field>
+                                </div>
+                            </div>
+                        </form>
+                    </ng-container>
+                </ng-container>
+            </mat-tab>
+            <mat-tab label="Load an existing intervention">
+                <div class="content-container">
+                    <mat-form-field appearance="outline">
+                        <mat-select (empty)="null" placeholder="Select an intervention"
+                            [(ngModel)]="selectedInterventionLoad" (ngModelChange)="this.proceed.next(true);"
+                            matNativeControl required>
+                            <mat-option *ngFor="let intervention of interventionsAllowedToUse" [value]="intervention">
+                                (<strong>ID:</strong> {{ intervention.id }}) <strong>Name:</strong> {{ intervention.name
+                                }}
+                            </mat-option>
+                        </mat-select>
+                    </mat-form-field>
+                </div>
+                <div class="result-wrapper"
+                    [ngClass]="(showResults.asObservable() | async) === true ? 'visible' : 'hidden'">
+                    <ng-container *ngIf="selectedInterventionLoad">
+                        <ng-container *ngIf="(err.asObservable() | async) === false">
+                            <h2>Selected Intervention Summary</h2>
+                            <p><strong>Intervention Name:</strong> {{ selectedInterventionLoad.name }}</p>
+                            <p><strong>Description:</strong> {{ selectedInterventionLoad.description }}</p>
+                        </ng-container>
+                    </ng-container>
+                    <ng-container *ngIf="(err.asObservable() | async) === true || selectedInterventionLoad === null">
+                        <strong>No intervention found with ID: {{ interventionId }}</strong>
+                    </ng-container>
+                </div>
+            </mat-tab>
+        </mat-tab-group>
+        <div class="btn-wrapper">
+            <button mat-stroked-button type="button" (click)="closeDialog()">
+                Cancel
+            </button>
+            <button form="form" mat-flat-button color="primary" (click)="createIntervention()" class="btn-proceed"
+                [disabled]="!interventionForm.valid || !parameterForm.valid">
+                {{ tabID === 'copy' ? 'Copy & edit' : 'Load' }}
+            </button>
         </div>
-        <div class="result-wrapper" [ngClass]="(showResults.asObservable() | async) === true ? 'visible' : 'hidden'">
-          <ng-container *ngIf="selectedInterventionLoad">
-            <ng-container *ngIf="(err.asObservable() | async) === false">
-              <h2>Selected Intervention Summary</h2>
-              <p><strong>Intervention Name:</strong> {{ selectedInterventionLoad.name }}</p>
-              <p><strong>Description:</strong> {{ selectedInterventionLoad.description }}</p>
-            </ng-container>
-          </ng-container>
-          <ng-container *ngIf="(err.asObservable() | async) === true || selectedInterventionLoad === null">
-            <strong>No intervention found with ID: {{ interventionId }}</strong>
-          </ng-container>
-        </div>
-      </mat-tab>
-    </mat-tab-group>
-    <div class="btn-wrapper">
-      <button mat-stroked-button type="button" (click)="closeDialog()">
-        Cancel
-      </button>
-      <button form="form" mat-flat-button color="primary" (click)="createIntervention()" class="btn-proceed"
-        [disabled]="(proceed.asObservable() | async) === false">
-        {{ tabID === 'copy' ? 'Copy & edit' : 'Load' }}
-      </button>
     </div>
-  </div>
 </app-base-dialog>

--- a/src/app/components/dialogs/costEffectivenessSelectionDialog/costEffectivenessSelectionDialog.component.scss
+++ b/src/app/components/dialogs/costEffectivenessSelectionDialog/costEffectivenessSelectionDialog.component.scss
@@ -46,6 +46,7 @@ form {
 
   &#intervention-form {
     margin-top: 1rem;
+    margin-bottom: 2rem;
   }
 
   .form-flex-wrapper {
@@ -54,7 +55,7 @@ form {
     width: 100%;
 
     div {
-      width: 50%;
+      width: 100%;
       margin-bottom: 0.5rem;
 
       h4 {

--- a/src/app/components/dialogs/costEffectivenessSelectionDialog/costEffectivenessSelectionDialog.component.ts
+++ b/src/app/components/dialogs/costEffectivenessSelectionDialog/costEffectivenessSelectionDialog.component.ts
@@ -134,9 +134,6 @@ export class CostEffectivenessSelectionDialogComponent implements OnInit {
       .then((dicts: Array<Dictionary>) => {
         this.countriesDictionary = dicts.shift();
         this.micronutrientsDictionary = dicts.shift();
-
-        this.getDictionaryItems(DictionaryType.COUNTRIES);
-        this.getDictionaryItems(DictionaryType.MICRONUTRIENTS);
       });
     if (this.queryParams['country-id']) {
       this.apiService.endpoints.region.getRegions
@@ -185,8 +182,14 @@ export class CostEffectivenessSelectionDialogComponent implements OnInit {
     this.parameterForm = this.formBuilder.group({
       nation: new UntypedFormControl('', [Validators.required]),
       focusGeography: new UntypedFormControl('', []),
-      focusMicronutrient: new UntypedFormControl('', []),
-      interventionType: new UntypedFormControl({ value: '', disabled: true }, []),
+      focusMicronutrient: new UntypedFormControl('', [Validators.required]),
+      interventionType: new UntypedFormControl(
+        {
+          value: this.interventionTypeOptionArray,
+          disabled: true,
+        },
+        [],
+      ),
       foodVehicle: new UntypedFormControl({ value: '', disabled: true }, []),
       interventionStatus: new UntypedFormControl({ value: '', disabled: true }, []),
     });
@@ -301,6 +304,11 @@ export class CostEffectivenessSelectionDialogComponent implements OnInit {
   }
 
   public handleInterventionChange(change: MatSelectChange): void {
+    setTimeout(() => {
+      this.getDictionaryItems(DictionaryType.COUNTRIES);
+      this.getDictionaryItems(DictionaryType.MICRONUTRIENTS);
+    }, 100);
+
     this.interventionRequestBody.parentInterventionId = this.selectedInterventionEdit.id;
     this.interventionTypeOptionArray.push({
       fortificationTypeId: change.value.fortificationTypeId,


### PR DESCRIPTION
**Updates:** 

- Removed select boxes for steps 4, 5 & 6. These are automatically populated when a template is selected & the values are read-only, the data is still sent in the request. 
- Form is not shown until the user selects a template to fork from.
- Clearer messaging for when user selects a country that has no regions associated to it.
- 'Copy and edit' button is disabled until a name is given, country is selected & micronutrient is selected.

**To test:**

- [ ] Flow of creating an intervention still works as it did previously
- [ ] Country/region/micronutrient options not shown until user selects a template
- [ ] User cannot proceed until all required fields are filled out
- [ ] No errors occur during POST request when user hits 'Copy & edit'