### PR TITLE
refactor: mat-menu for login UI

### DIFF
--- a/src/app/components/components.module.ts
+++ b/src/app/components/components.module.ts
@@ -15,6 +15,8 @@ import { NotFoundComponent } from './notFound/notFound.component';
 import { DownloadComponent } from '../pages/quickMaps/components/download/download.component';
 import { DirectivesModule } from '../directives/directives.module';
 import { NoResultsComponent } from './noResults/noResults.component';
+import { UserMenuComponent } from './header/user-menu/user-menu.component';
+import { MatMenuModule } from '@angular/material/menu';
 
 @NgModule({
   declarations: [
@@ -26,6 +28,7 @@ import { NoResultsComponent } from './noResults/noResults.component';
     NotFoundComponent,
     DownloadComponent,
     NoResultsComponent,
+    UserMenuComponent,
   ],
   imports: [
     CommonModule,
@@ -36,6 +39,7 @@ import { NoResultsComponent } from './noResults/noResults.component';
     DialogModule,
     NotificationModule,
     DirectivesModule,
+    MatMenuModule,
   ],
   exports: [
     HeaderComponent,

--- a/src/app/components/header/header.component.html
+++ b/src/app/components/header/header.component.html
@@ -1,16 +1,10 @@
 <header>
   <mat-toolbar color="primary" class="space-between">
     <div class="left-content">
-      <div class="user-details" *ngIf="activeUser">
-        <img src="{{activeUser.profilePic}}">
-        <button mat-flat-button color="primary" [routerLink]="ROUTES.PROFILE | route">{{activeUser.username}}</button>
-        <button *ngIf="activeUser" mat-flat-button color="primary" (click)="handleLogout()">Logout</button>
-      </div>
-      <button id="login" *ngIf="!activeUser" mat-flat-button color="primary"
-        (click)="handleLoginDialog()">Login</button>
       <a [routerLink]="ROUTES.HOME | route" class="header-logo">
         <img src="/assets/images/maps-logo-minimal-white.svg" alt="BMGF MAPS Logo" class="logo">
       </a>
+      <app-user-menu [activeUser]="activeUser"></app-user-menu>
     </div>
     <div class="large">
       <a [routerLink]="ROUTES.MAPS_TOOL | route">MAPS Tools</a>

--- a/src/app/components/header/user-menu/user-menu.component.html
+++ b/src/app/components/header/user-menu/user-menu.component.html
@@ -1,0 +1,19 @@
+<ng-container *ngIf="activeUser">
+  <button mat-button [matMenuTriggerFor]="menu" #t="matMenuTrigger">
+    <span class="dropdown">
+      {{ activeUser.username }}
+      <span class="icon-wrapper" [ngClass]="t.menuOpen ? 'rotate-180' : ''">
+        <mat-icon>keyboard_arrow_down</mat-icon>
+      </span>
+    </span>
+  </button>
+  <mat-menu #menu="matMenu">
+    <button mat-menu-item [routerLink]="ROUTES.PROFILE | route">Profile</button>
+    <button mat-menu-item (click)="handleLogout()">Log out</button>
+  </mat-menu>
+</ng-container>
+<ng-container *ngIf="!activeUser">
+  <button id="login" mat-raised-button (click)="handleLoginDialog()">
+    Log in
+  </button>
+</ng-container>

--- a/src/app/components/header/user-menu/user-menu.component.scss
+++ b/src/app/components/header/user-menu/user-menu.component.scss
@@ -1,0 +1,26 @@
+button {
+  &#login {
+    margin-left: 2rem;
+  }
+
+  &[mat-button] {
+    margin-left: 1rem;
+  }
+}
+
+span {
+  &.dropdown {
+    display: flex;
+    align-items: center;
+  }
+
+  &.icon-wrapper {
+    display: flex;
+    align-items: center;
+    transition: transform 0.25s ease-in-out;
+
+    &.rotate-180 {
+      transform: rotate(180deg);
+    }
+  }
+}

--- a/src/app/components/header/user-menu/user-menu.component.ts
+++ b/src/app/components/header/user-menu/user-menu.component.ts
@@ -1,0 +1,53 @@
+import { Component, Input } from '@angular/core';
+import { LoginRegisterResponseDataSource } from 'src/app/apiAndObjects/objects/loginRegisterResponseDataSource';
+import { AppRoutes } from 'src/app/routes/routes';
+import { DialogService } from '../../dialogs/dialog.service';
+import { ApiService } from 'src/app/apiAndObjects/api/api.service';
+import { UserLoginService } from 'src/app/services/userLogin.service';
+import { LogoutResponse } from 'src/app/apiAndObjects/api/login/logout';
+import { NotificationsService } from '../../notifications/notification.service';
+import { Router } from '@angular/router';
+
+@Component({
+  selector: 'app-user-menu',
+  templateUrl: './user-menu.component.html',
+  styleUrls: ['./user-menu.component.scss'],
+})
+export class UserMenuComponent {
+  @Input() activeUser: LoginRegisterResponseDataSource | null;
+
+  constructor(
+    private dialogService: DialogService,
+    private apiService: ApiService,
+    private userLoginService: UserLoginService,
+    private notificationsService: NotificationsService,
+    private router: Router,
+  ) {}
+
+  public ROUTES = AppRoutes;
+  public expanded = false;
+
+  public handleLoginDialog(): void {
+    this.dialogService.openLoginDialog();
+  }
+
+  public handleLogout(): void {
+    this.apiService.endpoints.user.logout
+      .call(this.userLoginService.getActiveUser())
+      .then((response: LogoutResponse) => {
+        if (response.success) {
+          this.notificationsService.sendPositive(
+            `${this.userLoginService.getActiveUser().username} successfully logged out.`,
+          );
+          this.userLoginService.setActiveUser(null);
+          if (this.router.url.includes(this.ROUTES.PROFILE.getRouterPath())) {
+            this.router.navigate(['/']);
+          }
+        }
+      });
+  }
+
+  public toggleState(): void {
+    this.expanded = !this.expanded;
+  }
+}


### PR DESCRIPTION
Alternative UI for login in header, makes use of mat-menu to keep things tidier & indicate the available actions to users.