### PR TITLE
feat: add objects for extra biomarker response fields.  Basic wiring and display

### DIFF
--- a/src/app/apiAndObjects/objects/biomaker.ts
+++ b/src/app/apiAndObjects/objects/biomaker.ts
@@ -2,27 +2,34 @@ import { BaseObject } from '../_lib_code/objects/baseObject';
 import { AggregatedOutliers } from './biomarker/aggregatedOutliers';
 import { AggregatedStats } from './biomarker/aggregatedStat';
 import { AggregatedThresholds } from './biomarker/aggregatedThresholds';
+import { BinnedValues } from './biomarker/binnedValues';
 import { TotalStats } from './biomarker/totalStats';
 
 export class Biomarker extends BaseObject {
   public static readonly KEYS = {
     TOTAL_STATS: 'totalStats',
+    TOTAL_THRESHOLDS: 'totalThresholds',
     AGGREGATED_STATS: 'aggregatedStats',
     AGGREGATED_OUTLIERS: 'aggregatedOutliers',
     AGGREGATED_THRESHOLDS: 'aggregatedThresholds',
+    BINNED_VALUES: 'binnedValues',
   };
 
   public readonly totalStats: Array<TotalStats>;
+  public readonly totalThresholds: AggregatedThresholds;
   public readonly aggregatedStats: Array<AggregatedStats>;
   public readonly aggregatedOutliers: Array<AggregatedOutliers>;
-  public readonly aggregatedThresholds: unknown;
+  public readonly aggregatedThresholds: AggregatedThresholds;
+  public readonly binnedValues: BinnedValues;
 
   protected constructor(sourceObject?: Record<string, unknown>) {
     super(sourceObject);
 
     this.totalStats = this._getArray(Biomarker.KEYS.TOTAL_STATS);
+    this.totalThresholds = this._getValue(Biomarker.KEYS.TOTAL_THRESHOLDS) as AggregatedThresholds;
     this.aggregatedStats = this._getArray(Biomarker.KEYS.AGGREGATED_STATS);
     this.aggregatedOutliers = this._getArray(Biomarker.KEYS.AGGREGATED_OUTLIERS);
     this.aggregatedThresholds = this._getValue(Biomarker.KEYS.AGGREGATED_THRESHOLDS) as AggregatedThresholds;
+    this.binnedValues = this._getValue(Biomarker.KEYS.BINNED_VALUES) as BinnedValues;
   }
 }

--- a/src/app/apiAndObjects/objects/biomarker/aggregatedThresholds.ts
+++ b/src/app/apiAndObjects/objects/biomarker/aggregatedThresholds.ts
@@ -5,17 +5,20 @@ export class AggregatedThresholds extends BaseObject {
     DEFICIENCY_1: 'deficiency1',
     EXCESS_1: 'excess1',
     EXCESS_2: 'excess2',
+    TOTAL: 'total',
   };
 
   public readonly deficiency1: Array<Deficiency1>;
   public readonly excess1: Array<Excess1>;
   public readonly excess2: Array<Excess2>;
+  public readonly total: Array<Total>;
 
   protected constructor(sourceObject?: Record<string, unknown>) {
     super(sourceObject);
     this.deficiency1 = this._getArray(AggregatedThresholds.KEYS.DEFICIENCY_1);
     this.excess1 = this._getArray(AggregatedThresholds.KEYS.EXCESS_1);
     this.excess2 = this._getArray(AggregatedThresholds.KEYS.EXCESS_2);
+    this.total = this._getArray(AggregatedThresholds.KEYS.TOTAL);
   }
 }
 
@@ -38,4 +41,11 @@ export interface Excess2 {
   confidenceIntervalLower: number;
   confidenceIntervalUpper: number;
   excess2: number;
+}
+
+export interface Total {
+  aggregation: string;
+  confidenceIntervalLower: number;
+  confidenceIntervalUpper: number;
+  total: number;
 }

--- a/src/app/apiAndObjects/objects/biomarker/binnedValues.ts
+++ b/src/app/apiAndObjects/objects/biomarker/binnedValues.ts
@@ -1,0 +1,21 @@
+import { BaseObject } from '../../_lib_code/objects/baseObject';
+
+export class BinnedValues extends BaseObject {
+  public static readonly KEYS = {
+    BIN_LABEL: 'binLabel',
+    BIN_DATA: 'binData',
+    BIN_SIZE: 'binSize',
+  };
+
+  public readonly binLabel: Array<number>;
+  public readonly binData: Array<number>;
+  public readonly binSize: Array<number>;
+
+  protected constructor(sourceObject?: Record<string, unknown>) {
+    super(sourceObject);
+    console.log('Build a bin val');
+    this.binLabel = this._getArray(BinnedValues.KEYS.BIN_LABEL);
+    this.binData = this._getArray(BinnedValues.KEYS.BIN_DATA);
+    this.binSize = this._getArray(BinnedValues.KEYS.BIN_SIZE) as number[];
+  }
+}

--- a/src/app/pages/quickMaps/pages/biomarkers/biomarkerInfo/biomarkerInfo.component.html
+++ b/src/app/pages/quickMaps/pages/biomarkers/biomarkerInfo/biomarkerInfo.component.html
@@ -6,18 +6,6 @@
           Histogram of <strong>{{ (quickMapsService.ageGenderGroup.obs | async)?.name }}</strong> in
           {{ (quickMapsService.country.obs | async)?.name }}
         </div>
-        <mat-form-field *ngIf="null != chartData" appearance="fill">
-          <mat-label>Bin selection</mat-label>
-          <!-- <mat-select #select (selectionChange)="createBins(select.value)"> -->
-          <mat-select [(value)]="selectedBinSize" (selectionChange)="createBins()">
-            <mat-option value="1">1</mat-option>
-            <mat-option value="2">2</mat-option>
-            <mat-option value="5">5</mat-option>
-            <mat-option value="10">10</mat-option>
-            <mat-option value="25">25</mat-option>
-            <mat-option value="50">50</mat-option>
-          </mat-select>
-        </mat-form-field>
         <!-- <ngx-chartjs *ngIf="chartData" id="histo" [data]="chartData.data" [type]="chartData.type"
           [options]="chartData.options" [plugins]="chartData.plugins"></ngx-chartjs> -->
         <canvas #histo>{{ chartData }}</canvas>

--- a/src/app/pages/quickMaps/pages/biomarkers/biomarkerInfo/biomarkerInfo.component.ts
+++ b/src/app/pages/quickMaps/pages/biomarkers/biomarkerInfo/biomarkerInfo.component.ts
@@ -75,13 +75,18 @@ export class BiomarkerInfoComponent implements AfterViewInit {
         this.selectedAgeGenderGroup = ageGenderGroup.name;
       }),
       this.quickMapsService.biomarkerParameterChangedObs.subscribe(() => {
-        this.createBins();
+        //  this.createBins();
         // Perhaps this can be used to trigger messgage to show tell user to refresh model
         this.init();
+        console.log({ activeBM: this.activeBiomarker });
       }),
-      // this.quickMapsService.biomarkerDataObs.subscribe((data: Biomarker) => {
-      //   console.debug('data in info', data);
-      // }),
+      this.quickMapsService.biomarkerDataObs.subscribe((data: Biomarker) => {
+        this.activeBiomarker = data;
+        this.binData = this.activeBiomarker.binnedValues.binData;
+        this.labels = this.activeBiomarker.binnedValues.binLabel;
+        this.setChart();
+        console.log({ activeBM: this.activeBiomarker });
+      }),
     );
   }
 
@@ -127,6 +132,9 @@ export class BiomarkerInfoComponent implements AfterViewInit {
 
       this.binData = bins.map((item: BinObject) => item.count);
       this.labels = bins.map((item: BinObject) => item.maxNum);
+
+      console.log({ binData: this.binData, binLabels: this.labels });
+      console.log({ biomarker: this.activeBiomarker });
 
       this.setChart();
     }
@@ -179,7 +187,7 @@ export class BiomarkerInfoComponent implements AfterViewInit {
 
         this.mineralData = filteredArray;
         this.generateTable();
-        this.createBins(); // set interval
+        //  this.createBins(); // set interval
         this.cdr.detectChanges();
       })
       .finally(() => {

--- a/src/app/pages/quickMaps/pages/biomarkers/biomarkerOverview/biomarkerOverview.component.html
+++ b/src/app/pages/quickMaps/pages/biomarkers/biomarkerOverview/biomarkerOverview.component.html
@@ -9,13 +9,11 @@
     ({{ (quickMapsService.biomarkerDataSource.obs | async)?.year }})
   </span>
   <span class="separator"></span>
-  <span>
-    Deficient: <strong class="red">{{ 0.22 | percent }}</strong>
-  </span>
-  <span>
-    Excess: <strong class="red">{{ 0.22 | percent }}</strong>
-  </span>
-  <span>
-    Adequate: <strong class="green">{{ 0.22 | percent }}</strong>
+  <span *ngIf="activeBiomarker">
+    <span *ngFor="let threshold of keys(activeBiomarker.totalThresholds);">
+      {{ threshold | titlecase }}: <strong class="red">{{ activeBiomarker.totalThresholds[threshold][0][threshold] |
+        percent
+        }}</strong>
+    </span>
   </span>
 </div>

--- a/src/app/pages/quickMaps/pages/biomarkers/biomarkerOverview/biomarkerOverview.component.ts
+++ b/src/app/pages/quickMaps/pages/biomarkers/biomarkerOverview/biomarkerOverview.component.ts
@@ -1,11 +1,30 @@
-import { ChangeDetectorRef, Component } from '@angular/core';
+import { AfterViewInit, ChangeDetectorRef, Component } from '@angular/core';
 import { QuickMapsService } from '../../../quickMaps.service';
+import { Biomarker } from 'src/app/apiAndObjects/objects/biomaker';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-biomarker-overview',
   templateUrl: './biomarkerOverview.component.html',
   styleUrls: ['./biomarkerOverview.component.scss'],
 })
-export class BiomarkerOverviewComponent {
+export class BiomarkerOverviewComponent implements AfterViewInit {
+  public activeBiomarker: Biomarker;
+  private subscriptions = new Array<Subscription>();
+
   constructor(public quickMapsService: QuickMapsService, private cdr: ChangeDetectorRef) {}
+
+  ngAfterViewInit(): void {
+    this.subscriptions.push(
+      this.quickMapsService.biomarkerDataObs.subscribe((data: Biomarker) => {
+        this.activeBiomarker = data;
+
+        this.activeBiomarker.totalThresholds;
+      }),
+    );
+  }
+
+  public keys(object: object): Array<string> {
+    return Object.keys(object);
+  }
 }


### PR DESCRIPTION
Add API objects for the new binnedData and totalThresholds response objects

Basic wiring to display total dataset thresholds in header bar (replacing hardcoded 22% values!)

<img width="353" alt="image" src="https://github.com/micronutrientsupport/micronutrient-support-tool/assets/39411049/8fb423e2-c113-4ac8-93b0-4ae7d815455d">

Basic wiring of the binnedData response to the histogram in the bottom card