### PR TITLE
feat: quickchart create short url via POST

### DIFF
--- a/src/app/apiAndObjects/objects/misc/chartjsObject.ts
+++ b/src/app/apiAndObjects/objects/misc/chartjsObject.ts
@@ -128,3 +128,8 @@ export interface ChartJSObject {
   };
   plugins?: Array<unknown>;
 }
+
+export interface CreateShortUrl {
+  success: boolean;
+  url: string;
+}

--- a/src/app/pages/quickMaps/pages/baselineDetails/foodItems/foodItems.component.html
+++ b/src/app/pages/quickMaps/pages/baselineDetails/foodItems/foodItems.component.html
@@ -51,7 +51,8 @@
     </mat-tab>
 
     <mat-tab label="Download">
-      <app-download [chartDownloadPNG]="chartPNG" [chartDownloadPDF]="chartPDF" [dataArray]="dataSource?.data">
+      <app-download [chartDownloadPNG]="chartPNG" [chartDownloadPDF]="chartPDF" [dataArray]="dataSource?.data"
+        *ngIf="urlCreated">
       </app-download>
     </mat-tab>
 

--- a/src/app/pages/quickMaps/pages/baselineDetails/foodItems/foodItems.component.ts
+++ b/src/app/pages/quickMaps/pages/baselineDetails/foodItems/foodItems.component.ts
@@ -15,7 +15,7 @@ import { QuickMapsService } from '../../../quickMaps.service';
 import 'chartjs-chart-treemap';
 import ColorHash from 'color-hash-ts';
 import { ChartData, ChartDataSets, ChartPoint, ChartTooltipItem } from 'chart.js';
-import { ChartJSObject } from 'src/app/apiAndObjects/objects/misc/chartjsObject';
+import { ChartJSObject, CreateShortUrl } from 'src/app/apiAndObjects/objects/misc/chartjsObject';
 import { DialogService } from 'src/app/components/dialogs/dialog.service';
 import { CardComponent } from 'src/app/components/card/card.component';
 import { BehaviorSubject, Subscription } from 'rxjs';
@@ -56,6 +56,7 @@ export class FoodItemsComponent implements AfterViewInit {
   public displayedColumns = ['ranking', 'foodGenusName', 'foodGroupName', 'dailyMnContribution'];
   public dataSource: MatTableDataSource<TopFoodSource>;
   public mnUnit = '';
+  public urlCreated = false;
 
   public readonly DATA_LEVEL = DataLevel;
 
@@ -240,10 +241,15 @@ export class FoodItemsComponent implements AfterViewInit {
         },
       },
     };
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const chartForRender: ChartJSObject = JSON.parse(JSON.stringify(generatedChart));
-    this.chartPNG = this.qcService.getChartAsImageUrl(chartForRender, 'png');
-    this.chartPDF = this.qcService.getChartAsImageUrl(chartForRender, 'pdf');
+
+    this.qcService.getChartViaPost(generatedChart, 'png').subscribe((response) => {
+      const chartResponse = response as CreateShortUrl;
+      this.chartPNG = chartResponse.url;
+    });
+    this.qcService.getChartViaPost(generatedChart, 'pdf').subscribe((response) => {
+      const chartResponse = response as CreateShortUrl;
+      this.chartPDF = chartResponse.url;
+    });
 
     return generatedChart;
   }

--- a/src/app/pages/quickMaps/pages/baselineDetails/householdSupply/householdSupply.component.ts
+++ b/src/app/pages/quickMaps/pages/baselineDetails/householdSupply/householdSupply.component.ts
@@ -12,7 +12,7 @@ import { DialogService } from 'src/app/components/dialogs/dialog.service';
 import * as ChartAnnotation from 'chartjs-plugin-annotation';
 import { MatSort } from '@angular/material/sort';
 import { MatTableDataSource } from '@angular/material/table';
-import { ChartJSObject } from 'src/app/apiAndObjects/objects/misc/chartjsObject';
+import { ChartJSObject, CreateShortUrl } from 'src/app/apiAndObjects/objects/misc/chartjsObject';
 import { QuickMapsService } from '../../../quickMaps.service';
 import { BehaviorSubject, Subscription } from 'rxjs';
 import { CardComponent } from 'src/app/components/card/card.component';
@@ -318,10 +318,15 @@ export class HouseholdSupplyComponent implements AfterViewInit {
     }
 
     this.chartData = generatedChart;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const chartForRender: ChartJSObject = JSON.parse(JSON.stringify(generatedChart));
-    this.chartPNG = this.qcService.getChartAsImageUrl(chartForRender, 'png');
-    this.chartPDF = this.qcService.getChartAsImageUrl(chartForRender, 'pdf');
+
+    this.qcService.getChartViaPost(generatedChart, 'png').subscribe((response) => {
+      const chartResponse = response as CreateShortUrl;
+      this.chartPNG = chartResponse.url;
+    });
+    this.qcService.getChartViaPost(generatedChart, 'pdf').subscribe((response) => {
+      const chartResponse = response as CreateShortUrl;
+      this.chartPDF = chartResponse.url;
+    });
   }
 
   private openDialog(): void {

--- a/src/app/pages/quickMaps/pages/baselineDetails/monthlyFood/monthlyFood.component.ts
+++ b/src/app/pages/quickMaps/pages/baselineDetails/monthlyFood/monthlyFood.component.ts
@@ -10,7 +10,7 @@ import {
 } from '@angular/core';
 import { MatSort } from '@angular/material/sort';
 import { MatTableDataSource } from '@angular/material/table';
-import { ChartJSObject, ChartsJSDataObject } from 'src/app/apiAndObjects/objects/misc/chartjsObject';
+import { ChartJSObject, ChartsJSDataObject, CreateShortUrl } from 'src/app/apiAndObjects/objects/misc/chartjsObject';
 import { MonthlyFoodGroup } from 'src/app/apiAndObjects/objects/monthlyFoodGroup';
 import { DialogService } from 'src/app/components/dialogs/dialog.service';
 import { QuickMapsService } from '../../../quickMaps.service';
@@ -235,9 +235,15 @@ export class MonthlyFoodComponent implements AfterViewInit {
       },
     };
     this.chartDataStack = generatedChart;
-    const chartForRender = JSON.parse(JSON.stringify(generatedChart)) as ChartJSObject;
-    this.chartPNG = this.qcService.getChartAsImageUrl(chartForRender, 'png');
-    this.chartPDF = this.qcService.getChartAsImageUrl(chartForRender, 'pdf');
+
+    this.qcService.getChartViaPost(generatedChart, 'png').subscribe((response) => {
+      const chartResponse = response as CreateShortUrl;
+      this.chartPNG = chartResponse.url;
+    });
+    this.qcService.getChartViaPost(generatedChart, 'pdf').subscribe((response) => {
+      const chartResponse = response as CreateShortUrl;
+      this.chartPDF = chartResponse.url;
+    });
   }
   private initialiseLineGraph(monthlyChartData: ChartsJSDataObject): void {
     const generatedChart: ChartJSObject = {
@@ -288,9 +294,14 @@ export class MonthlyFoodComponent implements AfterViewInit {
       },
     };
     this.chartDataLine = generatedChart;
-    const chartForRender = JSON.parse(JSON.stringify(generatedChart)) as ChartJSObject;
-    this.chartPNG = this.qcService.getChartAsImageUrl(chartForRender, 'png');
-    this.chartPDF = this.qcService.getChartAsImageUrl(chartForRender, 'pdf');
+    this.qcService.getChartViaPost(generatedChart, 'png').subscribe((response) => {
+      const chartResponse = response as CreateShortUrl;
+      this.chartPNG = chartResponse.url;
+    });
+    this.qcService.getChartViaPost(generatedChart, 'pdf').subscribe((response) => {
+      const chartResponse = response as CreateShortUrl;
+      this.chartPDF = chartResponse.url;
+    });
   }
 
   private genColorHex(foodTypeIndex: string) {

--- a/src/app/pages/quickMaps/pages/biomarkers/biomarkerInfo/biomarkerInfo.component.ts
+++ b/src/app/pages/quickMaps/pages/biomarkers/biomarkerInfo/biomarkerInfo.component.ts
@@ -1,6 +1,6 @@
 import { MatTableDataSource } from '@angular/material/table';
 import { Component, AfterViewInit, ViewChild, Input, Inject, Optional } from '@angular/core';
-import { ChartJSObject } from 'src/app/apiAndObjects/objects/misc/chartjsObject';
+import { ChartJSObject, CreateShortUrl } from 'src/app/apiAndObjects/objects/misc/chartjsObject';
 import * as ChartAnnotation from 'chartjs-plugin-annotation';
 import { MatTabChangeEvent, MatTabGroup } from '@angular/material/tabs';
 import { CardComponent } from 'src/app/components/card/card.component';
@@ -314,11 +314,14 @@ export class BiomarkerInfoComponent implements AfterViewInit {
       },
     };
     this.chartData = generatedChart;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const chartForRender: ChartJSObject = JSON.parse(JSON.stringify(generatedChart));
-    console.log(this.chartPNG);
-    this.chartPNG = this.qcService.getChartAsImageUrl(chartForRender, 'png');
-    this.chartPDF = this.qcService.getChartAsImageUrl(chartForRender, 'pdf');
+    this.qcService.getChartViaPost(generatedChart, 'png').subscribe((response) => {
+      const chartResponse = response as CreateShortUrl;
+      this.chartPNG = chartResponse.url;
+    });
+    this.qcService.getChartViaPost(generatedChart, 'pdf').subscribe((response) => {
+      const chartResponse = response as CreateShortUrl;
+      this.chartPDF = chartResponse.url;
+    });
   }
 
   private openDialog(): void {

--- a/src/app/pages/quickMaps/pages/biomarkers/biomarkerStatus/statusChart/statusChart.component.ts
+++ b/src/app/pages/quickMaps/pages/biomarkers/biomarkerStatus/statusChart/statusChart.component.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import { AfterViewInit, Component, Input, ViewChild } from '@angular/core';
 import { UntypedFormControl } from '@angular/forms';
-import { ChartJSObject } from 'src/app/apiAndObjects/objects/misc/chartjsObject';
+import { ChartJSObject, CreateShortUrl } from 'src/app/apiAndObjects/objects/misc/chartjsObject';
 import * as ChartAnnotation from 'chartjs-plugin-annotation';
 import { QuickchartService } from 'src/app/services/quickChart.service';
 import { ChartjsComponent } from '@ctrl/ngx-chartjs';
@@ -120,9 +120,14 @@ export class StatusChartComponent implements AfterViewInit {
       },
     };
 
-    const chartForRender: ChartJSObject = JSON.parse(JSON.stringify(this.boxChartData));
-    this.boxChartPNG = this.qcService.getChartAsImageUrl(chartForRender, 'png');
-    this.boxChartPDF = this.qcService.getChartAsImageUrl(chartForRender, 'pdf');
+    this.qcService.getChartViaPost(this.boxChartData, 'png').subscribe((response) => {
+      const chartResponse = response as CreateShortUrl;
+      this.boxChartPNG = chartResponse.url;
+    });
+    this.qcService.getChartViaPost(this.boxChartData, 'pdf').subscribe((response) => {
+      const chartResponse = response as CreateShortUrl;
+      this.boxChartPDF = chartResponse.url;
+    });
   }
 
   public initialiseBarChart(dataObj: any, type: string): void {
@@ -171,19 +176,36 @@ export class StatusChartComponent implements AfterViewInit {
       },
     };
 
-    const chartForRender: ChartJSObject = JSON.parse(JSON.stringify(this.barChartData));
     switch (type) {
       case 'pod':
-        this.deficiencyBarChartPNG = this.qcService.getChartAsImageUrl(chartForRender, 'png');
-        this.deficiencyBarChartPDF = this.qcService.getChartAsImageUrl(chartForRender, 'pdf');
+        this.qcService.getChartViaPost(this.boxChartData, 'png').subscribe((response) => {
+          const chartResponse = response as CreateShortUrl;
+          this.deficiencyBarChartPNG = chartResponse.url;
+        });
+        this.qcService.getChartViaPost(this.boxChartData, 'pdf').subscribe((response) => {
+          const chartResponse = response as CreateShortUrl;
+          this.deficiencyBarChartPDF = chartResponse.url;
+        });
         break;
       case 'poe':
-        this.excessBarChartPNG = this.qcService.getChartAsImageUrl(chartForRender, 'png');
-        this.excessBarChartPDF = this.qcService.getChartAsImageUrl(chartForRender, 'pdf');
+        this.qcService.getChartViaPost(this.boxChartData, 'png').subscribe((response) => {
+          const chartResponse = response as CreateShortUrl;
+          this.excessBarChartPNG = chartResponse.url;
+        });
+        this.qcService.getChartViaPost(this.boxChartData, 'pdf').subscribe((response) => {
+          const chartResponse = response as CreateShortUrl;
+          this.excessBarChartPDF = chartResponse.url;
+        });
         break;
       case 'cde':
-        this.combinedBarChartPNG = this.qcService.getChartAsImageUrl(chartForRender, 'png');
-        this.combinedBarChartPDF = this.qcService.getChartAsImageUrl(chartForRender, 'pdf');
+        this.qcService.getChartViaPost(this.boxChartData, 'png').subscribe((response) => {
+          const chartResponse = response as CreateShortUrl;
+          this.combinedBarChartPNG = chartResponse.url;
+        });
+        this.qcService.getChartViaPost(this.boxChartData, 'pdf').subscribe((response) => {
+          const chartResponse = response as CreateShortUrl;
+          this.combinedBarChartPDF = chartResponse.url;
+        });
         break;
     }
   }

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCostSummary/components/detailedView/graphCosts/graphCosts.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCostSummary/components/detailedView/graphCosts/graphCosts.component.ts
@@ -2,7 +2,7 @@ import { Component, Input, OnInit } from '@angular/core';
 import { MatTableDataSource } from '@angular/material/table';
 import { RecurringCost } from 'src/app/apiAndObjects/objects/interventionRecurringCosts';
 import { RecurringCosts } from 'src/app/apiAndObjects/objects/interventionRecurringCosts';
-import { ChartJSObject } from 'src/app/apiAndObjects/objects/misc/chartjsObject';
+import { ChartJSObject, CreateShortUrl } from 'src/app/apiAndObjects/objects/misc/chartjsObject';
 import ColorHash from 'color-hash-ts';
 import { QuickchartService } from 'src/app/services/quickChart.service';
 import { InterventionDataService } from 'src/app/services/interventionData.service';
@@ -108,13 +108,14 @@ export class InterventionCostSummaryDetailedCostsGraphComponent implements OnIni
     };
 
     this.chartData = generatedChart;
-    const chartForRender: ChartJSObject = JSON.parse(JSON.stringify(generatedChart));
-    this.interventionDataService.setInterventionDetailedChartPNG(
-      this.qcService.getChartAsImageUrl(chartForRender, 'png'),
-    );
-    this.interventionDataService.setInterventionDetailedChartPDF(
-      this.qcService.getChartAsImageUrl(chartForRender, 'pdf'),
-    );
+    this.qcService.getChartViaPost(generatedChart, 'png').subscribe((response) => {
+      const chartResponse = response as CreateShortUrl;
+      this.interventionDataService.setInterventionSummaryChartPNG(chartResponse.url);
+    });
+    this.qcService.getChartViaPost(generatedChart, 'pdf').subscribe((response) => {
+      const chartResponse = response as CreateShortUrl;
+      this.interventionDataService.setInterventionSummaryChartPDF(chartResponse.url);
+    });
   }
 
   private genColorHex(foodTypeIndex: string) {

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCostSummary/components/quickSummary/graphTotal/graphTotal.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCostSummary/components/quickSummary/graphTotal/graphTotal.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { InterventionCostSummary } from 'src/app/apiAndObjects/objects/interventionCostSummary';
-import { ChartJSObject } from 'src/app/apiAndObjects/objects/misc/chartjsObject';
+import { ChartJSObject, CreateShortUrl } from 'src/app/apiAndObjects/objects/misc/chartjsObject';
 import { InterventionDataService } from 'src/app/services/interventionData.service';
 import { QuickchartService } from 'src/app/services/quickChart.service';
 @Component({
@@ -83,12 +83,14 @@ export class InterventionCostSummaryQuickTotalGraphComponent implements OnInit {
     };
 
     this.chartData = generatedChart;
-    const chartForRender: ChartJSObject = JSON.parse(JSON.stringify(generatedChart));
-    this.interventionDataService.setInterventionSummaryChartPNG(
-      this.qcService.getChartAsImageUrl(chartForRender, 'png'),
-    );
-    this.interventionDataService.setInterventionSummaryChartPDF(
-      this.qcService.getChartAsImageUrl(chartForRender, 'pdf'),
-    );
+
+    this.qcService.getChartViaPost(generatedChart, 'png').subscribe((response) => {
+      const chartResponse = response as CreateShortUrl;
+      this.interventionDataService.setInterventionSummaryChartPNG(chartResponse.url);
+    });
+    this.qcService.getChartViaPost(generatedChart, 'pdf').subscribe((response) => {
+      const chartResponse = response as CreateShortUrl;
+      this.interventionDataService.setInterventionSummaryChartPDF(chartResponse.url);
+    });
   }
 }

--- a/src/app/pages/quickMaps/pages/projection/projectionAvailability/projectionAvailability.component.ts
+++ b/src/app/pages/quickMaps/pages/projection/projectionAvailability/projectionAvailability.component.ts
@@ -16,7 +16,7 @@ import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { DialogData } from 'src/app/components/dialogs/baseDialogService.abstract';
 import { MatTableDataSource } from '@angular/material/table';
 import { ProjectedAvailability } from 'src/app/apiAndObjects/objects/projectedAvailability';
-import { ChartJSObject } from 'src/app/apiAndObjects/objects/misc/chartjsObject';
+import { ChartJSObject, CreateShortUrl } from 'src/app/apiAndObjects/objects/misc/chartjsObject';
 import { MatTabGroup } from '@angular/material/tabs';
 import { MatSort } from '@angular/material/sort';
 import { QuickchartService } from 'src/app/services/quickChart.service';
@@ -51,6 +51,7 @@ export class ProjectionAvailabilityComponent implements AfterViewInit {
   public chartData: ChartJSObject;
   public chartPNG: string;
   public chartPDF: string;
+  public chartUrlLoaded = false;
   private data: Array<ProjectedAvailability>;
   private loadingSrc = new BehaviorSubject<boolean>(false);
   private errorSrc = new BehaviorSubject<boolean>(false);
@@ -258,9 +259,16 @@ export class ProjectionAvailabilityComponent implements AfterViewInit {
       },
     };
     this.chartData = generatedChart;
-    const chartForRender: ChartJSObject = JSON.parse(JSON.stringify(generatedChart));
-    this.chartPNG = this.qcService.getChartAsImageUrl(chartForRender, 'png');
-    this.chartPDF = this.qcService.getChartAsImageUrl(chartForRender, 'pdf');
+    this.qcService.getChartViaPost(generatedChart, 'png').subscribe((response) => {
+      const chartResponse = response as CreateShortUrl;
+      this.chartUrlLoaded = chartResponse.success;
+      this.chartPNG = chartResponse.url;
+    });
+    this.qcService.getChartViaPost(generatedChart, 'pdf').subscribe((response) => {
+      const chartResponse = response as CreateShortUrl;
+      this.chartUrlLoaded = chartResponse.success;
+      this.chartPDF = chartResponse.url;
+    });
   }
   private openDialog(): void {
     void this.dialogService.openDialogForComponent<ProjectionAvailabilityDialogData>(ProjectionAvailabilityComponent, {

--- a/src/app/pages/quickMaps/pages/projection/projectionFoodSources/projectionFoodSources.component.ts
+++ b/src/app/pages/quickMaps/pages/projection/projectionFoodSources/projectionFoodSources.component.ts
@@ -13,7 +13,7 @@ import { QuickMapsService } from '../../../quickMaps.service';
 import { CardComponent } from 'src/app/components/card/card.component';
 import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { DialogData } from 'src/app/components/dialogs/baseDialogService.abstract';
-import { ChartJSObject, ChartsJSDataObject } from 'src/app/apiAndObjects/objects/misc/chartjsObject';
+import { ChartJSObject, ChartsJSDataObject, CreateShortUrl } from 'src/app/apiAndObjects/objects/misc/chartjsObject';
 import { MatTableDataSource } from '@angular/material/table';
 import { MatTabGroup } from '@angular/material/tabs';
 import { MatSort } from '@angular/material/sort';
@@ -285,9 +285,14 @@ export class ProjectionFoodSourcesComponent implements AfterViewInit {
     };
 
     this.chartData = generatedChart;
-    const chartForRender: ChartJSObject = JSON.parse(JSON.stringify(generatedChart));
-    this.chartPNG = this.qcService.getChartAsImageUrl(chartForRender, 'png');
-    this.chartPDF = this.qcService.getChartAsImageUrl(chartForRender, 'pdf');
+    this.qcService.getChartViaPost(generatedChart, 'png').subscribe((response) => {
+      const chartResponse = response as CreateShortUrl;
+      this.chartPNG = chartResponse.url;
+    });
+    this.qcService.getChartViaPost(generatedChart, 'pdf').subscribe((response) => {
+      const chartResponse = response as CreateShortUrl;
+      this.chartPDF = chartResponse.url;
+    });
   }
 
   private openDialog(): void {

--- a/src/app/services/quickChart.service.ts
+++ b/src/app/services/quickChart.service.ts
@@ -1,10 +1,14 @@
 import { Injectable } from '@angular/core';
 import { ChartJSObject } from '../apiAndObjects/objects/misc/chartjsObject';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const QuickChart = require('quickchart-js');
 
 @Injectable()
 export class QuickchartService {
+  constructor(private http: HttpClient) {}
+
   /**
    *
    * @param chartData - object containing type, data, labels and options for your chart
@@ -21,5 +25,16 @@ export class QuickchartService {
     const chartUrl: string = tmpChart.getUrl();
 
     return chartUrl;
+  }
+
+  public getChartViaPost(chartData: ChartJSObject, format: string): Observable<unknown> {
+    const body = {
+      backgroundColor: '#fff',
+      width: 1000,
+      height: 500,
+      format: format,
+      chart: JSON.stringify(chartData),
+    };
+    return this.http.post('https://quickchart.io/chart/create', body);
   }
 }


### PR DESCRIPTION
This [Postman](https://www.postman.com/speeding-flare-926667/workspace/quickchart-public-workspace/example/11849833-9aff1606-4b22-4ad1-99cf-81ce3a48ac2c) instance shows how to create a shorter URL via a POST request with Quickchart.

This works as expected and resolves the issue of the URL being rejected for being too long. However, I have noticed a handful of caveats related to using this approach:

- Doesn't seem to be any way to specify the returned chart to be PNG or PDF, it just returns a WEBP image.
- Our custom MAPS watermark is not added to the image.
- There is an error when trying to download an image of a chart that has type `treemap`.

Regarding these current issues, leaving this PR as draft for now until we have found out how to resolve them or accept the caveats with the POST approach.