### PR TITLE
feat: show percentages between 0 and 100 but keep api comms 0 and 1

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,5 +14,24 @@
   "[json]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
-  "peacock.color": "#9b51e0"
+  "peacock.color": "#9b51e0",
+  "workbench.colorCustomizations": {
+    "activityBar.activeBackground": "#b47ce8",
+    "activityBar.background": "#b47ce8",
+    "activityBar.foreground": "#15202b",
+    "activityBar.inactiveForeground": "#15202b99",
+    "activityBarBadge.background": "#f1d0ae",
+    "activityBarBadge.foreground": "#15202b",
+    "commandCenter.border": "#e7e7e799",
+    "sash.hoverBorder": "#b47ce8",
+    "statusBar.background": "#9b51e0",
+    "statusBar.foreground": "#e7e7e7",
+    "statusBarItem.hoverBackground": "#b47ce8",
+    "statusBarItem.remoteBackground": "#9b51e0",
+    "statusBarItem.remoteForeground": "#e7e7e7",
+    "titleBar.activeBackground": "#9b51e0",
+    "titleBar.activeForeground": "#e7e7e7",
+    "titleBar.inactiveBackground": "#9b51e099",
+    "titleBar.inactiveForeground": "#e7e7e799"
+  }
 }

--- a/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.html
+++ b/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.html
@@ -20,8 +20,9 @@
                 (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input type="text" [value]="element.year0 * 100" (input)="element.year0 = $any($event.target).value / 100"
-                appDecimalInput formControlName="year0" (change)="recalculateChanges()">
+              <input id="year0" name="year0" (change)="storeIndex(index)" type="number" [ngModel]="element.year0 * 100"
+                formControlName="year0" min="0" max="100" (keyup)="validateUserInput($event, index, 'year0')"
+                (change)="recalculateChanges()">
             </div>
           </td>
           <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year0') | currencyExtended}} TBC</td>
@@ -39,8 +40,9 @@
                 (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input type="text" [value]="element.year1 * 100" (input)="element.year1 = $any($event.target).value / 100"
-                appDecimalInput formControlName="year1" (change)="recalculateChanges()">
+              <input id="year1" name="year1" (change)="storeIndex(index)" type="number" [ngModel]="element.year1 * 100"
+                formControlName="year1" min="0" max="100" (keyup)="validateUserInput($event, index, 'year1')"
+                (change)="recalculateChanges()">
             </div>
           </td>
           <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year1') | currencyExtended}} TBC</td>
@@ -58,8 +60,9 @@
                 (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input type="text" [value]="element.year2 * 100" (input)="element.year2 = $any($event.target).value / 100"
-                appDecimalInput formControlName="year2" (change)="recalculateChanges()">
+              <input id="year2" name="year2" (change)="storeIndex(index)" type="number" [ngModel]="element.year2 * 100"
+                formControlName="year2" min="0" max="100" (keyup)="validateUserInput($event, index, 'year2')"
+                (change)="recalculateChanges()">
             </div>
           </td>
           <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year2') | currencyExtended}} </td>
@@ -77,8 +80,9 @@
                 (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input type="text" [value]="element.year3 * 100" (input)="element.year3 = $any($event.target).value / 100"
-                appDecimalInput formControlName="year3" (change)="recalculateChanges()">
+              <input id="year3" name="year3" (change)="storeIndex(index)" type="number" [ngModel]="element.year3 * 100"
+                formControlName="year3" min="0" max="100" (keyup)="validateUserInput($event, index, 'year3')"
+                (change)="recalculateChanges()">
             </div>
           </td>
           <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year3') | currencyExtended}} </td>
@@ -96,8 +100,9 @@
                 (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input type="text" [value]="element.year4 * 100" (input)="element.year4 = $any($event.target).value / 100"
-                appDecimalInput formControlName="year4" (change)="recalculateChanges()">
+              <input id="year4" name="year4" (change)="storeIndex(index)" type="number" [ngModel]="element.year4 * 100"
+                formControlName="year4" min="0" max="100" (keyup)="validateUserInput($event, index, 'year4')"
+                (change)="recalculateChanges()">
             </div>
           </td>
           <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year4') | currencyExtended}} </td>
@@ -115,8 +120,9 @@
                 (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input type="text" [value]="element.year4 * 100" (input)="element.year5 = $any($event.target).value / 100"
-                appDecimalInput formControlName="year5" (change)="recalculateChanges()">
+              <input id="year5" name="year5" (change)="storeIndex(index)" type="number" [ngModel]="element.year5 * 100"
+                formControlName="year5" min="0" max="100" (keyup)="validateUserInput($event, index, 'year5')"
+                (change)="recalculateChanges()">
             </div>
           </td>
           <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year5') | currencyExtended}} </td>
@@ -134,8 +140,9 @@
                 (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input type="text" [value]="element.year6 * 100" (input)="element.year6 = $any($event.target).value / 100"
-                appDecimalInput formControlName="year6" (change)="recalculateChanges()">
+              <input id="year6" name="year6" (change)="storeIndex(index)" type="number" [ngModel]="element.year6 * 100"
+                formControlName="year6" min="0" max="100" (keyup)="validateUserInput($event, index, 'year6')"
+                (change)="recalculateChanges()">
             </div>
           </td>
           <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year6') | currencyExtended}} </td>
@@ -154,8 +161,9 @@
                 (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input type="text" [value]="element.year4 * 100" (input)="element.year7 = $any($event.target).value / 100"
-                appDecimalInput formControlName="year7" (change)="recalculateChanges()">
+              <input id="year7" name="year7" (change)="storeIndex(index)" type="number" [ngModel]="element.year7 * 100"
+                formControlName="year7" min="0" max="100" (keyup)="validateUserInput($event, index, 'year7')"
+                (change)="recalculateChanges()">
             </div>
           </td>
           <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year7') | currencyExtended}} </td>
@@ -173,8 +181,9 @@
                 (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input type="text" [value]="element.year4 * 100" (input)="element.year8 = $any($event.target).value / 100"
-                appDecimalInput formControlName="year8" (change)="recalculateChanges()">
+              <input id="year8" name="year8" (change)="storeIndex(index)" type="number" [ngModel]="element.year8 * 100"
+                formControlName="year8" min="0" max="100" (keyup)="validateUserInput($event, index, 'year8')"
+                (change)="recalculateChanges()">
             </div>
           </td>
           <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year8') | currencyExtended}} </td>
@@ -192,8 +201,9 @@
                 (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input type="text" [value]="element.year4 * 100" (input)="element.year9 = $any($event.target).value / 100"
-                appDecimalInput formControlName="year9" (change)="recalculateChanges()">
+              <input id="year9" name="year9" (change)="storeIndex(index)" type="number" [ngModel]="element.year9 * 100"
+                formControlName="year9" min="0" max="100" (keyup)="validateUserInput($event, index, 'year9')"
+                (change)="recalculateChanges()">
             </div>
           </td>
           <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year9') | currencyExtended}} </td>

--- a/src/app/components/dialogs/sectionStartUpCostReviewDialog/sectionStartUpCostReviewDialog.component.html
+++ b/src/app/components/dialogs/sectionStartUpCostReviewDialog/sectionStartUpCostReviewDialog.component.html
@@ -11,7 +11,6 @@
 
         <ng-container matColumnDef="year0">
           <th mat-header-cell *matHeaderCellDef>2021</th>
-          <!-- <td mat-cell *matCellDef="let element">{{element.year0 | currencyExtended}}</td> -->
           <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
               <input type="text" appDecimalInput required [value]=element.year0.toFixed(2) formControlName="year0"
@@ -22,8 +21,9 @@
                 (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input type="text" [value]="element.year0 * 100" (input)="element.year0 = $any($event.target).value / 100"
-                formControlName="year0" appDecimalInput (change)="recalculateChanges()">
+              <input id="year0" name="year0" (change)="storeIndex(index)" type="number" [ngModel]="element.year0 * 100"
+                formControlName="year0" min="0" max="100" (keyup)="validateUserInput($event, index, 'year0')"
+                (change)="recalculateChanges()">
             </div>
           </td>
           <td mat-footer-cell *matFooterCellDef> {{year0Total | currencyExtended}} TBC</td>
@@ -31,7 +31,6 @@
 
         <ng-container matColumnDef="year1">
           <th mat-header-cell *matHeaderCellDef>2022</th>
-          <!-- <td mat-cell *matCellDef="let element">{{element.year1 | currencyExtended}}</td> -->
           <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
               <input type="text" appDecimalInput required [value]=element.year1.toFixed(2) formControlName="year1"
@@ -42,8 +41,9 @@
                 (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input type="text" [value]="element.year1 * 100" (input)="element.year1 = $any($event.target).value / 100"
-                formControlName="year1" appDecimalInput (change)="recalculateChanges()">
+              <input id="year1" name="year1" (change)="storeIndex(index)" type="number" [ngModel]="element.year1 * 100"
+                formControlName="year1" min="0" max="100" (keyup)="validateUserInput($event, index, 'year1')"
+                (change)="recalculateChanges()">
             </div>
           </td>
           <td mat-footer-cell *matFooterCellDef> {{year1Total | currencyExtended}} TBC</td>

--- a/src/app/components/dialogs/sectionStartUpCostReviewDialog/sectionStartUpCostReviewDialog.component.ts
+++ b/src/app/components/dialogs/sectionStartUpCostReviewDialog/sectionStartUpCostReviewDialog.component.ts
@@ -7,6 +7,7 @@ import { UntypedFormBuilder, UntypedFormArray, UntypedFormGroup, FormGroup } fro
 import { pairwise, map, filter, startWith } from 'rxjs/operators';
 import { InterventionDataService, InterventionForm } from 'src/app/services/interventionData.service';
 import { JSONLogicService } from 'src/app/services/jsonlogic.service';
+import { NotificationsService } from '../../notifications/notification.service';
 
 @Component({
   selector: 'app-section-start-up-cost-review',
@@ -16,6 +17,7 @@ import { JSONLogicService } from 'src/app/services/jsonlogic.service';
 export class SectionStartUpCostReviewDialogComponent {
   public dataSource = new MatTableDataSource<StartUpCostBreakdown>();
   public title = '';
+  public dirtyIndexes = [];
   public displayedColumns: string[] = ['labelText', 'year0', 'year1'];
   public form: UntypedFormGroup;
   public formChanges: InterventionForm['formChanges'] = {};
@@ -27,6 +29,7 @@ export class SectionStartUpCostReviewDialogComponent {
     private interventionDataService: InterventionDataService,
     private formBuilder: UntypedFormBuilder,
     private jsonLogicService: JSONLogicService,
+    private notificationsService: NotificationsService,
   ) {}
 
   public ngOnInit() {
@@ -83,22 +86,37 @@ export class SectionStartUpCostReviewDialogComponent {
           map(([oldState, newState]) => {
             for (const key in newState.items) {
               const rowIndex = this.form.get('items')['controls'][key]['controls'].rowIndex.value;
-
+              const rowUnits = this.form.get('items')['controls'][key]['controls'].rowUnits.value;
               if (oldState.items[key] !== newState.items[key] && oldState.items[key] !== undefined) {
                 const diff = compareObjs(oldState.items[key], newState.items[key]);
                 if (Array.isArray(diff) && diff.length > 0) {
                   diff.forEach((item) => {
-                    if (changes[rowIndex]) {
-                      changes[rowIndex] = {
-                        ...changes[rowIndex],
-                        [item[0]]: Number(item[1]),
-                      };
-                      changes[rowIndex]['rowIndex'] = rowIndex;
+                    if (rowUnits === 'percent') {
+                      if (changes[rowIndex]) {
+                        changes[rowIndex] = {
+                          ...changes[rowIndex],
+                          [item[0]]: Number(item[1]) / 100,
+                        };
+                        changes[rowIndex]['rowIndex'] = rowIndex;
+                      } else {
+                        changes[rowIndex] = {
+                          [item[0]]: Number(item[1]) / 100,
+                        };
+                        changes[rowIndex]['rowIndex'] = rowIndex;
+                      }
                     } else {
-                      changes[rowIndex] = {
-                        [item[0]]: Number(item[1]),
-                      };
-                      changes[rowIndex]['rowIndex'] = rowIndex;
+                      if (changes[rowIndex]) {
+                        changes[rowIndex] = {
+                          ...changes[rowIndex],
+                          [item[0]]: Number(item[1]),
+                        };
+                        changes[rowIndex]['rowIndex'] = rowIndex;
+                      } else {
+                        changes[rowIndex] = {
+                          [item[0]]: Number(item[1]),
+                        };
+                        changes[rowIndex]['rowIndex'] = rowIndex;
+                      }
                     }
                   });
                 }
@@ -165,6 +183,10 @@ export class SectionStartUpCostReviewDialogComponent {
     this.form.markAsPristine();
   }
 
+  public storeIndex(index: number) {
+    this.dirtyIndexes.push(index);
+  }
+
   public recalculateChanges(): void {
     // getRawValue returns values even if cell is marked as disabled
     const allItems: Array<StartUpCostBreakdown> = this.form.getRawValue().items;
@@ -208,5 +230,16 @@ export class SectionStartUpCostReviewDialogComponent {
         });
       }
     });
+  }
+
+  public validateUserInput(event: Event, rowIndex: number, year: string) {
+    const userInput = Number((event.target as HTMLInputElement).value);
+    if (userInput < 0) {
+      this.form.controls.items['controls'][rowIndex].patchValue({ [year]: 0 });
+      this.notificationsService.sendInformative('Percentage input must be between 0 and 100.');
+    } else if (userInput > 100) {
+      this.form.controls.items['controls'][rowIndex].patchValue({ [year]: 100 });
+      this.notificationsService.sendInformative('Percentage input must be between 0 and 100.');
+    }
   }
 }

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionBaseline/interventionBaseline.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionBaseline/interventionBaseline.component.html
@@ -25,8 +25,8 @@
             <td mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
               <div class="double-cell">
                 <div>
-                  <input (change)="storeIndex(index)" type="text" appDecimalInput [value]="element.year0 * 100"
-                    (input)="element.year0 = $any($event.target).value / 100" formControlName="year0">
+                  <input id="year0" name="year0" (change)="storeIndex(index)" type="number"
+                    [ngModel]="element.year0 * 100" formControlName="year0" min="0" max="100">
                 </div>
                 <button *ngIf="dirtyIndexes.includes(index) === false" mat-button color="primary">
                   GFDx<mat-icon>arrow_right_alt</mat-icon>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionBaseline/interventionBaseline.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionBaseline/interventionBaseline.component.html
@@ -26,7 +26,8 @@
               <div class="double-cell">
                 <div>
                   <input id="year0" name="year0" (change)="storeIndex(index)" type="number"
-                    [ngModel]="element.year0 * 100" formControlName="year0" min="0" max="100">
+                    [ngModel]="element.year0 * 100" formControlName="year0" min="0" max="100"
+                    (keyup)="validateUserInput($event, index, 'year0')">
                 </div>
                 <button *ngIf="dirtyIndexes.includes(index) === false" mat-button color="primary">
                   GFDx<mat-icon>arrow_right_alt</mat-icon>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionBaseline/interventionBaseline.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionBaseline/interventionBaseline.component.ts
@@ -19,6 +19,7 @@ import { AppRoutes } from 'src/app/routes/routes';
 import { InterventionDataService, InterventionForm } from 'src/app/services/interventionData.service';
 import { InterventionSideNavContentService } from '../../components/interventionSideNavContent/interventionSideNavContent.service';
 import { FormGroup, NonNullableFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
+import { NotificationsService } from 'src/app/components/notifications/notification.service';
 
 @Component({
   selector: 'app-intervention-baseline',
@@ -62,6 +63,7 @@ export class InterventionBaselineComponent implements AfterViewInit {
     private intSideNavService: InterventionSideNavContentService,
     private readonly cdr: ChangeDetectorRef,
     private formBuilder: NonNullableFormBuilder,
+    private notificationsService: NotificationsService,
   ) {
     this.activeInterventionId = this.interventionDataService.getActiveInterventionId();
     this.intSideNavService.setCurrentStepperPosition(this.pageStepperPosition);
@@ -240,5 +242,16 @@ export class InterventionBaselineComponent implements AfterViewInit {
 
   public storeIndex(index: number) {
     this.dirtyIndexes.push(index);
+  }
+
+  public validateUserInput(event: Event, rowIndex: number, year: string) {
+    const userInput = Number((event.target as HTMLInputElement).value);
+    if (userInput < 0) {
+      this.form.controls.items['controls'][rowIndex].patchValue({ [year]: 0 });
+      this.notificationsService.sendInformative('Percentage input must be between 0 and 100.');
+    } else if (userInput > 100) {
+      this.form.controls.items['controls'][rowIndex].patchValue({ [year]: 100 });
+      this.notificationsService.sendInformative('Percentage input must be between 0 and 100.');
+    }
   }
 }

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCompliance/interventionCompliance.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCompliance/interventionCompliance.component.html
@@ -16,18 +16,6 @@
           </th>
           <td class="row-title-left" mat-cell *matCellDef="let element">{{element.title}}</td>
         </ng-container>
-        <!-- <ng-container matColumnDef="year0">
-          <th mat-header-cell *matHeaderCellDef> 2021 </th>
-          <td mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
-            <div *ngIf="element.rowUnits === 'number'">
-              <input type="text" appDecimalInput required [value]=element.year0 formControlName="year0">
-            </div>
-            <div *ngIf="element.rowUnits === 'percent'">
-              <input type="text" appDecimalInput [value]="element.year0 * 100"
-                (input)="element.year0 = $any($event.target).value / 100" formControlName="year0">
-            </div>
-          </td>
-        </ng-container> -->
         <ng-container matColumnDef="year0">
           <th mat-header-cell *matHeaderCellDef>2021</th>
           <td mat-cell *matCellDef="let element">{{element.year0 | percent}}</td>
@@ -39,8 +27,10 @@
               <input type="text" appDecimalInput required [value]=element.year1 formControlName="year1">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input type="text" appDecimalInput [value]="element.year1 * 100"
-                (input)="element.year1 = $any($event.target).value / 100" formControlName="year1">
+              <!-- <input type="text" appDecimalInput [value]="element.year1 * 100"
+                (input)="element.year1 = $any($event.target).value / 100" formControlName="year1"> -->
+              <input id="year1" name="year1" type="number" [ngModel]="element.year1 * 100" formControlName="year1"
+                min="0" max="100" (keyup)="validateUserInput($event, index, 'year1')">
             </div>
           </td>
         </ng-container>
@@ -51,8 +41,8 @@
               <input type="text" appDecimalInput required [value]=element.year2 formControlName="year2">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input type="text" appDecimalInput [value]="element.year2 * 100"
-                (input)="element.year2 = $any($event.target).value / 100" formControlName="year2">
+              <input id="year2" name="year2" type="number" [ngModel]="element.year2 * 100" formControlName="year2"
+                min="0" max="100" (keyup)="validateUserInput($event, index, 'year2')">
             </div>
           </td>
         </ng-container>
@@ -63,8 +53,8 @@
               <input type="text" appDecimalInput required [value]=element.year3 formControlName="year3">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input type="text" appDecimalInput [value]="element.year3 * 100"
-                (input)="element.year3 = $any($event.target).value / 100" formControlName="year3">
+              <input id="year3" name="year3" type="number" [ngModel]="element.year3 * 100" formControlName="year3"
+                min="0" max="100" (keyup)="validateUserInput($event, index, 'year3')">
             </div>
           </td>
         </ng-container>
@@ -75,8 +65,8 @@
               <input type="text" appDecimalInput required [value]=element.year4 formControlName="year4">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input type="text" appDecimalInput [value]="element.year4 * 100"
-                (input)="element.year4 = $any($event.target).value / 100" formControlName="year4">
+              <input id="year4" name="year4" type="number" [ngModel]="element.year4 * 100" formControlName="year4"
+                min="0" max="100" (keyup)="validateUserInput($event, index, 'year4')">
             </div>
           </td>
         </ng-container>
@@ -87,8 +77,8 @@
               <input type="text" appDecimalInput required [value]=element.year5 formControlName="year5">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input type="text" appDecimalInput [value]="element.year5 * 100"
-                (input)="element.year5 = $any($event.target).value / 100" formControlName="year5">
+              <input id="year5" name="year5" type="number" [ngModel]="element.year5 * 100" formControlName="year5"
+                min="0" max="100" (keyup)="validateUserInput($event, index, 'year5')">
             </div>
           </td>
         </ng-container>
@@ -99,8 +89,8 @@
               <input type="text" appDecimalInput required [value]=element.year6 formControlName="year6">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input type="text" appDecimalInput [value]="element.year6 * 100"
-                (input)="element.year6 = $any($event.target).value / 100" formControlName="year6">
+              <input id="year6" name="year6" type="number" [ngModel]="element.year6 * 100" formControlName="year6"
+                min="0" max="100" (keyup)="validateUserInput($event, index, 'year6')">
             </div>
           </td>
         </ng-container>
@@ -111,8 +101,8 @@
               <input type="text" appDecimalInput required [value]=element.year7 formControlName="year7">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input type="text" appDecimalInput [value]="element.year7 * 100"
-                (input)="element.year7 = $any($event.target).value / 100" formControlName="year7">
+              <input id="year7" name="year7" type="number" [ngModel]="element.year7 * 100" formControlName="year7"
+                min="0" max="100" (keyup)="validateUserInput($event, index, 'year7')">
             </div>
           </td>
         </ng-container>
@@ -123,8 +113,8 @@
               <input type="text" appDecimalInput required [value]=element.year8 formControlName="year8">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input type="text" appDecimalInput [value]="element.year8 * 100"
-                (input)="element.year8 = $any($event.target).value / 100" formControlName="year8">
+              <input id="year8" name="year8" type="number" [ngModel]="element.year8 * 100" formControlName="year8"
+                min="0" max="100" (keyup)="validateUserInput($event, index, 'year8')">
             </div>
           </td>
         </ng-container>
@@ -135,8 +125,8 @@
               <input type="text" appDecimalInput required [value]=element.year9 formControlName="year9">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input type="text" appDecimalInput [value]="element.year9 * 100"
-                (input)="element.year9 = $any($event.target).value / 100" formControlName="year9">
+              <input id="year9" name="year9" type="number" [ngModel]="element.year9 * 100" formControlName="year9"
+                min="0" max="100" (keyup)="validateUserInput($event, index, 'year9')">
             </div>
           </td>
         </ng-container>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCompliance/interventionCompliance.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionCompliance/interventionCompliance.component.ts
@@ -14,6 +14,7 @@ import { QuickMapsService } from 'src/app/pages/quickMaps/quickMaps.service';
 import { AppRoutes } from 'src/app/routes/routes';
 import { InterventionDataService, InterventionForm } from 'src/app/services/interventionData.service';
 import { InterventionSideNavContentService } from '../../components/interventionSideNavContent/interventionSideNavContent.service';
+import { NotificationsService } from 'src/app/components/notifications/notification.service';
 @Component({
   selector: 'app-intervention-compliance',
   templateUrl: './interventionCompliance.component.html',
@@ -65,6 +66,7 @@ export class InterventionComplianceComponent implements OnInit {
     private intSideNavService: InterventionSideNavContentService,
     private interventionDataService: InterventionDataService,
     private formBuilder: NonNullableFormBuilder,
+    private notificationsService: NotificationsService,
   ) {
     const activeInterventionId = this.interventionDataService.getActiveInterventionId();
     this.subscriptions.push(
@@ -113,22 +115,38 @@ export class InterventionComplianceComponent implements OnInit {
                     map(([oldState, newState]) => {
                       for (const key in newState.items) {
                         const rowIndex = this.form.get('items')['controls'][key]['controls'].rowIndex.value;
-
+                        const rowUnits = this.form.get('items')['controls'][key]['controls'].rowUnits.value;
                         if (oldState.items[key] !== newState.items[key] && oldState.items[key] !== undefined) {
                           const diff = compareObjs(oldState.items[key], newState.items[key]);
                           if (Array.isArray(diff) && diff.length > 0) {
+                            console.debug('bing');
                             diff.forEach((item) => {
-                              if (changes[rowIndex]) {
-                                changes[rowIndex] = {
-                                  ...changes[rowIndex],
-                                  [item[0]]: Number(item[1]),
-                                };
-                                changes[rowIndex]['rowIndex'] = rowIndex;
+                              if (rowUnits === 'percent') {
+                                if (changes[rowIndex]) {
+                                  changes[rowIndex] = {
+                                    ...changes[rowIndex],
+                                    [item[0]]: Number(item[1]) / 100,
+                                  };
+                                  changes[rowIndex]['rowIndex'] = rowIndex;
+                                } else {
+                                  changes[rowIndex] = {
+                                    [item[0]]: Number(item[1]) / 100,
+                                  };
+                                  changes[rowIndex]['rowIndex'] = rowIndex;
+                                }
                               } else {
-                                changes[rowIndex] = {
-                                  [item[0]]: Number(item[1]),
-                                };
-                                changes[rowIndex]['rowIndex'] = rowIndex;
+                                if (changes[rowIndex]) {
+                                  changes[rowIndex] = {
+                                    ...changes[rowIndex],
+                                    [item[0]]: Number(item[1]),
+                                  };
+                                  changes[rowIndex]['rowIndex'] = rowIndex;
+                                } else {
+                                  changes[rowIndex] = {
+                                    [item[0]]: Number(item[1]),
+                                  };
+                                  changes[rowIndex]['rowIndex'] = rowIndex;
+                                }
                               }
                             });
                           }
@@ -202,6 +220,7 @@ export class InterventionComplianceComponent implements OnInit {
   private createAssumptionGroup(item: PotentiallyFortified | ActuallyFortified): UntypedFormGroup {
     return this.formBuilder.group({
       rowIndex: [item.rowIndex, []],
+      rowUnits: [item.rowUnits, []],
       isEditable: [item.isEditable, []],
       year0: [Number(item.year0), []],
       year0Edited: [Boolean(item.year0Edited), []],
@@ -254,6 +273,17 @@ export class InterventionComplianceComponent implements OnInit {
     });
     //on reset mark forma as pristine to remove blue highlights
     this.form.markAsPristine();
+  }
+
+  public validateUserInput(event: Event, rowIndex: number, year: string) {
+    const userInput = Number((event.target as HTMLInputElement).value);
+    if (userInput < 0) {
+      this.form.controls.items['controls'][rowIndex].patchValue({ [year]: 0 });
+      this.notificationsService.sendInformative('Percentage input must be between 0 and 100.');
+    } else if (userInput > 100) {
+      this.form.controls.items['controls'][rowIndex].patchValue({ [year]: 100 });
+      this.notificationsService.sendInformative('Percentage input must be between 0 and 100.');
+    }
   }
 }
 

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.html
@@ -24,8 +24,8 @@
                 formControlName="year0" (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input (change)="storeIndex(index)" type="text" appDecimalInput [value]="element.year0 * 100"
-                (input)="element.year0 = $any($event.target).value / 100" formControlName="year0"
+              <input id="year0" name="year0" (change)="storeIndex(index)" type="number" [ngModel]="element.year0 * 100"
+                formControlName="year0" min="0" max="100" (keyup)="validateUserInput($event, index, 'year0')"
                 (change)="recalculateChanges()">
             </div>
           </td>
@@ -38,8 +38,8 @@
                 formControlName="year1" (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input (change)="storeIndex(index)" type="text" appDecimalInput [value]="element.year1 * 100"
-                (input)="element.year1 = $any($event.target).value / 100" formControlName="year1"
+              <input id="year1" name="year1" (change)="storeIndex(index)" type="number" [ngModel]="element.year1 * 100"
+                formControlName="year1" min="0" max="100" (keyup)="validateUserInput($event, index, 'year1')"
                 (change)="recalculateChanges()">
             </div>
           </td>
@@ -52,8 +52,8 @@
                 formControlName="year2" (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input (change)="storeIndex(index)" type="text" appDecimalInput [value]="element.year2 * 100"
-                (input)="element.year2 = $any($event.target).value / 100" formControlName="year2"
+              <input id="year2" name="year2" (change)="storeIndex(index)" type="number" [ngModel]="element.year2 * 100"
+                formControlName="year2" min="0" max="100" (keyup)="validateUserInput($event, index, 'year2')"
                 (change)="recalculateChanges()">
             </div>
           </td>
@@ -66,8 +66,8 @@
                 formControlName="year3" (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input (change)="storeIndex(index)" type="text" appDecimalInput [value]="element.year3 * 100"
-                (input)="element.year3 = $any($event.target).value / 100" formControlName="year3"
+              <input id="year3" name="year3" (change)="storeIndex(index)" type="number" [ngModel]="element.year3 * 100"
+                formControlName="year3" min="0" max="100" (keyup)="validateUserInput($event, index, 'year3')"
                 (change)="recalculateChanges()">
             </div>
           </td>
@@ -80,8 +80,8 @@
                 formControlName="year4" (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input (change)="storeIndex(index)" type="text" appDecimalInput [value]="element.year4 * 100"
-                (input)="element.year4 = $any($event.target).value / 100" formControlName="year4"
+              <input id="year4" name="year4" (change)="storeIndex(index)" type="number" [ngModel]="element.year4 * 100"
+                formControlName="year4" min="0" max="100" (keyup)="validateUserInput($event, index, 'year4')"
                 (change)="recalculateChanges()">
             </div>
           </td>
@@ -95,8 +95,8 @@
                 formControlName="year5" (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input (change)="storeIndex(index)" type="text" appDecimalInput [value]="element.year5 * 100"
-                (input)="element.year5 = $any($event.target).value / 100" formControlName="year5"
+              <input id="year5" name="year5" (change)="storeIndex(index)" type="number" [ngModel]="element.year5 * 100"
+                formControlName="year5" min="0" max="100" (keyup)="validateUserInput($event, index, 'year5')"
                 (change)="recalculateChanges()">
             </div>
           </td>
@@ -109,8 +109,8 @@
                 formControlName="year6" (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input (change)="storeIndex(index)" type="text" appDecimalInput [value]="element.year6 * 100"
-                (input)="element.year6 = $any($event.target).value / 100" formControlName="year6"
+              <input id="year6" name="year6" (change)="storeIndex(index)" type="number" [ngModel]="element.year6 * 100"
+                formControlName="year6" min="0" max="100" (keyup)="validateUserInput($event, index, 'year6')"
                 (change)="recalculateChanges()">
             </div>
           </td>
@@ -123,8 +123,8 @@
                 formControlName="year7" (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input (change)="storeIndex(index)" type="text" appDecimalInput [value]="element.year7 * 100"
-                (input)="element.year7 = $any($event.target).value / 100" formControlName="year7"
+              <input id="year7" name="year7" (change)="storeIndex(index)" type="number" [ngModel]="element.year7 * 100"
+                formControlName="year7" min="0" max="100" (keyup)="validateUserInput($event, index, 'year7')"
                 (change)="recalculateChanges()">
             </div>
           </td>
@@ -137,8 +137,8 @@
                 formControlName="year8" (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input (change)="storeIndex(index)" type="text" appDecimalInput [value]="element.year8 * 100"
-                (input)="element.year8 = $any($event.target).value / 100" formControlName="year8"
+              <input id="year8" name="year8" (change)="storeIndex(index)" type="number" [ngModel]="element.year8 * 100"
+                formControlName="year8" min="0" max="100" (keyup)="validateUserInput($event, index, 'year8')"
                 (change)="recalculateChanges()">
             </div>
           </td>
@@ -151,8 +151,8 @@
                 formControlName="year9" (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input (change)="storeIndex(index)" type="text" appDecimalInput [value]="element.year9 * 100"
-                (input)="element.year9 = $any($event.target).value / 100" formControlName="year9"
+              <input id="year9" name="year9" (change)="storeIndex(index)" type="number" [ngModel]="element.year9 * 100"
+                formControlName="year9" min="0" max="100" (keyup)="validateUserInput($event, index, 'year9')"
                 (change)="recalculateChanges()">
             </div>
           </td>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.ts
@@ -10,6 +10,7 @@ import { InterventionSideNavContentService } from '../../components/intervention
 import { UntypedFormArray, UntypedFormGroup, NonNullableFormBuilder, FormGroup } from '@angular/forms';
 import { pairwise, map, filter, startWith } from 'rxjs/operators';
 import { JSONLogicService } from 'src/app/services/jsonlogic.service';
+import { NotificationsService } from 'src/app/components/notifications/notification.service';
 
 @Component({
   selector: 'app-intervention-industry-information',
@@ -46,6 +47,7 @@ export class InterventionIndustryInformationComponent implements OnInit {
     private interventionDataService: InterventionDataService,
     private formBuilder: NonNullableFormBuilder,
     private jsonLogicService: JSONLogicService,
+    private notificationsService: NotificationsService,
   ) {}
 
   /**
@@ -104,21 +106,37 @@ export class InterventionIndustryInformationComponent implements OnInit {
               map(([oldState, newState]) => {
                 for (const key in newState.items) {
                   const rowIndex = this.form.get('items')['controls'][key]['controls'].rowIndex.value;
+                  const rowUnits = this.form.get('items')['controls'][key]['controls'].rowUnits.value;
                   if (oldState.items[key] !== newState.items[key] && oldState.items[key] !== undefined) {
                     const diff = compareObjs(oldState.items[key], newState.items[key]);
                     if (Array.isArray(diff) && diff.length > 0) {
                       diff.forEach((item) => {
-                        if (changes[rowIndex]) {
-                          changes[rowIndex] = {
-                            ...changes[rowIndex],
-                            [item[0]]: Number(item[1]),
-                          };
-                          changes[rowIndex]['rowIndex'] = rowIndex;
+                        if (rowUnits === 'percent') {
+                          if (changes[rowIndex]) {
+                            changes[rowIndex] = {
+                              ...changes[rowIndex],
+                              [item[0]]: Number(item[1]) / 100,
+                            };
+                            changes[rowIndex]['rowIndex'] = rowIndex;
+                          } else {
+                            changes[rowIndex] = {
+                              [item[0]]: Number(item[1]) / 100,
+                            };
+                            changes[rowIndex]['rowIndex'] = rowIndex;
+                          }
                         } else {
-                          changes[rowIndex] = {
-                            [item[0]]: Number(item[1]),
-                          };
-                          changes[rowIndex]['rowIndex'] = rowIndex;
+                          if (changes[rowIndex]) {
+                            changes[rowIndex] = {
+                              ...changes[rowIndex],
+                              [item[0]]: Number(item[1]),
+                            };
+                            changes[rowIndex]['rowIndex'] = rowIndex;
+                          } else {
+                            changes[rowIndex] = {
+                              [item[0]]: Number(item[1]),
+                            };
+                            changes[rowIndex]['rowIndex'] = rowIndex;
+                          }
                         }
                       });
                     }
@@ -147,6 +165,7 @@ export class InterventionIndustryInformationComponent implements OnInit {
   private createIndustryGroup(item: IndustryInformation): UntypedFormGroup {
     return this.formBuilder.group({
       rowIndex: [item.rowIndex, []],
+      rowUnits: [item.rowUnits, []],
       isEditable: [item.isEditable, []],
       year0: [Number(item.year0), []],
       year0Edited: [Boolean(item.year0Edited), []],
@@ -267,5 +286,16 @@ export class InterventionIndustryInformationComponent implements OnInit {
         });
       }
     });
+  }
+
+  public validateUserInput(event: Event, rowIndex: number, year: string) {
+    const userInput = Number((event.target as HTMLInputElement).value);
+    if (userInput < 0) {
+      this.form.controls.items['controls'][rowIndex].patchValue({ [year]: 0 });
+      this.notificationsService.sendInformative('Percentage input must be between 0 and 100.');
+    } else if (userInput > 100) {
+      this.form.controls.items['controls'][rowIndex].patchValue({ [year]: 100 });
+      this.notificationsService.sendInformative('Percentage input must be between 0 and 100.');
+    }
   }
 }

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionMonitoringInformation/interventionMonitoringInformation.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionMonitoringInformation/interventionMonitoringInformation.component.html
@@ -23,8 +23,8 @@
                 formControlName="year0" (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input (change)="storeIndex(index)" type="text" appDecimalInput [value]="element.year0 * 100"
-                (input)="element.year0 = $any($event.target).value / 100" formControlName="year0"
+              <input id="year0" name="year0" (change)="storeIndex(index)" type="number" [ngModel]="element.year0 * 100"
+                formControlName="year0" min="0" max="100" (keyup)="validateUserInput($event, index, 'year0')"
                 (change)="recalculateChanges()">
             </div>
           </td>
@@ -37,8 +37,8 @@
                 formControlName="year1" (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input (change)="storeIndex(index)" type="text" appDecimalInput [value]="element.year1 * 100"
-                (input)="element.year1 = $any($event.target).value / 100" formControlName="year1"
+              <input id="year1" name="year1" (change)="storeIndex(index)" type="number" [ngModel]="element.year1 * 100"
+                formControlName="year1" min="0" max="100" (keyup)="validateUserInput($event, index, 'year1')"
                 (change)="recalculateChanges()">
             </div>
           </td>
@@ -51,8 +51,8 @@
                 formControlName="year2" (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input (change)="storeIndex(index)" type="text" appDecimalInput [value]="element.year2 * 100"
-                (input)="element.year2 = $any($event.target).value / 100" formControlName="year2"
+              <input id="year2" name="year2" (change)="storeIndex(index)" type="number" [ngModel]="element.year2 * 100"
+                formControlName="year2" min="0" max="100" (keyup)="validateUserInput($event, index, 'year2')"
                 (change)="recalculateChanges()">
             </div>
           </td>
@@ -65,8 +65,8 @@
                 formControlName="year3" (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input (change)="storeIndex(index)" type="text" appDecimalInput [value]="element.year3 * 100"
-                (input)="element.year3 = $any($event.target).value / 100" formControlName="year3"
+              <input id="year3" name="year3" (change)="storeIndex(index)" type="number" [ngModel]="element.year3 * 100"
+                formControlName="year3" min="0" max="100" (keyup)="validateUserInput($event, index, 'year3')"
                 (change)="recalculateChanges()">
             </div>
           </td>
@@ -79,8 +79,8 @@
                 formControlName="year4" (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input (change)="storeIndex(index)" type="text" appDecimalInput [value]="element.year4 * 100"
-                (input)="element.year4 = $any($event.target).value / 100" formControlName="year4"
+              <input id="year4" name="year4" (change)="storeIndex(index)" type="number" [ngModel]="element.year4 * 100"
+                formControlName="year4" min="0" max="100" (keyup)="validateUserInput($event, index, 'year4')"
                 (change)="recalculateChanges()">
             </div>
           </td>
@@ -93,8 +93,8 @@
                 formControlName="year5" (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input (change)="storeIndex(index)" type="text" appDecimalInput [value]="element.year5 * 100"
-                (input)="element.year5 = $any($event.target).value / 100" formControlName="year5"
+              <input id="year5" name="year5" (change)="storeIndex(index)" type="number" [ngModel]="element.year5 * 100"
+                formControlName="year5" min="0" max="100" (keyup)="validateUserInput($event, index, 'year5')"
                 (change)="recalculateChanges()">
             </div>
           </td>
@@ -107,8 +107,8 @@
                 formControlName="year6" (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input (change)="storeIndex(index)" type="text" appDecimalInput [value]="element.year6 * 100"
-                (input)="element.year6 = $any($event.target).value / 100" formControlName="year6"
+              <input id="year6" name="year6" (change)="storeIndex(index)" type="number" [ngModel]="element.year6 * 100"
+                formControlName="year6" min="0" max="100" (keyup)="validateUserInput($event, index, 'year6')"
                 (change)="recalculateChanges()">
             </div>
           </td>
@@ -121,8 +121,8 @@
                 formControlName="year7" (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input (change)="storeIndex(index)" type="text" appDecimalInput [value]="element.year7 * 100"
-                (input)="element.year7 = $any($event.target).value / 100" formControlName="year7"
+              <input id="year7" name="year7" (change)="storeIndex(index)" type="number" [ngModel]="element.year7 * 100"
+                formControlName="year7" min="0" max="100" (keyup)="validateUserInput($event, index, 'year7')"
                 (change)="recalculateChanges()">
             </div>
           </td>
@@ -135,8 +135,8 @@
                 formControlName="year8" (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input (change)="storeIndex(index)" type="text" appDecimalInput [value]="element.year8 * 100"
-                (input)="element.year8 = $any($event.target).value / 100" formControlName="year8"
+              <input id="year8" name="year8" (change)="storeIndex(index)" type="number" [ngModel]="element.year8 * 100"
+                formControlName="year8" min="0" max="100" (keyup)="validateUserInput($event, index, 'year8')"
                 (change)="recalculateChanges()">
             </div>
           </td>
@@ -149,8 +149,8 @@
                 formControlName="year9" (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
-              <input (change)="storeIndex(index)" type="text" appDecimalInput [value]="element.year9 * 100"
-                (input)="element.year9 = $any($event.target).value / 100" formControlName="year9"
+              <input id="year9" name="year9" (change)="storeIndex(index)" type="number" [ngModel]="element.year9 * 100"
+                formControlName="year9" min="0" max="100" (keyup)="validateUserInput($event, index, 'year9')"
                 (change)="recalculateChanges()">
             </div>
           </td>

--- a/src/assets/exampleData/industry-information.json
+++ b/src/assets/exampleData/industry-information.json
@@ -1,0 +1,618 @@
+[
+  {
+    "year0": 44,
+    "year1": 33,
+    "year2": 3,
+    "year3": 3,
+    "year4": 3,
+    "year5": 3,
+    "year6": 3,
+    "year7": 3,
+    "year8": 3,
+    "year9": 3,
+    "rowName": "number_domestic_factories",
+    "rowIndex": 33,
+    "rowUnits": "number",
+    "labelText": "Number of domstic industrial sugar refineries (capacity to refine > 5 MT/day)",
+    "dataSource": null,
+    "isEditable": true,
+    "missingData": null,
+    "missingRows": null,
+    "year0Edited": false,
+    "year1Edited": false,
+    "year2Edited": false,
+    "year3Edited": false,
+    "year4Edited": false,
+    "year5Edited": false,
+    "year6Edited": false,
+    "year7Edited": false,
+    "year8Edited": false,
+    "year9Edited": false,
+    "dataCitation": null,
+    "reportedRows": null,
+    "year0Default": null,
+    "year0Formula": {},
+    "year1Default": null,
+    "year1Formula": {},
+    "year2Default": null,
+    "year2Formula": {},
+    "year3Default": null,
+    "year3Formula": {},
+    "year4Default": null,
+    "year4Formula": {},
+    "year5Default": null,
+    "year5Formula": {},
+    "year6Default": null,
+    "year6Formula": {},
+    "year7Default": null,
+    "year7Formula": {},
+    "year8Default": null,
+    "year8Formula": {},
+    "year9Default": null,
+    "year9Formula": {},
+    "dependentRows": null,
+    "dataSourceDefault": null
+  },
+  {
+    "year0": 3,
+    "year1": 3,
+    "year2": 3,
+    "year3": 3,
+    "year4": 3,
+    "year5": 3,
+    "year6": 3,
+    "year7": 3,
+    "year8": 3,
+    "year9": 3,
+    "rowName": "number_domestic_factories_fortifying",
+    "rowIndex": 34,
+    "rowUnits": "number",
+    "labelText": "Number of domestic industrial sugar refineries fortifying sugar",
+    "dataSource": null,
+    "isEditable": false,
+    "missingData": {
+      "29": {
+        "year0": 0.82,
+        "year1": 0.82,
+        "year2": 0.82,
+        "year3": 0.82,
+        "year4": 0.82,
+        "year5": 0.82,
+        "year6": 0.82,
+        "year7": 0.82,
+        "year8": 0.82,
+        "year9": 0.82,
+        "rowIndex": 29
+      }
+    },
+    "missingRows": [29],
+    "year0Edited": false,
+    "year1Edited": false,
+    "year2Edited": false,
+    "year3Edited": false,
+    "year4Edited": false,
+    "year5Edited": false,
+    "year6Edited": false,
+    "year7Edited": false,
+    "year8Edited": false,
+    "year9Edited": false,
+    "dataCitation": null,
+    "reportedRows": [39, 33, 38, 37, 36, 35, 34, 40],
+    "year0Default": null,
+    "year0Formula": [
+      {
+        "roundup": [
+          {
+            "*": [
+              0.82,
+              {
+                "var": {
+                  "colIndex": "year0",
+                  "rowIndex": "33"
+                }
+              }
+            ]
+          },
+          0
+        ]
+      }
+    ],
+    "year1Default": null,
+    "year1Formula": [
+      {
+        "roundup": [
+          {
+            "*": [
+              0.82,
+              {
+                "var": {
+                  "colIndex": "year1",
+                  "rowIndex": "33"
+                }
+              }
+            ]
+          },
+          0
+        ]
+      }
+    ],
+    "year2Default": null,
+    "year2Formula": [
+      {
+        "roundup": [
+          {
+            "*": [
+              0.82,
+              {
+                "var": {
+                  "colIndex": "year2",
+                  "rowIndex": "33"
+                }
+              }
+            ]
+          },
+          0
+        ]
+      }
+    ],
+    "year3Default": null,
+    "year3Formula": [
+      {
+        "roundup": [
+          {
+            "*": [
+              0.82,
+              {
+                "var": {
+                  "colIndex": "year3",
+                  "rowIndex": "33"
+                }
+              }
+            ]
+          },
+          0
+        ]
+      }
+    ],
+    "year4Default": null,
+    "year4Formula": [
+      {
+        "roundup": [
+          {
+            "*": [
+              0.82,
+              {
+                "var": {
+                  "colIndex": "year4",
+                  "rowIndex": "33"
+                }
+              }
+            ]
+          },
+          0
+        ]
+      }
+    ],
+    "year5Default": null,
+    "year5Formula": [
+      {
+        "roundup": [
+          {
+            "*": [
+              0.82,
+              {
+                "var": {
+                  "colIndex": "year5",
+                  "rowIndex": "33"
+                }
+              }
+            ]
+          },
+          0
+        ]
+      }
+    ],
+    "year6Default": null,
+    "year6Formula": [
+      {
+        "roundup": [
+          {
+            "*": [
+              0.82,
+              {
+                "var": {
+                  "colIndex": "year6",
+                  "rowIndex": "33"
+                }
+              }
+            ]
+          },
+          0
+        ]
+      }
+    ],
+    "year7Default": null,
+    "year7Formula": [
+      {
+        "roundup": [
+          {
+            "*": [
+              0.82,
+              {
+                "var": {
+                  "colIndex": "year7",
+                  "rowIndex": "33"
+                }
+              }
+            ]
+          },
+          0
+        ]
+      }
+    ],
+    "year8Default": null,
+    "year8Formula": [
+      {
+        "roundup": [
+          {
+            "*": [
+              0.82,
+              {
+                "var": {
+                  "colIndex": "year8",
+                  "rowIndex": "33"
+                }
+              }
+            ]
+          },
+          0
+        ]
+      }
+    ],
+    "year9Default": null,
+    "year9Formula": [
+      {
+        "roundup": [
+          {
+            "*": [
+              0.82,
+              {
+                "var": {
+                  "colIndex": "year9",
+                  "rowIndex": "33"
+                }
+              }
+            ]
+          },
+          0
+        ]
+      }
+    ],
+    "dependentRows": [33, 29],
+    "dataSourceDefault": null
+  },
+  {
+    "year0": 270,
+    "year1": 270,
+    "year2": 270,
+    "year3": 270,
+    "year4": 270,
+    "year5": 270,
+    "year6": 270,
+    "year7": 270,
+    "year8": 270,
+    "year9": 270,
+    "rowName": "annual_factory_operating_days",
+    "rowIndex": 35,
+    "rowUnits": "number",
+    "labelText": "Average number of refining days per year",
+    "dataSource": null,
+    "isEditable": true,
+    "missingData": null,
+    "missingRows": null,
+    "year0Edited": false,
+    "year1Edited": false,
+    "year2Edited": false,
+    "year3Edited": false,
+    "year4Edited": false,
+    "year5Edited": false,
+    "year6Edited": false,
+    "year7Edited": false,
+    "year8Edited": false,
+    "year9Edited": false,
+    "dataCitation": null,
+    "reportedRows": null,
+    "year0Default": null,
+    "year0Formula": {},
+    "year1Default": null,
+    "year1Formula": {},
+    "year2Default": null,
+    "year2Formula": {},
+    "year3Default": null,
+    "year3Formula": {},
+    "year4Default": null,
+    "year4Formula": {},
+    "year5Default": null,
+    "year5Formula": {},
+    "year6Default": null,
+    "year6Formula": {},
+    "year7Default": null,
+    "year7Formula": {},
+    "year8Default": null,
+    "year8Formula": {},
+    "year9Default": null,
+    "year9Formula": {},
+    "dependentRows": null,
+    "dataSourceDefault": null
+  },
+  {
+    "year0": 24,
+    "year1": 24,
+    "year2": 24,
+    "year3": 24,
+    "year4": 24,
+    "year5": 24,
+    "year6": 24,
+    "year7": 24,
+    "year8": 24,
+    "year9": 24,
+    "rowName": "number_daily_internal_nutrient1_tests",
+    "rowIndex": 36,
+    "rowUnits": "number",
+    "labelText": "Average number of in-house quantitative or qualitative vitamin A tests per refinery per day",
+    "dataSource": null,
+    "isEditable": true,
+    "missingData": null,
+    "missingRows": null,
+    "year0Edited": false,
+    "year1Edited": false,
+    "year2Edited": false,
+    "year3Edited": false,
+    "year4Edited": false,
+    "year5Edited": false,
+    "year6Edited": false,
+    "year7Edited": false,
+    "year8Edited": false,
+    "year9Edited": false,
+    "dataCitation": null,
+    "reportedRows": null,
+    "year0Default": null,
+    "year0Formula": {},
+    "year1Default": null,
+    "year1Formula": {},
+    "year2Default": null,
+    "year2Formula": {},
+    "year3Default": null,
+    "year3Formula": {},
+    "year4Default": null,
+    "year4Formula": {},
+    "year5Default": null,
+    "year5Formula": {},
+    "year6Default": null,
+    "year6Formula": {},
+    "year7Default": null,
+    "year7Formula": {},
+    "year8Default": null,
+    "year8Formula": {},
+    "year9Default": null,
+    "year9Formula": {},
+    "dependentRows": null,
+    "dataSourceDefault": null
+  },
+  {
+    "year0": 0,
+    "year1": 0,
+    "year2": 0,
+    "year3": 0,
+    "year4": 0,
+    "year5": 0,
+    "year6": 0,
+    "year7": 0,
+    "year8": 0,
+    "year9": 0,
+    "rowName": "number_daily_internal_nutrient2_tests",
+    "rowIndex": 37,
+    "rowUnits": "number",
+    "labelText": "Average number of in-house quantitative or qualitative tests for other micronutrient per refinery per day",
+    "dataSource": null,
+    "isEditable": true,
+    "missingData": null,
+    "missingRows": null,
+    "year0Edited": false,
+    "year1Edited": false,
+    "year2Edited": false,
+    "year3Edited": false,
+    "year4Edited": false,
+    "year5Edited": false,
+    "year6Edited": false,
+    "year7Edited": false,
+    "year8Edited": false,
+    "year9Edited": false,
+    "dataCitation": null,
+    "reportedRows": null,
+    "year0Default": null,
+    "year0Formula": {},
+    "year1Default": null,
+    "year1Formula": {},
+    "year2Default": null,
+    "year2Formula": {},
+    "year3Default": null,
+    "year3Formula": {},
+    "year4Default": null,
+    "year4Formula": {},
+    "year5Default": null,
+    "year5Formula": {},
+    "year6Default": null,
+    "year6Formula": {},
+    "year7Default": null,
+    "year7Formula": {},
+    "year8Default": null,
+    "year8Formula": {},
+    "year9Default": null,
+    "year9Formula": {},
+    "dependentRows": null,
+    "dataSourceDefault": null
+  },
+  {
+    "year0": 24,
+    "year1": 24,
+    "year2": 24,
+    "year3": 24,
+    "year4": 24,
+    "year5": 24,
+    "year6": 24,
+    "year7": 24,
+    "year8": 24,
+    "year9": 24,
+    "rowName": "annual_external_tests",
+    "rowIndex": 38,
+    "rowUnits": "number",
+    "labelText": "Average number of external lab tests per refinery per year",
+    "dataSource": null,
+    "isEditable": true,
+    "missingData": null,
+    "missingRows": null,
+    "year0Edited": false,
+    "year1Edited": false,
+    "year2Edited": false,
+    "year3Edited": false,
+    "year4Edited": false,
+    "year5Edited": false,
+    "year6Edited": false,
+    "year7Edited": false,
+    "year8Edited": false,
+    "year9Edited": false,
+    "dataCitation": null,
+    "reportedRows": null,
+    "year0Default": null,
+    "year0Formula": {},
+    "year1Default": null,
+    "year1Formula": {},
+    "year2Default": null,
+    "year2Formula": {},
+    "year3Default": null,
+    "year3Formula": {},
+    "year4Default": null,
+    "year4Formula": {},
+    "year5Default": null,
+    "year5Formula": {},
+    "year6Default": null,
+    "year6Formula": {},
+    "year7Default": null,
+    "year7Formula": {},
+    "year8Default": null,
+    "year8Formula": {},
+    "year9Default": null,
+    "year9Formula": {},
+    "dependentRows": null,
+    "dataSourceDefault": null
+  },
+  {
+    "year0": 1,
+    "year1": 1,
+    "year2": 1,
+    "year3": 1,
+    "year4": 1,
+    "year5": 1,
+    "year6": 1,
+    "year7": 1,
+    "year8": 1,
+    "year9": 1,
+    "rowName": "domestically_processed_vehicle_pct",
+    "rowIndex": 39,
+    "rowUnits": "percent",
+    "labelText": "Fortifiable sugar that is domestically processed (%)",
+    "dataSource": null,
+    "isEditable": true,
+    "missingData": null,
+    "missingRows": null,
+    "year0Edited": false,
+    "year1Edited": false,
+    "year2Edited": false,
+    "year3Edited": false,
+    "year4Edited": false,
+    "year5Edited": false,
+    "year6Edited": false,
+    "year7Edited": false,
+    "year8Edited": false,
+    "year9Edited": false,
+    "dataCitation": null,
+    "reportedRows": null,
+    "year0Default": null,
+    "year0Formula": {},
+    "year1Default": null,
+    "year1Formula": {},
+    "year2Default": null,
+    "year2Formula": {},
+    "year3Default": null,
+    "year3Formula": {},
+    "year4Default": null,
+    "year4Formula": {},
+    "year5Default": null,
+    "year5Formula": {},
+    "year6Default": null,
+    "year6Formula": {},
+    "year7Default": null,
+    "year7Formula": {},
+    "year8Default": null,
+    "year8Formula": {},
+    "year9Default": null,
+    "year9Formula": {},
+    "dependentRows": null,
+    "dataSourceDefault": null
+  },
+  {
+    "year0": 0,
+    "year1": 0,
+    "year2": 0,
+    "year3": 0,
+    "year4": 0,
+    "year5": 0,
+    "year6": 0,
+    "year7": 0,
+    "year8": 0,
+    "year9": 0,
+    "rowName": "imported_vehicle_pct",
+    "rowIndex": 40,
+    "rowUnits": "percent",
+    "labelText": "Fortifiable sugar that is imported (%)",
+    "dataSource": null,
+    "isEditable": true,
+    "missingData": null,
+    "missingRows": null,
+    "year0Edited": false,
+    "year1Edited": false,
+    "year2Edited": false,
+    "year3Edited": false,
+    "year4Edited": false,
+    "year5Edited": false,
+    "year6Edited": false,
+    "year7Edited": false,
+    "year8Edited": false,
+    "year9Edited": false,
+    "dataCitation": null,
+    "reportedRows": null,
+    "year0Default": null,
+    "year0Formula": {},
+    "year1Default": null,
+    "year1Formula": {},
+    "year2Default": null,
+    "year2Formula": {},
+    "year3Default": null,
+    "year3Formula": {},
+    "year4Default": null,
+    "year4Formula": {},
+    "year5Default": null,
+    "year5Formula": {},
+    "year6Default": null,
+    "year6Formula": {},
+    "year7Default": null,
+    "year7Formula": {},
+    "year8Default": null,
+    "year8Formula": {},
+    "year9Default": null,
+    "year9Formula": {},
+    "dependentRows": null,
+    "dataSourceDefault": null
+  }
+]


### PR DESCRIPTION
- intervention forms which have a user editable percentage display the value from the api (which is between 0 and 1) as a human readable percentage between 0 and 100. 
- Input set to `number` which allows the up/down increment UI on the input itself
- If the user manually types in a number which is below 0 (e.g. -50) or above 100 (e.g. 999) the input will correct itself to the nearest valid value i.e. 0 or 100. A notification will display advising the user of this. It was felt that instant correction was preferable to highlighting the input in red or displaying some less-clear messages due to the number of inputs which the user could potentially edit.

### to test

- [ ] calcium/ethiopia, ID 47
- [ ] each intervention page which has inputs for percentages should only allow values between 0 and 1
- [ ] increment on input should only allow 0 to 100 values
- [ ] notification should alert user when invalid value is input and value auto-corrects to nearest valid value (0 or 100)
- [ ] edited user values should be correctly identified for PATCH to API
- [ ] user edited values (between 0 to 100) should be converted to (0.0 to 1.0) when sending to the API