### PR TITLE
feat: implement next version of jsonlogic to intervention section with wider rollout

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,5 +14,24 @@
   "[json]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
-  "peacock.color": "#9b51e0"
+  "peacock.color": "#9b51e0",
+  "workbench.colorCustomizations": {
+    "activityBar.activeBackground": "#b47ce8",
+    "activityBar.background": "#b47ce8",
+    "activityBar.foreground": "#15202b",
+    "activityBar.inactiveForeground": "#15202b99",
+    "activityBarBadge.background": "#f1d0ae",
+    "activityBarBadge.foreground": "#15202b",
+    "commandCenter.border": "#e7e7e799",
+    "sash.hoverBorder": "#b47ce8",
+    "statusBar.background": "#9b51e0",
+    "statusBar.foreground": "#e7e7e7",
+    "statusBarItem.hoverBackground": "#b47ce8",
+    "statusBarItem.remoteBackground": "#9b51e0",
+    "statusBarItem.remoteForeground": "#e7e7e7",
+    "titleBar.activeBackground": "#9b51e0",
+    "titleBar.activeForeground": "#e7e7e7",
+    "titleBar.inactiveBackground": "#9b51e099",
+    "titleBar.inactiveForeground": "#e7e7e799"
+  }
 }

--- a/src/app/apiAndObjects/objects/interventionRecurringCosts.ts
+++ b/src/app/apiAndObjects/objects/interventionRecurringCosts.ts
@@ -41,7 +41,7 @@ export interface RecurringCosts {
   year9Total: number;
 }
 export interface RecurringCostBreakdown {
-  name: string;
+  labelText: string;
   rowIndex: number;
   year0: number;
   year0Default: number;

--- a/src/app/apiAndObjects/objects/interventionStartupCosts.ts
+++ b/src/app/apiAndObjects/objects/interventionStartupCosts.ts
@@ -38,7 +38,7 @@ export interface StartUpCosts {
 }
 
 export interface StartUpCostBreakdown {
-  name: string;
+  labelText: string;
   rowIndex: number;
   year0: number;
   year0Default: number;

--- a/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.html
+++ b/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.html
@@ -2,10 +2,10 @@
   <div class="bmgf-maps-nice-scrollbar">
     <form [formGroup]="form" *ngIf="form">
       <table mat-table [dataSource]="dataSource" matSort class="table-full-width" formArrayName="items">
-        <ng-container matColumnDef="name">
+        <ng-container matColumnDef="labelText">
           <th class="row-title-left" mat-header-cell *matHeaderCellDef>Years of start-up or scale-up
           </th>
-          <td class="row-title-left" mat-cell *matCellDef="let element"> {{element.name}} </td>
+          <td class="row-title-left" mat-cell *matCellDef="let element"> {{element.labelText}} </td>
           <td class="row-title-left" mat-footer-cell *matFooterCellDef>Total</td>
         </ng-container>
         <ng-container matColumnDef="year0">

--- a/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.html
+++ b/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.html
@@ -12,48 +12,54 @@
           <th mat-header-cell *matHeaderCellDef>2021</th>
           <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
-              <input type="text" appDecimalInput required [value]=element.year0 formControlName="year0">
+              <input type="text" appDecimalInput required [value]=element.year0 formControlName="year0"
+                (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'US dollars'">
-              <input type="text" appDecimalInput required [value]=element.year0 formControlName="year0">
+              <input type="text" appDecimalInput required [value]=element.year0 formControlName="year0"
+                (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
               <input type="text" [value]="element.year0 * 100" (input)="element.year0 = $any($event.target).value / 100"
-                appDecimalInput formControlName="year0">
+                appDecimalInput formControlName="year0" (change)="recalculateChanges()">
             </div>
           </td>
-          <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year0') | currencyExtended}} </td>
+          <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year0') | currencyExtended}} TBC</td>
         </ng-container>
         <!-- year1 -->
         <ng-container matColumnDef="year1">
           <th mat-header-cell *matHeaderCellDef>2022</th>
           <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
-              <input type="text" appDecimalInput required [value]=element.year1 formControlName="year1">
+              <input type="text" appDecimalInput required [value]=element.year1 formControlName="year1"
+                (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'US dollars'">
-              <input type="text" appDecimalInput required [value]=element.year1 formControlName="year1">
+              <input type="text" appDecimalInput required [value]=element.year1 formControlName="year1"
+                (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
               <input type="text" [value]="element.year1 * 100" (input)="element.year1 = $any($event.target).value / 100"
-                appDecimalInput formControlName="year1">
+                appDecimalInput formControlName="year1" (change)="recalculateChanges()">
             </div>
           </td>
-          <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year1') | currencyExtended}} </td>
+          <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year1') | currencyExtended}} TBC</td>
         </ng-container>
         <!-- year2 -->
         <ng-container matColumnDef="year2">
           <th mat-header-cell *matHeaderCellDef>2023</th>
           <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
-              <input type="text" appDecimalInput required [value]=element.year2 formControlName="year2">
+              <input type="text" appDecimalInput required [value]=element.year2 formControlName="year2"
+                (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'US dollars'">
-              <input type="text" appDecimalInput required [value]=element.year2 formControlName="year2">
+              <input type="text" appDecimalInput required [value]=element.year2 formControlName="year2"
+                (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
               <input type="text" [value]="element.year2 * 100" (input)="element.year2 = $any($event.target).value / 100"
-                appDecimalInput formControlName="year2">
+                appDecimalInput formControlName="year2" (change)="recalculateChanges()">
             </div>
           </td>
           <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year2') | currencyExtended}} </td>
@@ -63,14 +69,16 @@
           <th mat-header-cell *matHeaderCellDef>2024</th>
           <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
-              <input type="text" appDecimalInput required [value]=element.year3 formControlName="year3">
+              <input type="text" appDecimalInput required [value]=element.year3 formControlName="year3"
+                (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'US dollars'">
-              <input type="text" appDecimalInput required [value]=element.year3 formControlName="year3">
+              <input type="text" appDecimalInput required [value]=element.year3 formControlName="year3"
+                (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
               <input type="text" [value]="element.year3 * 100" (input)="element.year3 = $any($event.target).value / 100"
-                appDecimalInput formControlName="year3">
+                appDecimalInput formControlName="year3" (change)="recalculateChanges()">
             </div>
           </td>
           <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year3') | currencyExtended}} </td>
@@ -80,14 +88,16 @@
           <th mat-header-cell *matHeaderCellDef>2025</th>
           <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
-              <input type="text" appDecimalInput required [value]=element.year4 formControlName="year4">
+              <input type="text" appDecimalInput required [value]=element.year4 formControlName="year4"
+                (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'US dollars'">
-              <input type="text" appDecimalInput required [value]=element.year4 formControlName="year4">
+              <input type="text" appDecimalInput required [value]=element.year4 formControlName="year4"
+                (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
               <input type="text" [value]="element.year4 * 100" (input)="element.year4 = $any($event.target).value / 100"
-                appDecimalInput formControlName="year4">
+                appDecimalInput formControlName="year4" (change)="recalculateChanges()">
             </div>
           </td>
           <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year4') | currencyExtended}} </td>
@@ -97,14 +107,16 @@
           <th mat-header-cell *matHeaderCellDef>2026</th>
           <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
-              <input type="text" appDecimalInput required [value]=element.year5 formControlName="year5">
+              <input type="text" appDecimalInput required [value]=element.year5 formControlName="year5"
+                (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'US dollars'">
-              <input type="text" appDecimalInput required [value]=element.year5 formControlName="year5">
+              <input type="text" appDecimalInput required [value]=element.year5 formControlName="year5"
+                (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
               <input type="text" [value]="element.year4 * 100" (input)="element.year5 = $any($event.target).value / 100"
-                appDecimalInput formControlName="year5">
+                appDecimalInput formControlName="year5" (change)="recalculateChanges()">
             </div>
           </td>
           <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year5') | currencyExtended}} </td>
@@ -114,14 +126,16 @@
           <th mat-header-cell *matHeaderCellDef>2027</th>
           <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
-              <input type="text" appDecimalInput required [value]=element.year6 formControlName="year6">
+              <input type="text" appDecimalInput required [value]=element.year6 formControlName="year6"
+                (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'US dollars'">
-              <input type="text" appDecimalInput required [value]=element.year6 formControlName="year6">
+              <input type="text" appDecimalInput required [value]=element.year6 formControlName="year6"
+                (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
               <input type="text" [value]="element.year6 * 100" (input)="element.year6 = $any($event.target).value / 100"
-                appDecimalInput formControlName="year6">
+                appDecimalInput formControlName="year6" (change)="recalculateChanges()">
             </div>
           </td>
           <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year6') | currencyExtended}} </td>
@@ -131,15 +145,17 @@
           <th mat-header-cell *matHeaderCellDef>2028</th>
           <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
-              <input type="text" appDecimalInput required [value]=element.year7 formControlName="year7">
+              <input type="text" appDecimalInput required [value]=element.year7 formControlName="year7"
+                (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'US dollars'">
 
-              <input type="text" appDecimalInput required [value]=element.year7 formControlName="year7">
+              <input type="text" appDecimalInput required [value]=element.year7 formControlName="year7"
+                (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
               <input type="text" [value]="element.year4 * 100" (input)="element.year7 = $any($event.target).value / 100"
-                appDecimalInput formControlName="year7">
+                appDecimalInput formControlName="year7" (change)="recalculateChanges()">
             </div>
           </td>
           <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year7') | currencyExtended}} </td>
@@ -149,14 +165,16 @@
           <th mat-header-cell *matHeaderCellDef>2029</th>
           <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
-              <input type="text" appDecimalInput required [value]=element.year8 formControlName="year8">
+              <input type="text" appDecimalInput required [value]=element.year8 formControlName="year8"
+                (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'US dollars'">
-              <input type="text" appDecimalInput required [value]=element.year8 formControlName="year8">
+              <input type="text" appDecimalInput required [value]=element.year8 formControlName="year8"
+                (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
               <input type="text" [value]="element.year4 * 100" (input)="element.year8 = $any($event.target).value / 100"
-                appDecimalInput formControlName="year8">
+                appDecimalInput formControlName="year8" (change)="recalculateChanges()">
             </div>
           </td>
           <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year8') | currencyExtended}} </td>
@@ -166,14 +184,16 @@
           <th mat-header-cell *matHeaderCellDef>2030</th>
           <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
-              <input type="text" appDecimalInput required [value]=element.year9 formControlName="year9">
+              <input type="text" appDecimalInput required [value]=element.year9 formControlName="year9"
+                (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'US dollars'">
-              <input type="text" appDecimalInput required [value]=element.year9 formControlName="year9">
+              <input type="text" appDecimalInput required [value]=element.year9 formControlName="year9"
+                (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
               <input type="text" [value]="element.year4 * 100" (input)="element.year9 = $any($event.target).value / 100"
-                appDecimalInput formControlName="year9">
+                appDecimalInput formControlName="year9" (change)="recalculateChanges()">
             </div>
           </td>
           <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year9') | currencyExtended}} </td>

--- a/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.ts
+++ b/src/app/components/dialogs/sectionRecurringCostReviewDialog/sectionRecurringCostReviewDialog.component.ts
@@ -19,7 +19,7 @@ export class SectionRecurringCostReviewDialogComponent {
   public formChanges: InterventionForm['formChanges'] = {};
 
   public displayedColumns: string[] = [
-    'name',
+    'labelText',
     'year0',
     'year1',
     'year2',

--- a/src/app/components/dialogs/sectionStartUpCostReviewDialog/sectionStartUpCostReviewDialog.component.html
+++ b/src/app/components/dialogs/sectionStartUpCostReviewDialog/sectionStartUpCostReviewDialog.component.html
@@ -14,17 +14,19 @@
           <!-- <td mat-cell *matCellDef="let element">{{element.year0 | currencyExtended}}</td> -->
           <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
-              <input type="text" appDecimalInput required [value]=element.year0.toFixed(2) formControlName="year0">
+              <input type="text" appDecimalInput required [value]=element.year0.toFixed(2) formControlName="year0"
+                (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'US dollars'">
-              <input type="text" appDecimalInput required [value]=element.year0.toFixed(2) formControlName="year0">
+              <input type="text" appDecimalInput required [value]=element.year0.toFixed(2) formControlName="year0"
+                (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
               <input type="text" [value]="element.year0 * 100" (input)="element.year0 = $any($event.target).value / 100"
-                formControlName="year0" appDecimalInput>
+                formControlName="year0" appDecimalInput (change)="recalculateChanges()">
             </div>
           </td>
-          <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year0') | currencyExtended}} </td>
+          <td mat-footer-cell *matFooterCellDef> {{year0Total | currencyExtended}} TBC</td>
         </ng-container>
 
         <ng-container matColumnDef="year1">
@@ -32,17 +34,19 @@
           <!-- <td mat-cell *matCellDef="let element">{{element.year1 | currencyExtended}}</td> -->
           <td class="column-title" mat-cell *matCellDef="let element; let index = index" [formGroupName]="index">
             <div *ngIf="element.rowUnits === 'number'">
-              <input type="text" appDecimalInput required [value]=element.year1.toFixed(2) formControlName="year1">
+              <input type="text" appDecimalInput required [value]=element.year1.toFixed(2) formControlName="year1"
+                (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'US dollars'">
-              <input type="text" appDecimalInput required [value]=element.year1.toFixed(2) formControlName="year1">
+              <input type="text" appDecimalInput required [value]=element.year1.toFixed(2) formControlName="year1"
+                (change)="recalculateChanges()">
             </div>
             <div *ngIf="element.rowUnits === 'percent'">
               <input type="text" [value]="element.year1 * 100" (input)="element.year1 = $any($event.target).value / 100"
-                formControlName="year1" appDecimalInput>
+                formControlName="year1" appDecimalInput (change)="recalculateChanges()">
             </div>
           </td>
-          <td mat-footer-cell *matFooterCellDef> {{getTotalCost('year1') | currencyExtended}} </td>
+          <td mat-footer-cell *matFooterCellDef> {{year1Total | currencyExtended}} TBC</td>
         </ng-container>
 
         <tr mat-header-row *matHeaderRowDef="displayedColumns;"></tr>

--- a/src/app/components/dialogs/sectionStartUpCostReviewDialog/sectionStartUpCostReviewDialog.component.html
+++ b/src/app/components/dialogs/sectionStartUpCostReviewDialog/sectionStartUpCostReviewDialog.component.html
@@ -2,10 +2,10 @@
   <div class="bmgf-maps-nice-scrollbar">
     <form [formGroup]="form" *ngIf="form">
       <table mat-table [dataSource]="dataSource" matSort class="table-full-width" formArrayName="items">
-        <ng-container matColumnDef="name">
+        <ng-container matColumnDef="labelText">
           <th class="row-title-left" mat-header-cell *matHeaderCellDef>Years of start-up or scale-up
           </th>
-          <td class="row-title-left" mat-cell *matCellDef="let element"> {{element.name}} </td>
+          <td class="row-title-left" mat-cell *matCellDef="let element"> {{element.labelText}} </td>
           <td class="row-title-left" mat-footer-cell *matFooterCellDef>Total</td>
         </ng-container>
 

--- a/src/app/components/dialogs/sectionStartUpCostReviewDialog/sectionStartUpCostReviewDialog.component.ts
+++ b/src/app/components/dialogs/sectionStartUpCostReviewDialog/sectionStartUpCostReviewDialog.component.ts
@@ -15,7 +15,7 @@ import { InterventionDataService, InterventionForm } from 'src/app/services/inte
 export class SectionStartUpCostReviewDialogComponent {
   public dataSource = new MatTableDataSource<StartUpCostBreakdown>();
   public title = '';
-  public displayedColumns: string[] = ['name', 'year0', 'year1'];
+  public displayedColumns: string[] = ['labelText', 'year0', 'year1'];
   public form: UntypedFormGroup;
   public formChanges: InterventionForm['formChanges'] = {};
 

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.ts
@@ -241,6 +241,11 @@ export class InterventionIndustryInformationComponent implements OnInit {
           // if isEditable = true AND no yearXFormula exists, calculated value by vars outside this endpoint
           return;
         }
+        if (Object.keys(item['year' + columnIndex + 'Formula']).length === 0) {
+          // Check to see if the formula is present as expected, otherwise display static value
+          console.debug('missing year' + columnIndex + 'Formula');
+          return;
+        }
         // calculate the result of the formula using the inputs describes in jsonlogic
         const theResult = this.jsonLogicService.calculateResult(item, columnIndex, allItems);
 

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionIndustryInformation/interventionIndustryInformation.component.ts
@@ -246,6 +246,7 @@ export class InterventionIndustryInformationComponent implements OnInit {
           console.debug('missing year' + columnIndex + 'Formula');
           return;
         }
+
         // calculate the result of the formula using the inputs describes in jsonlogic
         const theResult = this.jsonLogicService.calculateResult(item, columnIndex, allItems);
 

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionMonitoringInformation/interventionMonitoringInformation.component.ts
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionMonitoringInformation/interventionMonitoringInformation.component.ts
@@ -235,6 +235,11 @@ export class InterventionMonitoringInformationComponent implements OnInit {
           // if isEditable = true AND no yearXFormula exists, calculated value by vars outside this endpoint
           return;
         }
+        if (Object.keys(item['year' + columnIndex + 'Formula']).length === 0) {
+          // Check to see if the formula is present as expected, otherwise display static value
+          console.debug('missing year' + columnIndex + 'Formula');
+          return;
+        }
         // calculate the result of the formula using the inputs describes in jsonlogic
         const theResult = this.jsonLogicService.calculateResult(item, columnIndex, allItems);
 

--- a/src/app/services/jsonlogic.service.ts
+++ b/src/app/services/jsonlogic.service.ts
@@ -3,10 +3,12 @@ import * as jsonLogic from 'json-logic-js';
 import { IndustryInformation } from '../apiAndObjects/objects/interventionIndustryInformation';
 import { CellIndex } from '../apiAndObjects/objects/cellIndex.interface';
 import { MonitoringInformation } from '../apiAndObjects/objects/interventionMonitoringInformation';
+import { StartUpCostBreakdown } from '../apiAndObjects/objects/interventionStartupCosts';
+import { RecurringCostBreakdown } from '../apiAndObjects/objects/interventionRecurringCosts';
 
 @Injectable()
 export class JSONLogicService {
-  public allItems: Array<IndustryInformation | MonitoringInformation>;
+  public allItems: Array<IndustryInformation | MonitoringInformation | StartUpCostBreakdown | RecurringCostBreakdown>;
 
   constructor() {
     /**
@@ -19,6 +21,14 @@ export class JSONLogicService {
     jsonLogic.add_operation('roundup', (value, decimals = 0) => {
       const multiplier = Math.pow(10, decimals);
       return Math.ceil(value * multiplier) / multiplier;
+    });
+
+    jsonLogic.add_operation('sum', (...values) => {
+      console.debug(
+        'sum: ',
+        values.reduce((acc, curr) => acc + curr, 0),
+      );
+      return values.reduce((acc, curr) => acc + curr, 0);
     });
 
     /**
@@ -56,15 +66,17 @@ export class JSONLogicService {
   }
 
   public calculateResult(
-    item: IndustryInformation | MonitoringInformation,
+    item: IndustryInformation | MonitoringInformation | StartUpCostBreakdown | RecurringCostBreakdown,
     columnIndex: number,
-    allItems: Array<IndustryInformation | MonitoringInformation>,
+    allItems: Array<IndustryInformation | MonitoringInformation | StartUpCostBreakdown | RecurringCostBreakdown>,
   ): number {
     this.setItems(allItems);
     return jsonLogic.apply(item['year' + columnIndex + 'Formula'], {});
   }
 
-  public setItems(data: Array<IndustryInformation | MonitoringInformation>) {
+  public setItems(
+    data: Array<IndustryInformation | MonitoringInformation | StartUpCostBreakdown | RecurringCostBreakdown>,
+  ) {
     this.allItems = data;
   }
 

--- a/src/app/services/jsonlogic.service.ts
+++ b/src/app/services/jsonlogic.service.ts
@@ -20,7 +20,7 @@ export class JSONLogicService {
      */
     jsonLogic.add_operation('roundup', (value, decimals = 0) => {
       const multiplier = Math.pow(10, decimals);
-      return Math.ceil(value * multiplier) / multiplier;
+      return Math.ceil(Number(value) * multiplier) / multiplier;
     });
 
     /**
@@ -62,7 +62,7 @@ export class JSONLogicService {
         (item: IndustryInformation | MonitoringInformation) => item.rowIndex == cellIndex.rowIndex,
       );
       const colToFind = cellIndex.colIndex;
-      const valueAtCol = resAtRow[colToFind];
+      const valueAtCol = Number(resAtRow[colToFind]);
       return valueAtCol;
     });
   }

--- a/src/app/services/jsonlogic.service.ts
+++ b/src/app/services/jsonlogic.service.ts
@@ -23,12 +23,14 @@ export class JSONLogicService {
       return Math.ceil(value * multiplier) / multiplier;
     });
 
+    /**
+     *  Calculate the total or cumulative value obtained by adding together individual values
+     *
+     * @param {Array<number>} value - An array of values to be summed up.
+     * @returns {number} - The total value of all input values.
+     */
     jsonLogic.add_operation('sum', (...values) => {
-      console.debug(
-        'sum: ',
-        values.reduce((acc, curr) => acc + curr, 0),
-      );
-      return values.reduce((acc, curr) => acc + curr, 0);
+      return Number(values.reduce((acc, curr) => acc + curr, 0));
     });
 
     /**


### PR DESCRIPTION
- several pages of the intervention review stage now are able to update input forms based on a formula which is included in the API request. These formula broadly fit into three use cases
- 1. formula of cell A is based on cell B which is available in the current API response
- 2. formula of cell A is based on a formula in cell B which is part is not available in the current API response. This uses an API caluclated value
- 3. formula of cell is based on values which are entirely in an external API response

## testing
- load Ethiopia/Calcium
- load intervention 46
- navigate through the sections and pay attention to SUSU costs and Recurring costs section.
- open some modals and edit the data, formula should update in dark/non editable cells

> Note: intervention section values are not being updated based on the user-edited values, so when loading a form the values shown are the 'default'. Editing a cell then triggers the recalculation which is why editing row 1 may update multiple other rows as they are *now* recalculating based on their formula inputs. When the API stores the new values this issue will be gone.