### PR TITLE
fix: load button disabled, separated logic

### DIFF
--- a/src/app/components/dialogs/costEffectivenessSelectionDialog/costEffectivenessSelectionDialog.component.html
+++ b/src/app/components/dialogs/costEffectivenessSelectionDialog/costEffectivenessSelectionDialog.component.html
@@ -111,8 +111,12 @@
                 Cancel
             </button>
             <button form="form" mat-flat-button color="primary" (click)="createIntervention()" class="btn-proceed"
-                [disabled]="!interventionForm.valid || !parameterForm.valid">
-                {{ tabID === 'copy' ? 'Copy & edit' : 'Load' }}
+                *ngIf="tabID === 'copy'" [disabled]="!interventionForm.valid || !parameterForm.valid">
+                Copy & edit
+            </button>
+            <button form="form" mat-flat-button color="primary" (click)="createIntervention()" class="btn-proceed"
+                *ngIf="tabID === 'load'" [disabled]="(proceed.asObservable() | async) === false">
+                Load
             </button>
         </div>
     </div>


### PR DESCRIPTION
Intervention load button greyed out.. Split into two buttons rather than one so that we can have separate disabling logic for each. 