### PR TITLE
fix: copying an intervention while logged in or not logged in adds it to storage

### DIFF
--- a/src/app/components/dialogs/costEffectivenessSelectionDialog/costEffectivenessSelectionDialog.component.ts
+++ b/src/app/components/dialogs/costEffectivenessSelectionDialog/costEffectivenessSelectionDialog.component.ts
@@ -339,6 +339,7 @@ export class CostEffectivenessSelectionDialogComponent implements OnInit {
           this.interventionRequestBody.newInterventionFocusMicronutrient,
         )
         .then((result: Intervention) => {
+          this.interventionDataService.setSimpleInterventionInStorage(result);
           this.selectedInterventionIDLoad = result.id.toString();
           this.dialogData.dataOut = result;
           this.closeDialog();


### PR DESCRIPTION
To test:

- [ ] copy an intervention while logged in
- [ ] intervention should appear
- [ ] logout
- [ ] intervention should disappear.
- [ ] copy another intervention
- [ ] intervention should appear
- [ ] login
- [ ] both interventions should appear