### PR TITLE
ci: check that pull request titles match commit lint config

### DIFF
--- a/.github/workflows/commitlint-pr.yml
+++ b/.github/workflows/commitlint-pr.yml
@@ -1,0 +1,21 @@
+name: Verify pull request commitlint
+on:
+  pull_request:
+    types: ['opened', 'edited', 'reopened', 'synchronize']
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+      - run: yarn install --immutable --immutable-cache --check-cache
+
+      - name: Lint pull request title
+        uses: JulienKode/pull-request-name-linter-action@v0.5.0
+        with:
+          configuration-path: ./commitlint.config.js

--- a/.github/workflows/commitlint-pr.yml
+++ b/.github/workflows/commitlint-pr.yml
@@ -1,4 +1,4 @@
-name: Verify pull request commitlint
+name: Verify pull request title meets commitlint criteria
 on:
   pull_request:
     types: ['opened', 'edited', 'reopened', 'synchronize']

--- a/.github/workflows/commitlint-pr.yml
+++ b/.github/workflows/commitlint-pr.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18.x
-      - run: yarn install --immutable --immutable-cache --check-cache
+      - run: npm install --immutable --immutable-cache --check-cache
 
       - name: Lint pull request title
         uses: JulienKode/pull-request-name-linter-action@v0.5.0


### PR DESCRIPTION
- pull request titles need to meet the same commit int criteria used for existing commits. This is most useful when squashing PRs to ensure they are correctly titled and therefore changelog is clean.