### PR TITLE
fix: ui elements in the intervention stages

### DIFF
--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/components/interventionSideNavContent/interventionSideNavContent.component.scss
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/components/interventionSideNavContent/interventionSideNavContent.component.scss
@@ -29,7 +29,7 @@
 }
 .intervention-review-subtitle {
   text-align: center;
-  font-size: 14px;
+  font-size: 12px;
   padding: 10px;
   margin-bottom: 10px;
 }

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionBaseline/interventionBaseline.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionBaseline/interventionBaseline.component.html
@@ -16,7 +16,7 @@
 
         <table mat-table [dataSource]="dataSource" formArrayName="items" class="table-full-width">
           <ng-container matColumnDef="title">
-            <td class="row-title-left " mat-cell *matCellDef="let element">
+            <td class="row-title-left" mat-cell *matCellDef="let element">
               {{ element.title }}
             </td>
           </ng-container>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionBaseline/interventionBaseline.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionBaseline/interventionBaseline.component.html
@@ -16,7 +16,7 @@
 
         <table mat-table [dataSource]="dataSource" formArrayName="items" class="table-full-width">
           <ng-container matColumnDef="title">
-            <td class="row-title-left" mat-cell *matCellDef="let element">
+            <td class="row-title-left " mat-cell *matCellDef="let element">
               {{ element.title }}
             </td>
           </ng-container>
@@ -83,7 +83,8 @@
             </td>
           </ng-container>
           <ng-container matColumnDef="targetVal">
-            <th class="row-title-left" mat-header-cell *matHeaderCellDef>Standard/target nutrient level at point of
+            <th class="row-title-left header-top-align" mat-header-cell *matHeaderCellDef>Standard/target nutrient level
+              at point of
               fortification (mg/kg)
             </th>
             <td mat-cell *matCellDef="let element">
@@ -102,10 +103,11 @@
             </td>
           </ng-container>
           <ng-container matColumnDef="avgVal">
-            <th class="row-title-left" mat-header-cell *matHeaderCellDef>Calculated average fortification level (mg/kg)
+            <th class="row-title-left header-top-align" mat-header-cell *matHeaderCellDef>Calculated average
+              fortification level (mg/kg)
               among
               fortifiable food vehicle at point of fortification
-              <button class="icon-display" mat-mini-fab color="primary" (click)="openFortificationInfoDialog()">
+              <button class="icon-display floater" mat-mini-fab color="primary" (click)="openFortificationInfoDialog()">
                 <mat-icon class="icon-display">question_mark</mat-icon>
               </button>
             </th>
@@ -120,7 +122,8 @@
           </ng-container>
 
           <ng-container matColumnDef="optFort">
-            <th class="row-title-left" mat-header-cell *matHeaderCellDef>Optional user-entered average fortification
+            <th class="row-title-left header-top-align" mat-header-cell *matHeaderCellDef>Optional user-entered average
+              fortification
               level
               (mg/kg) among fortifiable food vehicle at point of fortification
             </th>
@@ -141,10 +144,10 @@
           </ng-container>
 
           <ng-container matColumnDef="calcFort">
-            <th class="row-title-left" mat-header-cell *matHeaderCellDef>
-              Calculated average fortification level (mg/kg) among
-              all food vehicle
-              <button class="icon-display" mat-mini-fab color="primary"
+            <th class="row-title-left header-top-align" mat-header-cell *matHeaderCellDef>
+              Calculated average fortification level (mg/kg)
+              among all food vehicle
+              <button class="icon-display floater" mat-mini-fab color="primary"
                 (click)="openCalculatedFortificationInfoDialog()">
                 <mat-icon class="icon-display">question_mark</mat-icon>
               </button>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionBaseline/interventionBaseline.component.scss
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionBaseline/interventionBaseline.component.scss
@@ -138,3 +138,7 @@ input.ng-dirty {
   color: $color_input_blue;
   border-color: $color_input_blue;
 }
+
+.floater {
+  display: flex;
+}

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionStartupScaleupCosts/interventionStartupScaleupCosts.component.scss
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/pages/interventionStartupScaleupCosts/interventionStartupScaleupCosts.component.scss
@@ -1,38 +1,44 @@
 @use '../interventionReviewPages.scss';
 
 .row-container {
-    display: grid;
-    grid-template-areas: "table divider graph";
-    grid-template-columns: minmax(50%, 1fr) 1fr 45%;
-    grid-gap: 10px;
+  display: grid;
+  grid-template-areas: 'table divider graph';
+  grid-template-columns: minmax(50%, 1fr) 1fr 45%;
+  grid-gap: 10px;
 }
 
 .startUpTable {
-    grid-area: table;
+  grid-area: table;
 }
-  
+
 .startUpGraph {
-    grid-area: graph;
+  grid-area: graph;
 }
 
 .divider {
-    grid-area: divider;
-    border-left: 2px solid #703aa3 !important;
+  grid-area: divider;
+  border-left: 2px solid #703aa3 !important;
 }
 
-@media (max-width: 1200px) {
-    .row-container {
-      grid-template-columns: 1fr;
-      grid-template-areas:
-        "table"
-        "graph";
-      grid-template-rows: auto;
-    }
+@media (max-width: 1300px) {
+  .row-container {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      'table'
+      'graph';
+    grid-template-rows: auto;
+  }
 }
 
 @media only screen and (min-width: 1400px) {
-    .divider {
-        border-left: 1px solid #703aa3 !important;
-        height: 100% !important;
-    }
+  .divider {
+    border-left: 1px solid #703aa3 !important;
+    height: 100% !important;
+  }
+}
+
+@media only screen and (max-width: 1400px) {
+  .divider {
+    display: none;
+  }
 }

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/utilities/microNutrientsInPremixTable/premixTableRow/premixTable.component.html
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/utilities/microNutrientsInPremixTable/premixTableRow/premixTable.component.html
@@ -1,106 +1,110 @@
 <table mat-table [dataSource]="dataSource" class="table-full-width">
-    <ng-container matColumnDef="micronutrient">
-        <th class="row-title focus " mat-header-cell *matHeaderCellDef>
-            Micronutrient
-        </th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-            <ng-container *ngIf="!editable">
-                <span class="micronutrient-title">{{ element.micronutrient }}</span>
-            </ng-container>
-            <ng-container *ngIf="editable">
-                <button class="remove-mn" *ngIf="editable" mat-button (click)="removeMn(element)">
-                    <mat-icon color="danger">highlight_off</mat-icon>
-                </button>
-                <span class="micronutrient-title">{{ element.micronutrient }}</span>
-            </ng-container>
-        </td>
-    </ng-container>
-    <ng-container matColumnDef="compounds">
-        <th class="row-title" mat-header-cell *matHeaderCellDef>
-            Compound
-        </th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-            <mat-form-field appearance="outline" class="override">
-                <mat-select placeholder="Please select a compound" matNativeControl [compareWith]="compareObjects"
-                    [(ngModel)]="element.selectedCompound" (selectionChange)="handleSelectCompound(element)">
-                    <mat-option *ngFor="let item of element.compounds" [value]="item">
-                        {{ item.id }}
-                        {{ item.compound }}
-                    </mat-option>
-                </mat-select>
-            </mat-form-field>
-        </td>
-    </ng-container>
-    <ng-container matColumnDef="targetVal">
-        <th class="row-title" mat-header-cell *matHeaderCellDef>Standard/target nutrient level at point of
-            fortification (mg/kg)
-        </th>
-        <td class="column-title" mat-cell *matCellDef="let element;">
-            <div *ngIf="editable" class="double-cell">
-                <input type="number" matInput required
-                    [ngModel]="element.selectedCompound ? element.selectedCompound.targetVal : '0'">
-                <button mat-button>
-                    GFDx<mat-icon>arrow_right_alt</mat-icon>
-                </button>
-            </div>
-            <div *ngIf="!editable" class="double-cell">
-                {{element.selectedCompound ? element.selectedCompound.targetVal : '0'}}
-            </div>
-        </td>
-    </ng-container>
-    <ng-container matColumnDef="avgVal">
-        <th class="row-title" mat-header-cell *matHeaderCellDef>Calculated average fortification level (mg/kg) among
-            fortifiable food vehicle at point of fortification
-            <button class="icon-display" mat-mini-fab color="primary" (click)="openFortificationInfoDialog()">
-                <mat-icon class="icon-display">question_mark</mat-icon>
-            </button>
-        </th>
-        <td class="column-title" mat-cell *matCellDef="let element;">
-            <div class="double-cell">
-                <span>
-                    {{ (element.selectedCompound ? element.selectedCompound.targetVal : 0) *
-                    baselineAssumptions.potentiallyFortified.year0 | sigFig: 3
-                    }}
-                </span>
-            </div>
-        </td>
-    </ng-container>
-    <ng-container matColumnDef="optFort">
-        <th class="row-title" mat-header-cell *matHeaderCellDef>Optional user-entered average fortification level
-            (mg/kg) among fortifiable food vehicle at point of fortification
-        </th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-            <div *ngIf="editable" class="double-cell">
-                <input type="number" matInput required [(ngModel)]="optionalUserEnteredAverageAtPointOfFortification">
-                <span>
-                    <button mat-button>
-                        GFDx<mat-icon>arrow_right_alt</mat-icon>
-                    </button>
-                </span>
-            </div>
-            <div *ngIf="!editable" class="double-cell">
-                {{optionalUserEnteredAverageAtPointOfFortification}}
-            </div>
-        </td>
-    </ng-container>
-    <ng-container matColumnDef="calcFort">
-        <th class="row-title" mat-header-cell *matHeaderCellDef>
-            Calculated average fortification level (mg/kg) among
-            all food vehicle
-            <button class="icon-display" mat-mini-fab color="primary" (click)="openCalculatedFortificationInfoDialog()">
-                <mat-icon class="icon-display">question_mark</mat-icon>
-            </button>
-        </th>
-        <td class="column-title" mat-cell *matCellDef="let element">
-            <span>
-                {{ (optionalUserEnteredAverageAtPointOfFortification *
-                baselineAssumptions.actuallyFortified.year0 *
-                baselineAssumptions.potentiallyFortified.year0) | sigFig: 3 }}
-            </span>
-        </td>
-    </ng-container>
-    <div *ngIf="!editable">
-        <tr mat-header-row *matHeaderRowDef="addedFVdisplayedColumns;"></tr>
-    </div>
-    <tr mat-row *matRowDef="let row; columns: addedFVdisplayedColumns;"></tr>
+  <ng-container matColumnDef="micronutrient">
+    <th class="row-title focus " mat-header-cell *matHeaderCellDef>
+      Micronutrient
+    </th>
+    <td class="column-title" mat-cell *matCellDef="let element">
+      <ng-container *ngIf="!editable">
+        <span class="micronutrient-title">{{ element.micronutrient }}</span>
+      </ng-container>
+      <ng-container *ngIf="editable">
+        <button class="remove-mn" *ngIf="editable" mat-button (click)="removeMn(element)">
+          <mat-icon color="danger">highlight_off</mat-icon>
+        </button>
+        <span class="micronutrient-title">{{ element.micronutrient }}</span>
+      </ng-container>
+    </td>
+  </ng-container>
+  <ng-container matColumnDef="compounds">
+    <th class="row-title-left" mat-header-cell *matHeaderCellDef>
+      Compound
+    </th>
+    <td class="column-title" mat-cell *matCellDef="let element">
+      <mat-form-field appearance="outline" class="override">
+        <mat-select placeholder="Please select a compound" matNativeControl [compareWith]="compareObjects"
+          [(ngModel)]="element.selectedCompound" (selectionChange)="handleSelectCompound(element)">
+          <mat-option *ngFor="let item of element.compounds" [value]="item">
+            {{ item.id }}
+            {{ item.compound }}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+    </td>
+  </ng-container>
+  <ng-container matColumnDef="targetVal">
+    <th class="row-title-left header-top-align" mat-header-cell *matHeaderCellDef>Standard/target nutrient level at
+      point of
+      fortification (mg/kg)
+    </th>
+    <td class="column-title" mat-cell *matCellDef="let element;">
+      <div *ngIf="editable" class="double-cell">
+        <input type="number" matInput required
+          [ngModel]="element.selectedCompound ? element.selectedCompound.targetVal : '0'">
+        <button mat-button>
+          GFDx<mat-icon>arrow_right_alt</mat-icon>
+        </button>
+      </div>
+      <div *ngIf="!editable" class="double-cell">
+        {{element.selectedCompound ? element.selectedCompound.targetVal : '0'}}
+      </div>
+    </td>
+  </ng-container>
+  <ng-container matColumnDef="avgVal">
+    <th class="row-title-left header-top-align" mat-header-cell *matHeaderCellDef>Calculated average fortification level
+      (mg/kg) among
+      fortifiable food vehicle at point of fortification
+      <button class="icon-display floater" mat-mini-fab color="primary" (click)="openFortificationInfoDialog()">
+        <mat-icon class="icon-display">question_mark</mat-icon>
+      </button>
+    </th>
+    <td class="column-title" mat-cell *matCellDef="let element;">
+      <div class="double-cell">
+        <span>
+          {{ (element.selectedCompound ? element.selectedCompound.targetVal : 0) *
+          baselineAssumptions.potentiallyFortified.year0 | sigFig: 3
+          }}
+        </span>
+      </div>
+    </td>
+  </ng-container>
+  <ng-container matColumnDef="optFort">
+    <th class="row-title-left header-top-align" mat-header-cell *matHeaderCellDef>Optional user-entered average
+      fortification level
+      (mg/kg) among fortifiable food vehicle at point of fortification
+    </th>
+    <td class="column-title" mat-cell *matCellDef="let element">
+      <div *ngIf="editable" class="double-cell">
+        <input type="number" matInput required [(ngModel)]="optionalUserEnteredAverageAtPointOfFortification">
+        <span>
+          <button mat-button>
+            GFDx<mat-icon>arrow_right_alt</mat-icon>
+          </button>
+        </span>
+      </div>
+      <div *ngIf="!editable" class="double-cell">
+        {{optionalUserEnteredAverageAtPointOfFortification}}
+      </div>
+    </td>
+  </ng-container>
+  <ng-container matColumnDef="calcFort">
+    <th class="row-title-left header-top-align" mat-header-cell *matHeaderCellDef>
+      Calculated average fortification level (mg/kg) among
+      all food vehicle
+      <button class="icon-display floater" mat-mini-fab color="primary"
+        (click)="openCalculatedFortificationInfoDialog()">
+        <mat-icon class="icon-display">question_mark</mat-icon>
+      </button>
+    </th>
+    <td class="column-title" mat-cell *matCellDef="let element">
+      <span>
+        {{ (optionalUserEnteredAverageAtPointOfFortification *
+        baselineAssumptions.actuallyFortified.year0 *
+        baselineAssumptions.potentiallyFortified.year0) | sigFig: 3 }}
+      </span>
+    </td>
+  </ng-container>
+  <div *ngIf="!editable">
+    <tr mat-header-row *matHeaderRowDef="addedFVdisplayedColumns;"></tr>
+  </div>
+  <tr mat-row *matRowDef="let row; columns: addedFVdisplayedColumns;"></tr>
 </table>

--- a/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/utilities/microNutrientsInPremixTable/premixTableRow/premixTable.component.scss
+++ b/src/app/pages/quickMaps/pages/costEffectiveness/interventionReview/utilities/microNutrientsInPremixTable/premixTableRow/premixTable.component.scss
@@ -67,3 +67,7 @@ input.ng-dirty {
   color: $color_input_blue;
   border-color: $color_input_blue;
 }
+
+.floater {
+  display: flex;
+}

--- a/src/assets/scss/_tables.scss
+++ b/src/assets/scss/_tables.scss
@@ -20,6 +20,10 @@ table {
   text-align: center !important;
 }
 
+.header-top-align {
+  vertical-align: top !important;
+}
+
 .column-title {
   text-align: center !important;
   &-left {


### PR DESCRIPTION
- submarine text within header cells fixed
- where appropriate, vertical align header text as less jarring than central alignment
- startup/scale up costs section media query update to fix overlapping content
- left-aligned header to match rest of table ui
### to test

- [ ] baseline/comliance pages, clicking header ? button opens dialog and does not move the text content down
- [ ] startup/scale up, shrink browser and divider hides before hits left text, responsive row to column happens sooner o avoid overlap